### PR TITLE
Provide ability to specify inheritance on help option

### DIFF
--- a/samples/Subcommands/BuilderApi.cs
+++ b/samples/Subcommands/BuilderApi.cs
@@ -21,10 +21,9 @@ namespace SubcommandSample
                 Description = "A fake version of the node package manager",
             };
 
-            app.HelpOption();
+            app.HelpOption(inherited: true);
             app.Command("config", configCmd =>
             {
-                configCmd.HelpOption();
                 configCmd.OnExecute(() =>
                 {
                     Console.WriteLine("Specify a subcommand");
@@ -34,7 +33,6 @@ namespace SubcommandSample
 
                 configCmd.Command("set", setCmd =>
                 {
-                    setCmd.HelpOption();
                     setCmd.Description = "Set config value";
                     var key = setCmd.Argument("key", "Name of the config").IsRequired();
                     var val = setCmd.Argument("value", "Value of the config").IsRequired();
@@ -46,7 +44,6 @@ namespace SubcommandSample
 
                 configCmd.Command("list", listCmd =>
                 {
-                    listCmd.HelpOption();
                     var json = listCmd.Option("--json", "Json output", CommandOptionType.NoValue);
                     listCmd.OnExecute(() =>
                     {

--- a/src/CommandLineUtils/CommandLineApplication.cs
+++ b/src/CommandLineUtils/CommandLineApplication.cs
@@ -26,6 +26,7 @@ namespace McMaster.Extensions.CommandLineUtils
 
         internal CommandLineContext _context;
         private IHelpTextGenerator _helpTextGenerator;
+        private CommandOption _optionHelp;
 
         /// <summary>
         /// Initializes a new instance of <see cref="CommandLineApplication"/>.
@@ -134,7 +135,22 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <summary>
         /// The option used to determine if help text should be displayed. This is set by calling <see cref="HelpOption(string)"/>.
         /// </summary>
-        public CommandOption OptionHelp { get; internal set; }
+        public CommandOption OptionHelp
+        {
+            get
+            {
+                if (_optionHelp != null)
+                {
+                    return _optionHelp;
+                }
+                if (Parent?.OptionHelp?.Inherited == true)
+                {
+                    return Parent.OptionHelp;
+                }
+                return null;
+            }
+            internal set => _optionHelp = value;
+        }
 
         /// <summary>
         /// The options used to determine if the command version should be displayed. This is set by calling <see cref="VersionOption(string, Func{string}, Func{string})"/>.
@@ -252,14 +268,6 @@ namespace McMaster.Extensions.CommandLineUtils
 
             Commands.Add(command);
             configuration(command);
-
-            // Inherit the help option after configuration only if the consumer did not
-            // add its own help option. Adding it after configuration prevents the consumer
-            // from accidentally mutating the help option of the parent command via the subcommand.
-            if ((OptionHelp?.Inherited ?? false) && command.OptionHelp == null)
-            {
-                command.OptionHelp = OptionHelp;
-            }
 
             return command;
         }

--- a/src/CommandLineUtils/CommandLineApplication.cs
+++ b/src/CommandLineUtils/CommandLineApplication.cs
@@ -132,7 +132,7 @@ namespace McMaster.Extensions.CommandLineUtils
         public List<CommandOption> Options { get; private set; }
 
         /// <summary>
-        /// The option used to determine if help text should be displayed. This is set by calling <see cref="HelpOption(string)"/>.
+        /// The option used to determine if help text should be displayed. This is set by calling <see cref="HelpOption(string, bool)"/>.
         /// </summary>
         public CommandOption OptionHelp { get; internal set; }
 
@@ -397,12 +397,13 @@ namespace McMaster.Extensions.CommandLineUtils
         /// Helper method that adds a help option.
         /// </summary>
         /// <param name="template"></param>
+        /// <param name="inherited"></param>
         /// <returns></returns>
-        public CommandOption HelpOption(string template)
+        public CommandOption HelpOption(string template, bool inherited = false)
         {
             // Help option is special because we stop parsing once we see it
             // So we store it separately for further use
-            OptionHelp = Option(template, Strings.DefaultHelpOptionDescription, CommandOptionType.NoValue);
+            OptionHelp = Option(template, Strings.DefaultHelpOptionDescription, CommandOptionType.NoValue, inherited);
 
             return OptionHelp;
         }

--- a/src/CommandLineUtils/CommandLineApplication.cs
+++ b/src/CommandLineUtils/CommandLineApplication.cs
@@ -132,7 +132,7 @@ namespace McMaster.Extensions.CommandLineUtils
         public List<CommandOption> Options { get; private set; }
 
         /// <summary>
-        /// The option used to determine if help text should be displayed. This is set by calling <see cref="HelpOption(string, bool)"/>.
+        /// The option used to determine if help text should be displayed. This is set by calling <see cref="HelpOption(string)"/>.
         /// </summary>
         public CommandOption OptionHelp { get; internal set; }
 
@@ -252,6 +252,15 @@ namespace McMaster.Extensions.CommandLineUtils
 
             Commands.Add(command);
             configuration(command);
+
+            // Inherit the help option after configuration only if the consumer did not
+            // add its own help option. Adding it after configuration prevents the consumer
+            // from accidentally mutating the help option of the parent command via the subcommand.
+            if (OptionHelp.Inherited && command.OptionHelp == null)
+            {
+                command.OptionHelp = OptionHelp;
+            }
+
             return command;
         }
 
@@ -397,9 +406,17 @@ namespace McMaster.Extensions.CommandLineUtils
         /// Helper method that adds a help option.
         /// </summary>
         /// <param name="template"></param>
+        /// <returns></returns>
+        public CommandOption HelpOption(string template)
+            => HelpOption(template, false);
+
+        /// <summary>
+        /// Helper method that adds a help option.
+        /// </summary>
+        /// <param name="template"></param>
         /// <param name="inherited"></param>
         /// <returns></returns>
-        public CommandOption HelpOption(string template, bool inherited = false)
+        public CommandOption HelpOption(string template, bool inherited)
         {
             // Help option is special because we stop parsing once we see it
             // So we store it separately for further use

--- a/src/CommandLineUtils/CommandLineApplication.cs
+++ b/src/CommandLineUtils/CommandLineApplication.cs
@@ -256,7 +256,7 @@ namespace McMaster.Extensions.CommandLineUtils
             // Inherit the help option after configuration only if the consumer did not
             // add its own help option. Adding it after configuration prevents the consumer
             // from accidentally mutating the help option of the parent command via the subcommand.
-            if (OptionHelp.Inherited && command.OptionHelp == null)
+            if ((OptionHelp?.Inherited ?? false) && command.OptionHelp == null)
             {
                 command.OptionHelp = OptionHelp;
             }

--- a/src/CommandLineUtils/CommandLineApplicationExtensions.cs
+++ b/src/CommandLineUtils/CommandLineApplicationExtensions.cs
@@ -17,9 +17,10 @@ namespace McMaster.Extensions.CommandLineUtils
         /// Adds the help option with the template <c>-?|-h|--help</c>.
         /// </summary>
         /// <param name="app"></param>
+        /// <param name="inherited"></param>
         /// <returns></returns>
-        public static CommandOption HelpOption(this CommandLineApplication app)
-            => app.HelpOption(Strings.DefaultHelpTemplate);
+        public static CommandOption HelpOption(this CommandLineApplication app, bool inherited = false)
+            => app.HelpOption(Strings.DefaultHelpTemplate, inherited);
 
         /// <summary>
         /// Adds the verbose option with the template <c>-v|--verbose</c>.
@@ -55,7 +56,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// </summary>
         /// <param name="app"></param>
         /// <param name="action"></param>
-        public static void OnValidationError(this CommandLineApplication app, Func<ValidationResult, int> action) 
+        public static void OnValidationError(this CommandLineApplication app, Func<ValidationResult, int> action)
             => app.ValidationErrorHandler = action;
 
         /// <summary>

--- a/src/CommandLineUtils/CommandLineApplicationExtensions.cs
+++ b/src/CommandLineUtils/CommandLineApplicationExtensions.cs
@@ -17,9 +17,17 @@ namespace McMaster.Extensions.CommandLineUtils
         /// Adds the help option with the template <c>-?|-h|--help</c>.
         /// </summary>
         /// <param name="app"></param>
+        /// <returns></returns>
+        public static CommandOption HelpOption(this CommandLineApplication app)
+            => app.HelpOption(Strings.DefaultHelpTemplate);
+
+        /// <summary>
+        /// Adds the help option with the template <c>-?|-h|--help</c>.
+        /// </summary>
+        /// <param name="app"></param>
         /// <param name="inherited"></param>
         /// <returns></returns>
-        public static CommandOption HelpOption(this CommandLineApplication app, bool inherited = false)
+        public static CommandOption HelpOption(this CommandLineApplication app, bool inherited)
             => app.HelpOption(Strings.DefaultHelpTemplate, inherited);
 
         /// <summary>

--- a/test/CommandLineUtils.Tests/CommandLineApplicationTests.cs
+++ b/test/CommandLineUtils.Tests/CommandLineApplicationTests.cs
@@ -699,6 +699,30 @@ Examples:
         }
 
         [Fact]
+        public void InheritedHelpOptionIsSame()
+        {
+            var app = new CommandLineApplication();
+            var sub1 = app.Command("sub", _ => {});
+            var sub2 = sub1.Command("sub", _ => {});
+            var help = app.HelpOption(inherited: true);
+            Assert.Same(help, app.OptionHelp);
+            Assert.Same(help, sub1.OptionHelp);
+            Assert.Same(help, sub2.OptionHelp);
+        }
+
+        [Fact]
+        public void InheritedHelpOptionCanBeOverridden()
+        {
+            var app = new CommandLineApplication();
+            var sub1 = app.Command("sub", a => a.HelpOption());
+            var sub2 = sub1.Command("sub", a => a.HelpOption());
+            var help = app.HelpOption(inherited: true);
+            Assert.Same(help, app.OptionHelp);
+            Assert.NotSame(help, sub1.OptionHelp);
+            Assert.NotSame(help, sub2.OptionHelp);
+        }
+
+        [Fact]
         public void VersionOptionIsSet()
         {
             var app = new CommandLineApplication

--- a/test/CommandLineUtils.Tests/CommandLineApplicationTests.cs
+++ b/test/CommandLineUtils.Tests/CommandLineApplicationTests.cs
@@ -643,6 +643,40 @@ Examples:
             Assert.True(helpOption.HasValue());
         }
 
+        [Theory]
+        [InlineData("-h")]
+        [InlineData("--help")]
+        public void HelpOptionIsInherited(string helpOptionString)
+        {
+            var app = new CommandLineApplication
+            {
+                Out = new XunitTextWriter(_output)
+            };
+            var helpOption = app.HelpOption(true);
+            var subCommand = app.Command("lvl2", subCmd => { });
+
+            var commandOptions = new[] { "lvl2", helpOptionString };
+            app.Execute(commandOptions);
+            Assert.True(helpOption.HasValue());
+        }
+
+        [Theory]
+        [InlineData("-h")]
+        [InlineData("--help")]
+        public void HelpOptionIsNotInheritedByDefault(string helpOptionString)
+        {
+            var app = new CommandLineApplication
+            {
+                Out = new XunitTextWriter(_output)
+            };
+            app.HelpOption();
+            var subCommand = app.Command("lvl2", subCmd => { });
+
+            var commandOptions = new[] { "lvl2", helpOptionString };
+            var exception = Assert.Throws<CommandParsingException>(() => app.Execute(commandOptions));
+            Assert.Equal($"Unrecognized option '{helpOptionString}'", exception.Message);
+        }
+
         [Fact]
         public void VersionOptionIsSet()
         {

--- a/test/CommandLineUtils.Tests/LegalFilePathAttributeTests.cs
+++ b/test/CommandLineUtils.Tests/LegalFilePathAttributeTests.cs
@@ -46,7 +46,6 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         [InlineData(null)]
         [InlineData("")]
         [InlineData("\0")]
-        [InlineData("/////")]
         public void FailsInvalidLegalFilePaths(string filePath)
         {
             var console = new TestConsole(_output);


### PR DESCRIPTION
resolve #44 by adding an optional bool parameter to `.HelpOption` methods to specify
inheritance on the help option. The default value for the parameter is false so as to
be consistent with existing behavior in the system.