### PR TITLE
Align multi-line help text

### DIFF
--- a/src/CommandLineUtils/CommandLineApplication.cs
+++ b/src/CommandLineUtils/CommandLineApplication.cs
@@ -597,7 +597,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <returns></returns>
         public string GetFullNameAndVersion()
         {
-            return ShortVersionGetter == null ? FullName : string.Format("{0} {1}", FullName, ShortVersionGetter());
+            return ShortVersionGetter == null ? FullName : string.Format("{0} ({1})", FullName, ShortVersionGetter());
         }
 
         /// <summary>

--- a/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
+++ b/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Nate McMaster.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -75,9 +76,15 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
                 output.WriteLine("Arguments:");
                 var maxArgLen = arguments.Max(a => a.Name.Length);
                 var outputFormat = string.Format("  {{0, -{0}}}{{1}}", maxArgLen + 2);
+
+                var newLineWithMessagePadding = Environment.NewLine + new string(' ', maxArgLen + 4);
+
                 foreach (var arg in arguments)
                 {
-                    output.Write(outputFormat, arg.Name, arg.Description);
+                    var message = string.Format(outputFormat, arg.Name, arg.Description);
+                    message = message.Replace(Environment.NewLine, newLineWithMessagePadding);
+
+                    output.Write(message);
                     output.WriteLine();
                 }
             }
@@ -88,9 +95,15 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
                 output.WriteLine("Options:");
                 var maxOptLen = options.Max(o => o.Template?.Length ?? 0);
                 var outputFormat = string.Format("  {{0, -{0}}}{{1}}", maxOptLen + 2);
+
+                var newLineWithMessagePadding = Environment.NewLine + new string(' ', maxOptLen + 4);
+
                 foreach (var opt in options)
                 {
-                    output.Write(outputFormat, opt.Template, opt.Description);
+                    var message = string.Format(outputFormat, opt.Template, opt.Description);
+                    message = message.Replace(Environment.NewLine, newLineWithMessagePadding);
+
+                    output.Write(message);
                     output.WriteLine();
                 }
             }
@@ -101,20 +114,27 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
                 output.WriteLine("Commands:");
                 var maxCmdLen = commands.Max(c => c.Name?.Length ?? 0);
                 var outputFormat = string.Format("  {{0, -{0}}}{{1}}", maxCmdLen + 2);
+
+                var newLineWithMessagePadding = Environment.NewLine + new string(' ', maxCmdLen + 4);
+
                 foreach (var cmd in commands.OrderBy(c => c.Name))
                 {
-                    output.Write(outputFormat, cmd.Name, cmd.Description);
+                    var message = string.Format(outputFormat, cmd.Name, cmd.Description);
+                    message = message.Replace(Environment.NewLine, newLineWithMessagePadding);
+
+                    output.Write(message);
                     output.WriteLine();
                 }
 
                 if (application.OptionHelp != null)
                 {
                     output.WriteLine();
-                    output.WriteLine($"Use \"{application.Name} [command] --{application.OptionHelp.LongName}\" for more information about a command.");
+                    output.WriteLine($"Run '{application.Name} [command] --{application.OptionHelp.LongName}' for more information about a command.");
                 }
             }
 
             output.Write(application.ExtendedHelpText);
+            output.WriteLine();
         }
     }
 }


### PR DESCRIPTION
Aligning multi-line arguments, options and commands help text.

## Config:
```cs
            CommandOption fileNameCommadOption = cla.Option("-f|--fileName <FILENAME>",
                                                            "Name of the config file. Default is [config.props].",
                                                            CommandOptionType.SingleValue);
            CommandOption verbosityOption = cla.Option("-v|--verbosity <VERBOSITY_LEVEL>",
                                                       "Display this amount of information in the log.\r\n"
                                                       + "The available verbosity levels are: t[race], d[ebug], i[nformation], w[arning], e[rror], c[ritical] and n[one].\r\n"
                                                       + "Default:\r\n" + $"  default\r\n" + "Examples:\r\n"
                                                       + "  --verbosity:warning\r\n" + "  -v:d",
                                                       CommandOptionType.SingleValue);
            cla.HelpOption("-?|-h|--help");
```

## Instead of
```
Options:
  -f|--fileName <FILENAME>          Name of the config file. Default is [config.props].
  -v|--verbosity <VERBOSITY_LEVEL>  Display this amount of information in the log.
The available verbosity levels are: t[race], d[ebug], i[nformation], w[arning], e[rror], c[ritical] and n[one].
Default:
  default
Examples:
  --verbosity:warning
  -v:d
  -?|-h|--help                      Show help information
```

## print this:
```
Options:
  -f|--fileName <FILENAME>          Name of the config file. Default is [config.props].
  -v|--verbosity <VERBOSITY_LEVEL>  Display this amount of information in the log.
                                    The available verbosity levels are: t[race], d[ebug], i[nformation], w[arning], e[rror], c[ritical] and n[one].
                                    Default:
                                      default
                                    Examples:
                                      --verbosity:warning
                                      -v:d
  -?|-h|--help                      Show help information
```