### PR TITLE
Fix for CommandLineApplication Option Extensions

### DIFF
--- a/src/CommandLineUtils/CommandLineApplicationExtensions.cs
+++ b/src/CommandLineUtils/CommandLineApplicationExtensions.cs
@@ -55,8 +55,22 @@ namespace McMaster.Extensions.CommandLineUtils
         /// </summary>
         /// <param name="app"></param>
         /// <param name="assembly"></param>
-        public static void VersionOptionFromAssemblyAttributes(this CommandLineApplication app, Assembly assembly)
-            => app.VersionOption("--version", GetInformationalVersion(assembly));
+        public static CommandOption VersionOptionFromAssemblyAttributes(this CommandLineApplication app, Assembly assembly)
+            => VersionOptionFromAssemblyAttributes(app, "--version", assembly);
+
+        /// <summary>
+        /// Finds <see cref="AssemblyInformationalVersionAttribute"/> on <paramref name="assembly"/> and uses that
+        /// to set <see cref="CommandLineApplication.OptionVersion"/>.
+        /// <para>
+        /// Uses the Version that is part of the <see cref="AssemblyName"/> of the specified assembly
+        /// if no <see cref="AssemblyInformationalVersionAttribute"/> is applied.
+        /// </para>
+        /// </summary>
+        /// <param name="app"></param>
+        /// <param name="template"></param>
+        /// <param name="assembly"></param>
+        public static CommandOption VersionOptionFromAssemblyAttributes(CommandLineApplication app, string template, Assembly assembly)
+            => app.VersionOption(template, GetInformationalVersion(assembly));
 
         private static string GetInformationalVersion(Assembly assembly)
         {

--- a/src/CommandLineUtils/CommandLineApplicationExtensions.cs
+++ b/src/CommandLineUtils/CommandLineApplicationExtensions.cs
@@ -76,34 +76,16 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="assembly"></param>
         /// <exception cref="ArgumentNullException">Either <paramref name="app"/> or <paramref name="assembly"/> is <c>null</c>.</exception>
         public static CommandOption VersionOptionFromAssemblyAttributes(CommandLineApplication app, string template, Assembly assembly)
-        {
-            if (app == null)
-                throw new ArgumentNullException(nameof(app));
-            GetVersionStringsFromAssemblyAttributes(assembly ?? throw new ArgumentNullException(nameof(assembly)), 
-                out string shortVersion, out string longVersion);
-            return app.VersionOption(template, shortVersion, longVersion);
-        }
+            => app.VersionOption(template, GetInformationalVersion(assembly));
 
-        private static void GetVersionStringsFromAssemblyAttributes(Assembly assembly, out string shortVersion, out string longVersion)
+        private static string GetInformationalVersion(Assembly assembly)
         {
-            string infoVersion = assembly?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
-            string nameVersion = assembly.GetName().Version.ToString();
-
-            // A .NET Assembly always has a name, and that name always contains a version.
-            // Informational Version may be missing, so use AssemblyName as fallback.
+            string infoVersion = assembly?
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+                .InformationalVersion;
             if (string.IsNullOrWhiteSpace(infoVersion))
-            {
-                shortVersion = 'v' + nameVersion;
-                longVersion = shortVersion;
-            }
-            else
-            {
-                shortVersion = 'v' + infoVersion;
-                // Use both informational and machine-readable Version
-                // for long version string
-                // -> "v1.2.3-alpha-feature-x (v1.2.3.4242)"
-                longVersion = $"v{infoVersion} (v{nameVersion})";
-            }
+                return assembly?.GetName().Version.ToString();
+            return infoVersion;
         }
     }
 }

--- a/src/CommandLineUtils/CommandLineApplicationExtensions.cs
+++ b/src/CommandLineUtils/CommandLineApplicationExtensions.cs
@@ -26,7 +26,16 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="app"></param>
         /// <returns></returns>
         public static CommandOption VerboseOption(this CommandLineApplication app)
-            => app.Option("-v|--verbose", "Show verbose output", CommandOptionType.NoValue, inherited: true);
+            => VerboseOption(app, "-v|--verbose");
+
+        /// <summary>
+        /// Adds the verbose option with the template <c>-v|--verbose</c>.
+        /// </summary>
+        /// <param name="app"></param>
+        /// <param name="template" />
+        /// <returns></returns>
+        public static CommandOption VerboseOption(this CommandLineApplication app, string template)
+            => app.Option(template, "Show verbose output", CommandOptionType.NoValue, inherited: true);
 
         /// <summary>
         /// Sets <see cref="CommandLineApplication.Invoke"/> with a return code of <c>0</c>.


### PR DESCRIPTION
* `VersionOptionFromAssemblyAttributes` used to return `void`. Now returns `CommandOption` to be consistent with other Option-APIs
* `VerboseOption` gets a new overload that allows for specifying a template by argument if you are unhappy with the `-v|--verbose` default. *Most likely because you want to use `-v` for something else.*
* `VersionOptionFromAssemblyAttributes` gets a new overload that allows for specifying a template by argument.
* `VersionOptionFromAssemblyAttributes` gets a more intelligent implementation for finding the version strings as decribed below.

.NET Assemblies (especially old ones with that are compiled with an `Properties\AssemblyInfo.cs` file, like we used to do before `.NET Core` with the new project system came along) may not have an `AssemblyInformationalVersionAttribute` applied to them.  
However, all .NET Assemblies have a string AssemblyName which always carries a version. *More specifically: The compiler strips an applied `AssemblyVersionAttribute` at compile-time and puts the version of that attribute into the Assembly name instead.*  
Therefore this PR includes a fallback to use the version obtained from the `AssemblyName` in case the assembly has no informational version.

Finally, many applications that show versions (e.g. node and npm) prefix the version string with a `v`. This is also the most common way to create release tags on GitHub and in various other systems that use a version string. The PR prefixes the version string with a `v`.

Sometimes, the version obtained by `AssemblyName` might be important. For example when loading an Assembly by its full strong name (which includes its version). For that purpose it might be beneficial to use include the `AssemblyName` version in the long-version-string. The PR puts the `AssemblyName` version into parentheses.

