### PR TITLE
Add SecureString prompt

### DIFF
--- a/src/CommandLineUtils/Utilities/Prompt.cs
+++ b/src/CommandLineUtils/Utilities/Prompt.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Text;
 
 namespace McMaster.Extensions.CommandLineUtils
@@ -11,6 +12,8 @@ namespace McMaster.Extensions.CommandLineUtils
     /// </summary>
     public static class Prompt
     {
+        private const char Backspace = '\b';
+
         /// <summary>
         /// Gets a yes/no response from the console after displaying a <paramref name="prompt" />.
         /// <para>
@@ -89,36 +92,105 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <returns>The password as plaintext. Can be null or empty.</returns>
         public static string GetPassword(string prompt, ConsoleColor? promptColor = null, ConsoleColor? promptBgColor = null)
         {
+            var resp = new StringBuilder();
+
+            foreach (var key in ReadObfuscatedLine(prompt, promptColor, promptBgColor))
+            {
+                switch (key)
+                {
+                    case Backspace:
+                        resp.Remove(resp.Length - 1, 1);
+                        break;
+                    default:
+                        resp.Append(key);
+                        break;
+                }
+            }
+
+            return resp.ToString();
+        }
+
+#if !NETSTANDARD1_6
+        /// <summary>
+        /// Gets a response as a SecureString object. Input is masked with an asterisk.
+        /// </summary>
+        /// <param name="prompt">The question to display on the command line</param>
+        /// <param name="promptColor">The console color to use for the prompt</param>
+        /// <param name="promptBgColor">The console background color for the prompt</param>
+        /// <returns>A finalized SecureString object, may be empty.</returns>
+        public static System.Security.SecureString GetPasswordAsSecureString(string prompt, ConsoleColor? promptColor = null, ConsoleColor? promptBgColor = null)
+        {
+            var secureString = new System.Security.SecureString();
+
+            foreach (var key in ReadObfuscatedLine(prompt, promptColor, promptBgColor))
+            {
+                switch (key)
+                {
+                    case Backspace:
+                        secureString.RemoveAt(secureString.Length - 1);
+                        break;
+                    default:
+                        secureString.AppendChar(key);
+                        break;
+                }
+            }
+
+            secureString.MakeReadOnly();
+            return secureString;
+        }
+#endif
+
+        /// <summary>
+        /// Base implementation of <see cref="GetPassword"/> and <see cref="GetPasswordAsSecureString"/>. Prompts the user for
+        /// a password and yields each key as the user inputs. Password is masked as input. Pressing Escape will reset the password
+        /// by flushing the stream with backspace keys.
+        /// </summary>
+        /// <param name="prompt">The question to display on the command line</param>
+        /// <param name="promptColor">The console color to use for the prompt</param>
+        /// <param name="promptBgColor">The console background color for the prompt</param>
+        /// <returns>A stream of characters as input by the user including <see cref="Backspace"/> for deletions.</returns>
+        private static IEnumerable<char> ReadObfuscatedLine(string prompt, ConsoleColor? promptColor = null, ConsoleColor? promptBgColor = null)
+        {
+            const string whiteOut = "\b \b";
             Write(prompt, promptColor, promptBgColor);
             Console.Write(' ');
 
-            var resp = new StringBuilder();
+            var readChars = 0;
             ConsoleKeyInfo key;
-
             do
             {
                 key = Console.ReadKey(intercept: true);
+                // TODO: What should happen if the key has a modifier?
                 switch (key.Key)
                 {
                     case ConsoleKey.Enter:
                         Console.WriteLine();
                         break;
                     case ConsoleKey.Backspace:
-                        if (resp.Length > 0)
+                        if (readChars > 0)
                         {
-                            Console.Write("\b \b");
-                            resp.Remove(resp.Length - 1, 1);
+                            Console.Write(whiteOut);
+                            --readChars;
+                            yield return Backspace;
+                        }
+                        break;
+                    case ConsoleKey.Escape:
+                        // Reset the password
+                        while (readChars > 0)
+                        {
+                            Console.Write(whiteOut);
+                            yield return Backspace;
+                            --readChars;
                         }
                         break;
                     default:
-                        resp.Append(key.KeyChar);
-                        Console.Write("*");
+                        readChars += 1;
+                        Console.Write('*');
+                        yield return key.KeyChar;
                         break;
                 }
             }
             while (key.Key != ConsoleKey.Enter);
-
-            return resp.ToString();
         }
 
         /// <summary>

--- a/src/CommandLineUtils/Utilities/Prompt.cs
+++ b/src/CommandLineUtils/Utilities/Prompt.cs
@@ -141,7 +141,7 @@ namespace McMaster.Extensions.CommandLineUtils
 #endif
 
         /// <summary>
-        /// Base implementation of <see cref="GetPassword"/> and <see cref="GetPasswordAsSecureString"/>. Prompts the user for
+        /// Base implementation of GetPassword and GetPasswordAsString. Prompts the user for
         /// a password and yields each key as the user inputs. Password is masked as input. Pressing Escape will reset the password
         /// by flushing the stream with backspace keys.
         /// </summary>

--- a/src/CommandLineUtils/Utilities/Prompt.cs
+++ b/src/CommandLineUtils/Utilities/Prompt.cs
@@ -148,7 +148,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="prompt">The question to display on the command line</param>
         /// <param name="promptColor">The console color to use for the prompt</param>
         /// <param name="promptBgColor">The console background color for the prompt</param>
-        /// <returns>A stream of characters as input by the user including <see cref="Backspace"/> for deletions.</returns>
+        /// <returns>A stream of characters as input by the user including Backspace for deletions.</returns>
         private static IEnumerable<char> ReadObfuscatedLine(string prompt, ConsoleColor? promptColor = null, ConsoleColor? promptBgColor = null)
         {
             const string whiteOut = "\b \b";


### PR DESCRIPTION
Implemented as a helper method `ReadObfuscatedLine` and both `ReadPassword` and `ReadPasswordAsSecureString` use the helper.