### PR TITLE
Fix NullReferenceException when using default HelpOption and calling …

### DIFF
--- a/src/CommandLineUtils/CommandLineApplication.cs
+++ b/src/CommandLineUtils/CommandLineApplication.cs
@@ -462,29 +462,10 @@ namespace McMaster.Extensions.CommandLineUtils
                         }
 
                         // If we find a help/version option, show information and stop parsing
-                        if (command.OptionHelp == option)
+                        bool stopParsing = ShowHelpOrVersion(command, option);
+                        if (stopParsing)
                         {
-                            command.ShowHelp();
-                            option.TryParse(null);
-                            var parent = command;
-                            while (parent.Parent != null) parent = parent.Parent;
-                            parent.SelectedCommand = command;
-                            if (StopParsingAfterHelpOption)
-                            {
-                                return 0;
-                            }
-                        }
-                        else if (command.OptionVersion == option)
-                        {
-                            command.ShowVersion();
-                            option.TryParse(null);
-                            var parent = command;
-                            while (parent.Parent != null) parent = parent.Parent;
-                            parent.SelectedCommand = command;
-                            if (StopParsingAfterVersionOption)
-                            {
-                                return 0;
-                            }
+                            return 0;
                         }
 
                         if (longOption.Length == 2)
@@ -507,12 +488,13 @@ namespace McMaster.Extensions.CommandLineUtils
                     if (shortOption != null)
                     {
                         processed = true;
-                        option = command.GetOptions().SingleOrDefault(opt => string.Equals(opt.ShortName, shortOption[0], StringComparison.Ordinal));
+                        var shortOptionName = shortOption[0];
+                        option = command.GetOptions().SingleOrDefault(opt => string.Equals(opt.ShortName, shortOptionName, StringComparison.Ordinal));
 
                         // If not a short option, try symbol option
                         if (option == null)
                         {
-                            option = command.GetOptions().SingleOrDefault(opt => string.Equals(opt.SymbolName, shortOption[0], StringComparison.Ordinal));
+                            option = command.GetOptions().SingleOrDefault(opt => string.Equals(opt.SymbolName, shortOptionName, StringComparison.Ordinal));
                         }
 
                         if (option == null)
@@ -522,31 +504,10 @@ namespace McMaster.Extensions.CommandLineUtils
                         }
 
                         // If we find a help/version option, show information and stop parsing
-                        if (command.OptionHelp == option)
+                        bool stopParsing = ShowHelpOrVersion(command, option);
+                        if (stopParsing)
                         {
-                            command.ShowHelp();
                             return 0;
-                        }
-                        else if (command.OptionVersion == option)
-                        {
-                            command.ShowVersion();
-                            return 0;
-                        }
-
-                        if (shortOption.Length == 2)
-                        {
-                            if (!option.TryParse(shortOption[1]))
-                            {
-                                command.ShowHint();
-                                throw new CommandParsingException(command, $"Unexpected value '{shortOption[1]}' for option '{option.LongName}'");
-                            }
-                            option = null;
-                        }
-                        else if (option.OptionType == CommandOptionType.NoValue)
-                        {
-                            // No value is needed for this option
-                            option.TryParse(null);
-                            option = null;
                         }
                     }
                 }
@@ -962,6 +923,34 @@ namespace McMaster.Extensions.CommandLineUtils
                 // All remaining arguments are stored for further use
                 command.RemainingArguments.AddRange(new ArraySegment<string>(args.ToArray(), index, args.Count - index));
             }
+        }
+
+        /// <summary>
+        /// Shows the help or version information and returns true if StopParsingAfterHelpOption is true
+        /// </summary>
+        /// <param name="command">The CommandLineApplication</param>
+        /// <param name="option">The CommandOption</param>
+        /// <returns><c>true</c> if parsing should stop, <c>false</c> otherwise</returns>
+        private bool ShowHelpOrVersion(CommandLineApplication command, CommandOption option)
+        {
+            if (command.OptionHelp == option)
+            {
+                command.ShowHelp();
+            }
+            else if (command.OptionVersion == option)
+            {
+                command.ShowVersion();
+            }
+            
+            option.TryParse(null);
+            var parent = command;
+            while (parent.Parent != null) parent = parent.Parent;
+            parent.SelectedCommand = command;
+            if (StopParsingAfterHelpOption)
+            {
+                return true;
+            }
+            return false;
         }
 
         /// <summary>

--- a/src/CommandLineUtils/CommandLineApplication.cs
+++ b/src/CommandLineUtils/CommandLineApplication.cs
@@ -462,7 +462,7 @@ namespace McMaster.Extensions.CommandLineUtils
                         }
 
                         // If we find a help/version option, show information and stop parsing
-                        bool stopParsing = ShowHelpOrVersion(command, option);
+                        bool stopParsing = HandleHelpOrVersion(command, option);
                         if (stopParsing)
                         {
                             return 0;
@@ -504,7 +504,7 @@ namespace McMaster.Extensions.CommandLineUtils
                         }
 
                         // If we find a help/version option, show information and stop parsing
-                        bool stopParsing = ShowHelpOrVersion(command, option);
+                        bool stopParsing = HandleHelpOrVersion(command, option);
                         if (stopParsing)
                         {
                             return 0;
@@ -926,12 +926,12 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary>
-        /// Shows the help or version information and returns true if StopParsingAfterHelpOption is true
+        /// Shows the help or version information if the given option is a help or version option and returns <c>true</c> if StopParsingAfterHelpOption is true
         /// </summary>
         /// <param name="command">The CommandLineApplication</param>
         /// <param name="option">The CommandOption</param>
         /// <returns><c>true</c> if parsing should stop, <c>false</c> otherwise</returns>
-        private bool ShowHelpOrVersion(CommandLineApplication command, CommandOption option)
+        private bool HandleHelpOrVersion(CommandLineApplication command, CommandOption option)
         {
             if (command.OptionHelp == option)
             {
@@ -940,6 +940,10 @@ namespace McMaster.Extensions.CommandLineUtils
             else if (command.OptionVersion == option)
             {
                 command.ShowVersion();
+            }
+            else
+            {
+                return false;
             }
             
             option.TryParse(null);

--- a/src/CommandLineUtils/CommandLineApplication.cs
+++ b/src/CommandLineUtils/CommandLineApplication.cs
@@ -495,13 +495,14 @@ namespace McMaster.Extensions.CommandLineUtils
                         if (option == null)
                         {
                             option = command.GetOptions().SingleOrDefault(opt => string.Equals(opt.SymbolName, shortOptionName, StringComparison.Ordinal));
+                            // If still null, it's an error
+                            if (option == null)
+                            {
+                                HandleUnexpectedArg(command, args, index, argTypeName: "option");
+                                break;
+                            }
                         }
 
-                        if (option == null)
-                        {
-                            HandleUnexpectedArg(command, args, index, argTypeName: "option");
-                            break;
-                        }
 
                         // If we find a help/version option, show information and stop parsing
                         bool stopParsing = HandleHelpOrVersion(command, option);


### PR DESCRIPTION
…command with -h or -? instead of --help

Closes #26