### PR TITLE
Support netstandard1.6

### DIFF
--- a/src/CommandLineUtils/McMaster.Extensions.CommandLineUtils.csproj
+++ b/src/CommandLineUtils/McMaster.Extensions.CommandLineUtils.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.6</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
     <Description>Command-line parsing API. A community-maintained fork of Microsoft.Extensions.CommandLineUtils, plus extras.
@@ -16,5 +16,11 @@ McMaster.Extensions.CommandLineUtils.ArgumentEscaper
     <IncludeSymbols>true</IncludeSymbols>
     <IncludeSource>true</IncludeSource>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Condition="'$(TargetFramework)'=='netstandard1.6'" Include="System.AppContext" Version="4.3.0" />
+    <PackageReference Condition="'$(TargetFramework)'=='netstandard1.6'" Include="System.Diagnostics.Process" Version="4.3.0" />
+    <PackageReference Condition="'$(TargetFramework)'=='netstandard1.6'" Include="System.Threading.Thread" Version="4.3.0" />
+  </ItemGroup>
 
 </Project>

--- a/src/CommandLineUtils/McMaster.Extensions.CommandLineUtils.csproj
+++ b/src/CommandLineUtils/McMaster.Extensions.CommandLineUtils.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net45;;netstandard1.6;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
     <Description>Command-line parsing API. A community-maintained fork of Microsoft.Extensions.CommandLineUtils, plus extras.

--- a/src/CommandLineUtils/Utilities/DotNetExe.cs
+++ b/src/CommandLineUtils/Utilities/DotNetExe.cs
@@ -38,7 +38,7 @@ namespace McMaster.Extensions.CommandLineUtils
         {
 #if NET45
             return "dotnet.exe";
-#elif NETSTANDARD2_0
+#elif NETSTANDARD1_6
             var fileName = FileName;
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/src/CommandLineUtils/Utilities/DotNetExe.cs
+++ b/src/CommandLineUtils/Utilities/DotNetExe.cs
@@ -38,7 +38,7 @@ namespace McMaster.Extensions.CommandLineUtils
         {
 #if NET45
             return "dotnet.exe";
-#elif NETSTANDARD1_6
+#elif (NETSTANDARD1_6 || NETSTANDARD2_0)
             var fileName = FileName;
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))


### PR DESCRIPTION
Without any code changes, I was able to target .NET Standard 1.6 which makes CLU available on more .NET platforms.