### PR TITLE
Allow empty string for CommandOption.ShortName

### DIFF
--- a/src/CommandLineUtils/CommandOption.cs
+++ b/src/CommandLineUtils/CommandOption.cs
@@ -183,26 +183,26 @@ namespace McMaster.Extensions.CommandLineUtils
         internal string ToTemplateString()
         {
             var sb = new StringBuilder();
-            if (SymbolName != null)
+            if (!string.IsNullOrEmpty(SymbolName))
             {
                 sb.Append('-').Append(SymbolName);
             }
 
-            if (ShortName != null)
+            if (!string.IsNullOrEmpty(ShortName))
             {
                 if (sb.Length > 0) sb.Append('|');
 
                 sb.Append('-').Append(ShortName);
             }
 
-            if (LongName != null)
+            if (!string.IsNullOrEmpty(LongName))
             {
                 if (sb.Length > 0) sb.Append('|');
 
                 sb.Append("--").Append(LongName);
             }
 
-            if (ValueName != null && OptionType != CommandOptionType.NoValue)
+            if (!string.IsNullOrEmpty(ValueName) && OptionType != CommandOptionType.NoValue)
             {
                 sb.Append(" <").Append(ValueName).Append('>');
             }

--- a/src/CommandLineUtils/Internal/ReflectionAppBuilder.cs
+++ b/src/CommandLineUtils/Internal/ReflectionAppBuilder.cs
@@ -267,7 +267,7 @@ namespace McMaster.Extensions.CommandLineUtils
                 throw new InvalidOperationException(Strings.NoValueTypesMustBeBoolean);
             }
 
-            if (option.ShortName != null)
+            if (!string.IsNullOrEmpty(option.ShortName))
             {
                 if (_shortOptions.TryGetValue(option.ShortName, out var otherProp))
                 {
@@ -277,7 +277,7 @@ namespace McMaster.Extensions.CommandLineUtils
                 _shortOptions.Add(option.ShortName, prop);
             }
 
-            if (option.LongName != null)
+            if (!string.IsNullOrEmpty(option.LongName))
             {
                 if (_longOptions.TryGetValue(option.LongName, out var otherProp))
                 {

--- a/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
+++ b/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Nate McMaster.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Text;
+using McMaster.Extensions.CommandLineUtils.HelpText;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace McMaster.Extensions.CommandLineUtils.Tests
+{
+    public class DefaultHelpTextGeneratorTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public DefaultHelpTextGeneratorTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        private class EmptyShortName
+        {
+            [Option(ShortName = "")]
+            public string Option { get; }
+        }
+
+        [Fact]
+        public void ItListOptions()
+        {
+            var builder = new ReflectionAppBuilder<EmptyShortName>();
+            builder.Initialize();
+            var sb = new StringBuilder();
+            DefaultHelpTextGenerator.Singleton.Generate(builder.App, new StringWriter(sb));
+            var helpText = sb.ToString();
+            _output.WriteLine(helpText);
+
+            Assert.Contains("--option <OPTION>", helpText);
+            Assert.DoesNotContain("-|--option <OPTION>", helpText);
+        }
+    }
+}

--- a/test/CommandLineUtils.Tests/ReflectionAppBuilderTests.cs
+++ b/test/CommandLineUtils.Tests/ReflectionAppBuilderTests.cs
@@ -132,6 +132,24 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             Assert.Equal("-d2|--detail2 <DETAIL2>", d2.Template);
         }
 
+        private class EmptyShortName
+        {
+            [Option(ShortName = "")]
+            public string Detail1 { get; }
+
+            [Option(ShortName = "")]
+            public string Detail2 { get; }
+        }
+
+        [Fact]
+        public void CanSetShortNameToEmptyString()
+        {
+            var builder = new ReflectionAppBuilder<EmptyShortName>();
+            builder.Initialize();
+
+            Assert.All(builder.App.Options, o => Assert.Empty(o.ShortName));
+        }
+
         private class AmbiguousShortOptionName
         {
             [Option]


### PR DESCRIPTION
Fix #48 

cc @atruskie 