### PR TITLE
Adds support for user defined value parsers

### DIFF
--- a/src/CommandLineUtils/Attributes/OptionAttribute.cs
+++ b/src/CommandLineUtils/Attributes/OptionAttribute.cs
@@ -66,7 +66,7 @@ namespace McMaster.Extensions.CommandLineUtils
 
         internal CommandOption Configure(CommandLineApplication app, PropertyInfo prop)
         {
-            var optionType = GetOptionType(prop);
+            var optionType = GetOptionType(prop, app.ValueParsers);
             CommandOption option;
             if (Template != null)
             {
@@ -94,14 +94,14 @@ namespace McMaster.Extensions.CommandLineUtils
             return option;
         }
 
-        private CommandOptionType GetOptionType(PropertyInfo prop)
+        private CommandOptionType GetOptionType(PropertyInfo prop, ValueParserProvider valueParsers)
         {
             CommandOptionType optionType;
             if (OptionType.HasValue)
             {
                 optionType = OptionType.Value;
             }
-            else if (!CommandOptionTypeMapper.Default.TryGetOptionType(prop.PropertyType, out optionType))
+            else if (!CommandOptionTypeMapper.Default.TryGetOptionType(prop.PropertyType, valueParsers, out optionType))
             {
                 throw new InvalidOperationException(Strings.CannotDetermineOptionType(prop));
             }

--- a/src/CommandLineUtils/CommandLineApplication.Execute.cs
+++ b/src/CommandLineUtils/CommandLineApplication.Execute.cs
@@ -57,7 +57,7 @@ namespace McMaster.Extensions.CommandLineUtils
                     return app.Execute(context.Arguments);
                 }
             }
-            catch (CommandParsingException ex)
+            catch (Exception ex) when (ex is CommandParsingException || ex is FormatException)
             {
                 context.Console.Error.WriteLine(ex.Message);
                 return ValidationErrorExitCode;

--- a/src/CommandLineUtils/CommandLineApplication.cs
+++ b/src/CommandLineUtils/CommandLineApplication.cs
@@ -94,6 +94,7 @@ namespace McMaster.Extensions.CommandLineUtils
             ValidationErrorHandler = DefaultValidationErrorHandler;
             SetContext(context);
             _services = new Lazy<IServiceProvider>(() => new ServiceProvider(this));
+            ValueParsers =  new ValueParserProvider();
 
             _conventionContext = CreateConventionContext();
 
@@ -246,6 +247,19 @@ namespace McMaster.Extensions.CommandLineUtils
         /// The way arguments and options are matched.
         /// </summary>
         public StringComparison OptionsComparison { get; set; }
+
+        /// <summary>
+        /// Gets the default value parser provider.
+        /// <para>
+        /// The value parsers control how arugment values are converted from strings to other types. Additional value
+        /// parsers can be added so that domain specific types can converted. In-built value parsers can also be replaced
+        /// for precise control of all type conversion. 
+        /// </para>
+        /// <remarks>
+        /// Value parsers are currently only used by the Attribute API.
+        /// </remarks>
+        /// </summary>
+        public ValueParserProvider ValueParsers { get; private set; }
 
         /// <summary>
         /// <para>

--- a/src/CommandLineUtils/Conventions/ArgumentAttributeConvention.cs
+++ b/src/CommandLineUtils/Conventions/ArgumentAttributeConvention.cs
@@ -99,7 +99,9 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
 
             if (argument.MultipleValues)
             {
-                var collectionParser = CollectionParserProvider.Default.GetParser(prop.PropertyType);
+                var collectionParser = CollectionParserProvider.Default.GetParser(
+                    prop.PropertyType,
+                    convention.Application.ValueParsers);
                 if (collectionParser == null)
                 {
                     throw new InvalidOperationException(Strings.CannotDetermineParserType(prop));
@@ -115,7 +117,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
             }
             else
             {
-                var parser = ValueParserProvider.Default.GetParser(prop.PropertyType);
+                var parser = convention.Application.ValueParsers.GetParser(prop.PropertyType);
                 if (parser == null)
                 {
                     throw new InvalidOperationException(Strings.CannotDetermineParserType(prop));

--- a/src/CommandLineUtils/Conventions/OptionAttributeConventionBase.cs
+++ b/src/CommandLineUtils/Conventions/OptionAttributeConventionBase.cs
@@ -53,7 +53,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
             switch (option.OptionType)
             {
                 case CommandOptionType.MultipleValue:
-                    var collectionParser = CollectionParserProvider.Default.GetParser(prop.PropertyType);
+                    var collectionParser = CollectionParserProvider.Default.GetParser(prop.PropertyType, context.Application.ValueParsers);
                     if (collectionParser == null)
                     {
                         throw new InvalidOperationException(Strings.CannotDetermineParserType(prop));
@@ -62,7 +62,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                         setter.Invoke(context.ModelAccessor.GetModel(), collectionParser.Parse(option.LongName, option.Values)));
                     break;
                 case CommandOptionType.SingleOrNoValue:
-                    var valueTupleParser = ValueTupleParserProvider.Default.GetParser(prop.PropertyType);
+                    var valueTupleParser = ValueTupleParserProvider.Default.GetParser(prop.PropertyType, context.Application.ValueParsers);
                     if (valueTupleParser == null)
                     {
                         throw new InvalidOperationException(Strings.CannotDetermineParserType(prop));
@@ -71,7 +71,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                         setter.Invoke(context.ModelAccessor.GetModel(), valueTupleParser.Parse(option.HasValue(), option.LongName, option.Value())));
                     break;
                 case CommandOptionType.SingleValue:
-                    var parser = ValueParserProvider.Default.GetParser(prop.PropertyType);
+                    var parser = context.Application.ValueParsers.GetParser(prop.PropertyType);
                     if (parser == null)
                     {
                         throw new InvalidOperationException(Strings.CannotDetermineParserType(prop));

--- a/src/CommandLineUtils/Internal/CollectionParserProvider.cs
+++ b/src/CommandLineUtils/Internal/CollectionParserProvider.cs
@@ -16,12 +16,12 @@ namespace McMaster.Extensions.CommandLineUtils
 
         public static CollectionParserProvider Default { get; } = new CollectionParserProvider();
 
-        public ICollectionParser GetParser(Type type)
+        public ICollectionParser GetParser(Type type, ValueParserProvider valueParsers)
         {
             if (type.IsArray)
             {
                 var elementType = type.GetElementType();
-                var elementParser = ValueParserProvider.Default.GetParser(elementType);
+                var elementParser = valueParsers.GetParser(elementType);
                 if (elementParser == null)
                 {
                     return null;
@@ -35,7 +35,7 @@ namespace McMaster.Extensions.CommandLineUtils
             {
                 var typeDef = type.GetGenericTypeDefinition();
                 var elementType = typeInfo.GetGenericArguments().First();
-                var elementParser = ValueParserProvider.Default.GetParser(elementType);
+                var elementParser = valueParsers.GetParser(elementType);
 
                 if (typeof(IList<>) == typeDef
                     || typeof(IEnumerable<>) == typeDef

--- a/src/CommandLineUtils/Internal/CommandOptionTypeMapper.cs
+++ b/src/CommandLineUtils/Internal/CommandOptionTypeMapper.cs
@@ -15,11 +15,14 @@ namespace McMaster.Extensions.CommandLineUtils
 
         public static CommandOptionTypeMapper Default { get; } = new CommandOptionTypeMapper();
 
-        public bool TryGetOptionType(Type clrType, out CommandOptionType optionType)
+        public bool TryGetOptionType(
+            Type clrType,
+            ValueParserProvider valueParsers,
+            out CommandOptionType optionType)
         {
             try
             {
-                optionType = GetOptionType(clrType);
+                optionType = GetOptionType(clrType, valueParsers);
                 return true;
             }
             catch
@@ -29,7 +32,7 @@ namespace McMaster.Extensions.CommandLineUtils
             }
         }
 
-        public CommandOptionType GetOptionType(Type clrType)
+        public CommandOptionType GetOptionType(Type clrType, ValueParserProvider valueParsers = null)
         {
             if (clrType == typeof(bool))
             {
@@ -57,12 +60,12 @@ namespace McMaster.Extensions.CommandLineUtils
                 var typeDef = typeInfo.GetGenericTypeDefinition();
                 if (typeDef == typeof(Nullable<>))
                 {
-                    return GetOptionType(typeInfo.GetGenericArguments().First());
+                    return GetOptionType(typeInfo.GetGenericArguments().First(), valueParsers);
                 }
 
                 if (typeDef == typeof(Tuple<,>) && typeInfo.GenericTypeArguments[0] == typeof(bool))
                 {
-                    if (GetOptionType(typeInfo.GenericTypeArguments[1]) == CommandOptionType.SingleValue)
+                    if (GetOptionType(typeInfo.GenericTypeArguments[1], valueParsers) == CommandOptionType.SingleValue)
                     {
                         return CommandOptionType.SingleOrNoValue;
                     }
@@ -70,7 +73,7 @@ namespace McMaster.Extensions.CommandLineUtils
 
                 if (typeDef == typeof(ValueTuple<,>) && typeInfo.GenericTypeArguments[0] == typeof(bool))
                 {
-                    if (GetOptionType(typeInfo.GenericTypeArguments[1]) == CommandOptionType.SingleValue)
+                    if (GetOptionType(typeInfo.GenericTypeArguments[1], valueParsers) == CommandOptionType.SingleValue)
                     {
                         return CommandOptionType.SingleOrNoValue;
                     }
@@ -90,7 +93,12 @@ namespace McMaster.Extensions.CommandLineUtils
                 return CommandOptionType.SingleValue;
             }
 
-            throw new ArgumentException("Could not determine CommandOptionType", nameof(clrType));
+            if (valueParsers?.GetParser(clrType) != null)
+            {
+                return CommandOptionType.SingleValue;
+            }
+
+            throw new ArgumentException("Could not determine CommandOptionType", clrType.Name);
         }
     }
 }

--- a/src/CommandLineUtils/Internal/IValueParser.cs
+++ b/src/CommandLineUtils/Internal/IValueParser.cs
@@ -3,8 +3,25 @@
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    internal interface IValueParser
+    using System;
+
+    /// <summary>
+    /// The interface for defining a value parser.
+    /// </summary>
+    public interface IValueParser
     {
+        /// <summary>
+        /// Gets the Type that this value parser is defined for.
+        /// </summary>
+        Type TargetType { get; }
+
+        /// <summary>
+        /// Parses the raw string value.
+        /// </summary>
+        /// <param name="argName">The name of the argument this value will be bound to.</param>
+        /// <param name="value">The raw string value to parse.</param>
+        /// <returns>The parsed value object.</returns>
+        /// <throws name="System.FormatException">When the value cannot be parsed.</throws>
         object Parse(string argName, string value);
     }
 }

--- a/src/CommandLineUtils/Internal/ReflectionHelper.cs
+++ b/src/CommandLineUtils/Internal/ReflectionHelper.cs
@@ -82,5 +82,13 @@ namespace McMaster.Extensions.CommandLineUtils
 
             return arguments;
         }
+
+        public static bool IsNullableType(TypeInfo typeInfo, out Type wrappedType)
+        {
+            var result = typeInfo.IsGenericType && typeInfo.GetGenericTypeDefinition() == typeof(Nullable<>);
+            wrappedType = result ? typeInfo.GetGenericArguments().First() : null;
+                
+            return result;
+        }
     }
 }

--- a/src/CommandLineUtils/Internal/ValueParserProvider.cs
+++ b/src/CommandLineUtils/Internal/ValueParserProvider.cs
@@ -9,29 +9,33 @@ using McMaster.Extensions.CommandLineUtils.ValueParsers;
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    internal class ValueParserProvider
+    /// <summary>
+    /// A store of value parsers that are used to convert argument values from strings to types.
+    /// </summary>
+    public class ValueParserProvider
     {
-        private Dictionary<Type, IValueParser> _parsers = new Dictionary<Type, IValueParser>
+        private readonly Dictionary<Type, IValueParser> _parsers = new Dictionary<Type, IValueParser>(10);
+
+        internal ValueParserProvider()
         {
-            { typeof(string), StringValueParser.Singleton },
-            { typeof(bool), BooleanValueParser.Singleton },
-            { typeof(byte), ByteValueParser.Singleton },
-            { typeof(short), Int16ValueParser.Singleton },
-            { typeof(int), Int32ValueParser.Singleton },
-            { typeof(long), Int64ValueParser.Singleton },
-            { typeof(ushort), UInt16ValueParser.Singleton },
-            { typeof(uint), UInt32ValueParser.Singleton },
-            { typeof(ulong), UInt64ValueParser.Singleton },
-            { typeof(float), FloatValueParser.Singleton },
-            { typeof(double), DoubleValueParser.Singleton },
-        };
+            this.AddRange(
+                new IValueParser[]
+                {
+                    StringValueParser.Singleton,
+                    BooleanValueParser.Singleton,
+                    ByteValueParser.Singleton,
+                    Int16ValueParser.Singleton,
+                    Int32ValueParser.Singleton,
+                    Int64ValueParser.Singleton,
+                    UInt16ValueParser.Singleton,
+                    UInt32ValueParser.Singleton,
+                    UInt64ValueParser.Singleton,
+                    FloatValueParser.Singleton,
+                    DoubleValueParser.Singleton,
+                });
+        }
 
-        private ValueParserProvider()
-        { }
-
-        public static ValueParserProvider Default { get; } = new ValueParserProvider();
-
-        public IValueParser GetParser(Type type)
+        internal IValueParser GetParser(Type type)
         {
             if (_parsers.TryGetValue(type, out var parser))
             {
@@ -45,10 +49,8 @@ namespace McMaster.Extensions.CommandLineUtils
                 return new EnumParser(type);
             }
 
-            if (typeInfo.IsGenericType && typeInfo.GetGenericTypeDefinition() == typeof(Nullable<>))
+            if (ReflectionHelper.IsNullableType(typeInfo, out var wrappedType))
             {
-                var wrappedType = type.GetTypeInfo().GetGenericArguments().First();
-
                 if (wrappedType.GetTypeInfo().IsEnum)
                 {
                     return new NullableValueParser(new EnumParser(wrappedType));
@@ -61,6 +63,89 @@ namespace McMaster.Extensions.CommandLineUtils
             }
 
             return parser;
+        }
+
+
+        /// <summary>
+        /// Add a new value parser to the provider.
+        /// </summary>
+        /// <param name="parser">An instance of the parser that is used to convert an argument from a string.</param>
+        /// <exception cref="ArgumentException">
+        /// A value parser with the same <see cref="IValueParser.TargetType"/> is already registered.
+        /// </exception>
+        /// <exception cref="ArgumentNullException"><paramref name="parser"/> is null.</exception>
+        public void Add(IValueParser parser)
+        {
+            this.SafeAdd(parser);
+        }
+
+        /// <summary>
+        /// Add collection of a new value parsers to the provider.
+        /// </summary>
+        /// <param name="parsers">The collection whose parsers should be added.</param>
+        /// <exception cref="ArgumentException">
+        /// A value parser with the same <see cref="IValueParser.TargetType"/> is already registered.
+        /// </exception>
+        /// <exception cref="ArgumentNullException"><paramref name="parsers"/> is null.</exception>
+        public void AddRange(IEnumerable<IValueParser> parsers)
+        {
+            if (parsers == null)
+            {
+                throw new ArgumentNullException(nameof(parsers));
+            }
+
+            foreach (var parser in parsers)
+            {
+                this.SafeAdd(parser);
+            }
+        }
+
+        /// <summary>
+        /// Add a new value parser to the provider, or if a value provider already exists for 
+        /// <see cref="IValueParser.TargetType"/> then replaces it with <paramref name="parser"/>.
+        /// </summary>
+        /// <param name="parser">An instance of the parser that is used to convert an argument from a string.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="parser"/> is null.</exception>
+        public void AddOrReplace(IValueParser parser)
+        {
+            this.SafeAdd(parser, andReplace: true);
+        }
+
+        private void SafeAdd(IValueParser parser, bool andReplace = false)
+        {
+            if (parser == null)
+            {
+                throw new ArgumentNullException(nameof(parser));
+            }
+
+            var targetType = parser.TargetType;
+
+            if (targetType == null)
+            {
+                throw new ArgumentNullException(
+                    nameof(IValueParser.TargetType),
+                    "The value parser must have a target type set");
+            }
+
+            // strip nullable wrappers since we have a dedicated nullable value parser
+            targetType = ReflectionHelper.IsNullableType(targetType.GetTypeInfo(), out var wrappedType)
+                ? wrappedType
+                : targetType;
+            
+            if (this._parsers.ContainsKey(targetType))
+            {
+                if (andReplace)
+                {
+                    _parsers.Remove(targetType);
+                }
+                else
+                {
+                    throw new ArgumentException(
+                        $"Value parser provider for type '{targetType}' is already exists.");
+                }
+            }
+
+            this._parsers.Add(targetType, parser);
         }
     }
 }

--- a/src/CommandLineUtils/Internal/ValueParsers/BooleanValueParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/BooleanValueParser.cs
@@ -3,6 +3,8 @@
 
 namespace McMaster.Extensions.CommandLineUtils.ValueParsers
 {
+    using System;
+
     internal class BooleanValueParser : IValueParser
     {
         private BooleanValueParser()
@@ -10,11 +12,13 @@ namespace McMaster.Extensions.CommandLineUtils.ValueParsers
 
         public static BooleanValueParser Singleton { get; } = new BooleanValueParser();
 
+        public Type TargetType { get; } = typeof(bool);
+
         public object Parse(string argName, string value)
         {
             if (!bool.TryParse(value, out var result))
             {
-                throw new CommandParsingException(null, $"Invalid value specified for {argName}. Cannot convert '{value}' to a boolean.");
+                throw new FormatException($"Invalid value specified for {argName}. Cannot convert '{value}' to a boolean.");
             }
             return result;
         }

--- a/src/CommandLineUtils/Internal/ValueParsers/ByteValueParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/ByteValueParser.cs
@@ -3,6 +3,8 @@
 
 namespace McMaster.Extensions.CommandLineUtils.ValueParsers
 {
+    using System;
+
     internal class ByteValueParser : IValueParser
     {
         private ByteValueParser()
@@ -10,11 +12,13 @@ namespace McMaster.Extensions.CommandLineUtils.ValueParsers
 
         public static ByteValueParser Singleton { get; } = new ByteValueParser();
 
+        public Type TargetType { get; } = typeof(byte);
+
         public object Parse(string argName, string value)
         {
             if (!byte.TryParse(value, out var result))
             {
-                throw new CommandParsingException(null, $"Invalid value specified for {argName}. '{value}' is not a valid number.");
+                throw new FormatException($"Invalid value specified for {argName}. '{value}' is not a valid number.");
             }
             return result;
         }

--- a/src/CommandLineUtils/Internal/ValueParsers/DoubleValueParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/DoubleValueParser.cs
@@ -3,6 +3,8 @@
 
 namespace McMaster.Extensions.CommandLineUtils.ValueParsers
 {
+    using System;
+
     internal class DoubleValueParser : IValueParser
     {
         private DoubleValueParser()
@@ -10,11 +12,13 @@ namespace McMaster.Extensions.CommandLineUtils.ValueParsers
 
         public static DoubleValueParser Singleton { get; } = new DoubleValueParser();
 
+        public Type TargetType { get; } = typeof(double);
+
         public object Parse(string argName, string value)
         {
             if (!double.TryParse(value, out var result))
             {
-                throw new CommandParsingException(null, $"Invalid value specified for {argName}. '{value}' is not a valid floating-point number.");
+                throw new FormatException($"Invalid value specified for {argName}. '{value}' is not a valid floating-point number.");
             }
             return result;
         }

--- a/src/CommandLineUtils/Internal/ValueParsers/EnumParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/EnumParser.cs
@@ -14,6 +14,14 @@ namespace McMaster.Extensions.CommandLineUtils.ValueParsers
             _enumType = enumType;
         }
 
+        public Type TargetType
+        {
+            get
+            {
+                throw new InvalidOperationException($"{nameof(NullableValueParser)} does not have a target type");
+            }
+        }
+
         public object Parse(string argName, string value)
         {
             try
@@ -22,7 +30,7 @@ namespace McMaster.Extensions.CommandLineUtils.ValueParsers
             }
             catch
             {
-                throw new CommandParsingException(null, $"Invalid value specified for {argName}. Allowed values are: {string.Join(", ", Enum.GetNames(_enumType))}.");
+                throw new FormatException($"Invalid value specified for {argName}. Allowed values are: {string.Join(", ", Enum.GetNames(_enumType))}.");
             }
         }
     }

--- a/src/CommandLineUtils/Internal/ValueParsers/FloatValueParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/FloatValueParser.cs
@@ -3,6 +3,8 @@
 
 namespace McMaster.Extensions.CommandLineUtils.ValueParsers
 {
+    using System;
+
     internal class FloatValueParser : IValueParser
     {
         private FloatValueParser()
@@ -10,11 +12,13 @@ namespace McMaster.Extensions.CommandLineUtils.ValueParsers
 
         public static FloatValueParser Singleton { get; } = new FloatValueParser();
 
+        public Type TargetType { get; } = typeof(float);
+
         public object Parse(string argName, string value)
         {
             if (!float.TryParse(value, out var result))
             {
-                throw new CommandParsingException(null, $"Invalid value specified for {argName}. '{value}' is not a valid floating-point number.");
+                throw new FormatException($"Invalid value specified for {argName}. '{value}' is not a valid floating-point number.");
             }
             return result;
         }

--- a/src/CommandLineUtils/Internal/ValueParsers/Int16ValueParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/Int16ValueParser.cs
@@ -3,6 +3,8 @@
 
 namespace McMaster.Extensions.CommandLineUtils.ValueParsers
 {
+    using System;
+
     internal class Int16ValueParser : IValueParser
     {
         private Int16ValueParser()
@@ -10,11 +12,13 @@ namespace McMaster.Extensions.CommandLineUtils.ValueParsers
 
         public static Int16ValueParser Singleton { get; } = new Int16ValueParser();
 
+        public Type TargetType { get; } = typeof(short);
+
         public object Parse(string argName, string value)
         {
             if (!short.TryParse(value, out var result))
             {
-                throw new CommandParsingException(null, $"Invalid value specified for {argName}. '{value}' is not a valid number.");
+                throw new FormatException($"Invalid value specified for {argName}. '{value}' is not a valid number.");
             }
 
             return result;

--- a/src/CommandLineUtils/Internal/ValueParsers/Int32ValueParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/Int32ValueParser.cs
@@ -3,6 +3,8 @@
 
 namespace McMaster.Extensions.CommandLineUtils.ValueParsers
 {
+    using System;
+
     internal class Int32ValueParser : IValueParser
     {
         private Int32ValueParser()
@@ -10,11 +12,13 @@ namespace McMaster.Extensions.CommandLineUtils.ValueParsers
 
         public static Int32ValueParser Singleton { get; } = new Int32ValueParser();
 
+        public Type TargetType { get; } = typeof(int);
+
         public object Parse(string argName, string value)
         {
             if (!int.TryParse(value, out var result))
             {
-                throw new CommandParsingException(null, $"Invalid value specified for {argName}. '{value}' is not a valid number.");
+                throw new FormatException($"Invalid value specified for {argName}. '{value}' is not a valid number.");
             }
             return result;
         }

--- a/src/CommandLineUtils/Internal/ValueParsers/Int64ValueParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/Int64ValueParser.cs
@@ -3,6 +3,8 @@
 
 namespace McMaster.Extensions.CommandLineUtils.ValueParsers
 {
+    using System;
+
     internal class Int64ValueParser : IValueParser
     {
         private Int64ValueParser()
@@ -10,11 +12,13 @@ namespace McMaster.Extensions.CommandLineUtils.ValueParsers
 
         public static Int64ValueParser Singleton { get; } = new Int64ValueParser();
 
+        public Type TargetType { get; } = typeof(long);
+
         public object Parse(string argName, string value)
         {
             if (!long.TryParse(value, out var result))
             {
-                throw new CommandParsingException(null, $"Invalid value specified for {argName}. '{value}' is not a valid number.");
+                throw new FormatException($"Invalid value specified for {argName}. '{value}' is not a valid number.");
             }
             return result;
         }

--- a/src/CommandLineUtils/Internal/ValueParsers/NullableValueParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/NullableValueParser.cs
@@ -3,6 +3,8 @@
 
 namespace McMaster.Extensions.CommandLineUtils.ValueParsers
 {
+    using System;
+
     internal class NullableValueParser : IValueParser
     {
         private readonly IValueParser _wrapped;
@@ -11,6 +13,15 @@ namespace McMaster.Extensions.CommandLineUtils.ValueParsers
         {
             _wrapped = boxedParser;
         }
+
+        public Type TargetType
+        {
+            get
+            {
+                throw new InvalidOperationException($"{nameof(NullableValueParser)} does not have a target type");
+            }
+        }
+
 
         public object Parse(string argName, string value)
         {

--- a/src/CommandLineUtils/Internal/ValueParsers/StringValueParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/StringValueParser.cs
@@ -4,12 +4,16 @@
 
 namespace McMaster.Extensions.CommandLineUtils.ValueParsers
 {
+    using System;
+
     internal class StringValueParser : IValueParser
     {
         private StringValueParser()
         { }
 
         public static StringValueParser Singleton { get; } = new StringValueParser();
+
+        public Type TargetType { get; } = typeof(string);
 
         public object Parse(string argName, string value) => value;
     }

--- a/src/CommandLineUtils/Internal/ValueParsers/UInt16ValueParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/UInt16ValueParser.cs
@@ -3,6 +3,8 @@
 
 namespace McMaster.Extensions.CommandLineUtils.ValueParsers
 {
+    using System;
+
     internal class UInt16ValueParser : IValueParser
     {
         private UInt16ValueParser()
@@ -10,11 +12,13 @@ namespace McMaster.Extensions.CommandLineUtils.ValueParsers
 
         public static UInt16ValueParser Singleton { get; } = new UInt16ValueParser();
 
+        public Type TargetType { get; } = typeof(ushort);
+
         public object Parse(string argName, string value)
         {
             if (!ushort.TryParse(value, out var result))
             {
-                throw new CommandParsingException(null, $"Invalid value specified for {argName}. '{value}' is not a valid, non-negative number.");
+                throw new FormatException($"Invalid value specified for {argName}. '{value}' is not a valid, non-negative number.");
             }
             return result;
         }

--- a/src/CommandLineUtils/Internal/ValueParsers/UInt32ValueParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/UInt32ValueParser.cs
@@ -3,6 +3,8 @@
 
 namespace McMaster.Extensions.CommandLineUtils.ValueParsers
 {
+    using System;
+
     internal class UInt32ValueParser : IValueParser
     {
         private UInt32ValueParser()
@@ -10,11 +12,13 @@ namespace McMaster.Extensions.CommandLineUtils.ValueParsers
 
         public static UInt32ValueParser Singleton { get; } = new UInt32ValueParser();
 
+        public Type TargetType { get; } = typeof(uint);
+
         public object Parse(string argName, string value)
         {
             if (!uint.TryParse(value, out var result))
             {
-                throw new CommandParsingException(null, $"Invalid value specified for {argName}. '{value}' is not a valid, non-negative number.");
+                throw new FormatException($"Invalid value specified for {argName}. '{value}' is not a valid, non-negative number.");
             }
             return result;
         }

--- a/src/CommandLineUtils/Internal/ValueParsers/UInt64ValueParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/UInt64ValueParser.cs
@@ -3,6 +3,8 @@
 
 namespace McMaster.Extensions.CommandLineUtils.ValueParsers
 {
+    using System;
+
     internal class UInt64ValueParser : IValueParser
     {
         private UInt64ValueParser()
@@ -10,11 +12,13 @@ namespace McMaster.Extensions.CommandLineUtils.ValueParsers
 
         public static UInt64ValueParser Singleton { get; } = new UInt64ValueParser();
 
+        public Type TargetType { get; } = typeof(ulong);
+
         public object Parse(string argName, string value)
         {
             if (!ulong.TryParse(value, out var result))
             {
-                throw new CommandParsingException(null, $"Invalid value specified for {argName}. '{value}' is not a valid, non-negative number.");
+                throw new FormatException($"Invalid value specified for {argName}. '{value}' is not a valid, non-negative number.");
             }
             return result;
         }

--- a/src/CommandLineUtils/Internal/ValueTupleParserProvider.cs
+++ b/src/CommandLineUtils/Internal/ValueTupleParserProvider.cs
@@ -12,7 +12,7 @@ namespace McMaster.Extensions.CommandLineUtils
         private ValueTupleParserProvider() { }
         public static ValueTupleParserProvider Default { get; } = new ValueTupleParserProvider();
 
-        public ITupleValueParser GetParser(Type type)
+        public ITupleValueParser GetParser(Type type, ValueParserProvider valueParsers)
         {
             var typeInfo = type.GetTypeInfo();
             if (!typeInfo.IsGenericType)
@@ -22,7 +22,7 @@ namespace McMaster.Extensions.CommandLineUtils
             var typeDef = typeInfo.GetGenericTypeDefinition();
             if (typeDef == typeof(Tuple<,>) && typeInfo.GenericTypeArguments[0] == typeof(bool))
             {
-                var innerParser = ValueParserProvider.Default.GetParser(typeInfo.GenericTypeArguments[1]);
+                var innerParser = valueParsers.GetParser(typeInfo.GenericTypeArguments[1]);
                 if (innerParser == null)
                 {
                     return null;
@@ -33,7 +33,7 @@ namespace McMaster.Extensions.CommandLineUtils
 
             if (typeDef == typeof(ValueTuple<,>) && typeInfo.GenericTypeArguments[0] == typeof(bool))
             {
-                var innerParser = ValueParserProvider.Default.GetParser(typeInfo.GenericTypeArguments[1]);
+                var innerParser = valueParsers.GetParser(typeInfo.GenericTypeArguments[1]);
                 if (innerParser == null)
                 {
                     return null;

--- a/test/CommandLineUtils.Tests/ValueParserProviderCustomTests.cs
+++ b/test/CommandLineUtils.Tests/ValueParserProviderCustomTests.cs
@@ -1,0 +1,246 @@
+// Copyright (c) Nate McMaster.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Collections.Generic;
+using Xunit;
+
+namespace McMaster.Extensions.CommandLineUtils.Tests
+{
+    public class ValueParserProviderCustomTests
+    {
+
+        private class MyDateTimeOffsetParser : IValueParser
+        {
+            public Type TargetType { get; } = typeof(DateTimeOffset);
+
+            public object Parse(string argName, string value)
+            {
+                if (!DateTimeOffset.TryParse(value, out var result))
+                {
+                    throw new FormatException($"Invalid value specified for {argName}. '{value}' is not a valid date time (with offset)");
+                }
+
+                return result;
+            }
+        }
+
+        // scenario: specialized domain value in the format of 1=123.456=abc
+        private class ComplexTupleParser : IValueParser
+        {
+            public Type TargetType { get; } = typeof(ValueTuple<int, double, string>?);
+
+            public object Parse(string argName, string value)
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    return default(ValueTuple<int, double, string>?);
+                }
+
+                var fragments = value.Split('=');
+
+                try
+                {
+                    var item1 = double.Parse(fragments[0]);
+                    var item2 = double.Parse(fragments[1]);
+                    var item3 = fragments[2];
+                    return (ValueTuple<int, double, string>?)(item1, item2, item3);
+                }
+                catch(Exception ex) 
+                {
+                    throw new FormatException(
+                        $"Invalid value specified for {argName}. '{value} is not a valid time span (with offset)",
+                        ex);
+                }
+            }
+        }
+
+        // scenario: for some reason I insist on using thin spaces instead of commas for the thousands delimitters
+        private class MyDoubleParser : IValueParser
+        {
+            // This is a trivial example but rooted in a real standard
+            // https://en.wikipedia.org/wiki/ISO_31-0#Numbers
+            private readonly NumberFormatInfo _iso80000NumberFormatInfo;
+
+            public MyDoubleParser()
+            {
+                this._iso80000NumberFormatInfo = (NumberFormatInfo)CultureInfo.InvariantCulture.NumberFormat.Clone();
+
+                // a thin space
+                this._iso80000NumberFormatInfo.NumberGroupSeparator = "\u2009";
+            }
+
+            public Type TargetType { get; } = typeof(double);
+
+            public object Parse(string argName, string value)
+            {
+                if (!double.TryParse(value, NumberStyles.Number, _iso80000NumberFormatInfo, out var result))
+                {
+                    throw new FormatException($"Invalid value specified for {argName}. '{value}' is not a valid ISO80000 double");
+                }
+
+                return result;
+            }
+        }
+
+        private class CustomParserProgram
+        {
+            [Argument(0)]
+            public DateTimeOffset DateTimeOffset { get; }
+
+            [Argument(1)]
+            public double Double { get; }
+
+            [Argument(2)]
+            public ValueTuple<int, double, string>? ComplexValue { get; }
+        }
+
+        [Fact]
+        public void CustomParsersCanBeAdded()
+        {
+            var expectedDate = new DateTimeOffset(2018, 02, 16, 21, 30, 33, 45, TimeSpan.FromHours(10));
+            var expectedDouble = 123456.789;
+            ValueTuple<int, double, string>? expectedComplexValue = null;
+
+            var app = new CommandLineApplication<CustomParserProgram>();
+
+            app.ValueParsers.AddRange(new IValueParser[] { new MyDateTimeOffsetParser(), new ComplexTupleParser() });
+            app.ValueParsers.AddOrReplace(new MyDoubleParser());
+
+            app.Conventions.UseAttributes();
+
+            // We're omitting the third argument to test nullable-ness. The ComplexValue type (with a value) is tested
+            // in the next test
+            var args = new[] { expectedDate.ToString("O"), "123 456.789" };
+            app.Parse(args);
+            var model = app.Model;
+
+            Assert.Equal(expectedDate, model.DateTimeOffset);
+            Assert.Equal(expectedDouble, model.Double);
+            Assert.Equal(expectedComplexValue, model.ComplexValue);
+        }
+
+        private class CustomParserProgramOptions
+        {
+            [Option]
+            public ValueTuple<int, double, string>? ComplexValue { get; }
+        }
+
+        [Fact]
+        public void CustomParsersSupportComplexGenericTypes()
+        {
+            ValueTuple<int, double, string>? expectedComplexValue = (1, 123.456, "abc");
+
+            var app = new CommandLineApplication<CustomParserProgramOptions>();
+
+            app.ValueParsers.Add(new ComplexTupleParser());
+
+            app.Conventions.UseAttributes();
+
+            var args = $"-c=1=123.456=abc";
+            app.Parse(args);
+            var model = app.Model;
+
+            Assert.Equal(expectedComplexValue, model.ComplexValue);
+        }
+
+        [Fact]
+        public void CustomParsersAreAutomaticallySingleValues()
+        {
+            var app = new CommandLineApplication<CustomParserProgram>();
+
+            app.ValueParsers.AddRange(new IValueParser[] { new MyDateTimeOffsetParser(), new ComplexTupleParser() });
+            app.ValueParsers.AddOrReplace(new MyDoubleParser());
+
+            var optionMapper = CommandOptionTypeMapper.Default;
+            Assert.Equal(
+                CommandOptionType.SingleValue,
+                optionMapper.GetOptionType(typeof(DateTimeOffset), app.ValueParsers));
+            Assert.Equal(
+                CommandOptionType.SingleValue,
+                optionMapper.GetOptionType(typeof(ValueTuple<int, double, string>?), app.ValueParsers));
+            Assert.Equal(
+                CommandOptionType.SingleValue,
+                optionMapper.GetOptionType(typeof(double), app.ValueParsers));
+        }
+
+        private class BadValueParser : IValueParser
+        {
+            public Type TargetType { get; } = null;
+
+            public object Parse(string argName, string value)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        [Fact]
+        public void ThrowsIfNoType()
+        {
+            var ex = Assert.Throws<ArgumentNullException>(
+                () =>
+                {
+                    var app = new CommandLineApplication<CustomParserProgram>();
+                    app.ValueParsers.Add(new BadValueParser());
+                });
+
+            Assert.Contains("TargetType", ex.Message);
+        }
+
+        [Fact]
+        public void ThrowsIfAlreadyRegistered()
+        {
+            var ex = Assert.Throws<ArgumentException>(
+                () =>
+                {
+                    var app = new CommandLineApplication<CustomParserProgram>();
+                    app.ValueParsers.Add(new ComplexTupleParser());
+                    app.ValueParsers.Add(new ComplexTupleParser());
+                });
+
+            Assert.Contains(
+                "Value parser provider for type 'System.ValueTuple`3[System.Int32,System.Double,System.String]' is already registered.",
+                ex.Message);
+        }
+
+        [Fact]
+        public void AddThrowsIfNullParser()
+        {
+            var ex = Assert.Throws<ArgumentNullException>(
+                () =>
+                {
+                    var app = new CommandLineApplication<CustomParserProgram>();
+                    app.ValueParsers.Add(null);
+                });
+
+            Assert.Contains("parser", ex.Message);
+        }
+
+        [Fact]
+        public void AddRangeThrowsIfNullCollection()
+        {
+            var ex = Assert.Throws<ArgumentNullException>(
+                () =>
+                {
+                    var app = new CommandLineApplication<CustomParserProgram>();
+                    app.ValueParsers.AddRange(null);
+                });
+
+            Assert.Contains("parsers", ex.Message);
+        }
+
+        [Fact]
+        public void AddOrReplaceThrowsIfNullparser()
+        {
+            var ex = Assert.Throws<ArgumentNullException>(
+                () =>
+                {
+                    var app = new CommandLineApplication<CustomParserProgram>();
+                    app.ValueParsers.AddOrReplace(null);
+                });
+
+            Assert.Contains("parser", ex.Message);
+        }
+    }
+}


### PR DESCRIPTION
Closes #51.

This commit allows users to supply their own value parsers via the `ValueParsers` property on `CommandLineApplication`. The bulk of the changed files are small changes like converting all the current value parser implementations to the updated interface.

One side-effect of this change is that `ValueParserProvider` is no longer a singleton, but instead has state for the duration of the `CommandLineApplication`.

# Questions:

- This change I feel ties nicely in with #37, should we expand scope?
  - Because of this, I exposed the `ValueParsers` property on `CommandLineApplication` and not `CommandLineApplication<T>`
- `ValueParserProvider` and `IValueParser` are no longer internal utilities - should I move the files out of the internal folder?
- Should we simplify the `ValueTupleParserProvider` code? It is just a (non-)special case of an ordinary value parser
- I was forced to change the `ValueParseProvider` to a non-singleton (parallelism in tests affected singleton state). I don't like passing the ValueParserProvider around as arguments everywhere but I thought it better than managing god states.

# Assumptions:

- I assumed it would be best to update the existing value parser providers so all value parsers (predefined and user-defined) use the same interface

# Other notes:

- although tedious, leaving the exception inside the `Parse` method allows users to customize the error string, useful for example to allow internationalization of error messages
- I added an additional public API `AddRange` to `ValueParserProvider`. I know this wasn't agreed on so I don't mind removing it.