### PR TITLE
Allows the setting of a default culture for parsing

### DIFF
--- a/src/CommandLineUtils/Abstractions/IValueParser.cs
+++ b/src/CommandLineUtils/Abstractions/IValueParser.cs
@@ -4,6 +4,7 @@
 namespace McMaster.Extensions.CommandLineUtils.Abstractions
 {
     using System;
+    using System.Globalization;
 
     /// <summary>
     /// The interface for defining a value parser.
@@ -20,8 +21,9 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
         /// </summary>
         /// <param name="argName">The name of the argument this value will be bound to.</param>
         /// <param name="value">The raw string value to parse.</param>
+        /// <param name="culture">The culture that should be used to parse values.</param>
         /// <returns>The parsed value object.</returns>
         /// <throws name="System.FormatException">When the value cannot be parsed.</throws>
-        object Parse(string argName, string value);
+        object Parse(string argName, string value, CultureInfo culture);
     }
 }

--- a/src/CommandLineUtils/Abstractions/ValueParserProvider.cs
+++ b/src/CommandLineUtils/Abstractions/ValueParserProvider.cs
@@ -5,6 +5,7 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Reflection;
 
     /// <summary>
@@ -32,6 +33,14 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
                     DoubleValueParser.Singleton,
                 });
         }
+
+        /// <summary>
+        /// Gets or sets the CultureInfo which is used to convert argument values to types.
+        /// </summary>
+        /// <remarks>
+        /// The default value is <see cref="CultureInfo.CurrentCulture"/>.
+        /// </remarks>
+        public CultureInfo ParseCulture { get; set; } = CultureInfo.CurrentCulture;
 
         internal IValueParser GetParser(Type type)
         {

--- a/src/CommandLineUtils/Conventions/ArgumentAttributeConvention.cs
+++ b/src/CommandLineUtils/Conventions/ArgumentAttributeConvention.cs
@@ -127,7 +127,12 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                 {
                     if (r.SelectedCommand is IModelAccessor cmd)
                     {
-                        setter.Invoke(cmd.GetModel(), parser.Parse(argument.Name, argument.Value));
+                        setter.Invoke(
+                            cmd.GetModel(),
+                            parser.Parse(
+                                argument.Name,
+                                argument.Value,
+                                convention.Application.ValueParsers.ParseCulture));
                     }
                 });
             }

--- a/src/CommandLineUtils/Conventions/OptionAttributeConventionBase.cs
+++ b/src/CommandLineUtils/Conventions/OptionAttributeConventionBase.cs
@@ -68,7 +68,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                         throw new InvalidOperationException(Strings.CannotDetermineParserType(prop));
                     }
                     context.Application.OnParsingComplete(_ =>
-                        setter.Invoke(context.ModelAccessor.GetModel(), valueTupleParser.Parse(option.HasValue(), option.LongName, option.Value())));
+                        setter.Invoke(context.ModelAccessor.GetModel(), valueTupleParser.Parse(option.HasValue(), option.LongName, option.Value(), context.Application.ValueParsers.ParseCulture)));
                     break;
                 case CommandOptionType.SingleValue:
                     var parser = context.Application.ValueParsers.GetParser(prop.PropertyType);
@@ -83,7 +83,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                         {
                             return;
                         }
-                        setter.Invoke(context.ModelAccessor.GetModel(), parser.Parse(option.LongName, value));
+                        setter.Invoke(context.ModelAccessor.GetModel(), parser.Parse(option.LongName, value, context.Application.ValueParsers.ParseCulture));
                     });
                     break;
                 case CommandOptionType.NoValue:

--- a/src/CommandLineUtils/Internal/CollectionParserProvider.cs
+++ b/src/CommandLineUtils/Internal/CollectionParserProvider.cs
@@ -27,7 +27,7 @@ namespace McMaster.Extensions.CommandLineUtils
                     return null;
                 }
 
-                return new ArrayParser(elementType, elementParser);
+                return new ArrayParser(elementType, elementParser, valueParsers.ParseCulture);
             }
 
             var typeInfo = type.GetTypeInfo();
@@ -44,13 +44,13 @@ namespace McMaster.Extensions.CommandLineUtils
                     || typeof(IReadOnlyList<>) == typeDef
                     || typeof(List<>) == typeDef)
                 {
-                    return new ListParser(elementType, elementParser);
+                    return new ListParser(elementType, elementParser, valueParsers.ParseCulture);
                 }
 
                 if (typeof(ISet<>) == typeDef
                   || typeof(HashSet<>) == typeDef)
                 {
-                    return new HashSetParser(elementType, elementParser);
+                    return new HashSetParser(elementType, elementParser, valueParsers.ParseCulture);
                 }
             }
 

--- a/src/CommandLineUtils/Internal/ITupleValueParser.cs
+++ b/src/CommandLineUtils/Internal/ITupleValueParser.cs
@@ -3,11 +3,13 @@
 
 namespace McMaster.Extensions.CommandLineUtils
 {
+    using System.Globalization;
+
     /// <summary>
     /// Parses a value to Tuple{bool,} or ValueTuple{bool,}
     /// </summary>
     internal interface ITupleValueParser
     {
-        object Parse(bool hasValue, string argName, string value);
+        object Parse(bool hasValue, string argName, string value, CultureInfo culture);
     }
 }

--- a/src/CommandLineUtils/Internal/ValueParsers/ArrayParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/ArrayParser.cs
@@ -6,15 +6,19 @@ using System.Collections.Generic;
 
 namespace McMaster.Extensions.CommandLineUtils.Abstractions
 {
+    using System.Globalization;
+
     internal class ArrayParser : ICollectionParser
     {
         private readonly Type _elementType;
         private readonly IValueParser _elementParser;
+        private readonly CultureInfo _parserCulture;
 
-        public ArrayParser(Type elementType, IValueParser elementParser)
+        public ArrayParser(Type elementType, IValueParser elementParser, CultureInfo parserCulture)
         {
             _elementType = elementType;
             _elementParser = elementParser;
+            _parserCulture = parserCulture;
         }
 
         public object Parse(string argName, IReadOnlyList<string> values)
@@ -22,7 +26,7 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
             var array = Array.CreateInstance(_elementType, values.Count);
             for (var i = 0; i < values.Count; i++)
             {
-                array.SetValue(_elementParser.Parse(argName, values[i]), i);
+                array.SetValue(_elementParser.Parse(argName, values[i], _parserCulture), i);
             }
             return array;
         }

--- a/src/CommandLineUtils/Internal/ValueParsers/BooleanValueParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/BooleanValueParser.cs
@@ -4,6 +4,7 @@
 namespace McMaster.Extensions.CommandLineUtils.Abstractions
 {
     using System;
+    using System.Globalization;
 
     internal class BooleanValueParser : IValueParser
     {
@@ -14,7 +15,7 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
 
         public Type TargetType { get; } = typeof(bool);
 
-        public object Parse(string argName, string value)
+        public object Parse(string argName, string value, CultureInfo culture)
         {
             if (!bool.TryParse(value, out var result))
             {

--- a/src/CommandLineUtils/Internal/ValueParsers/ByteValueParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/ByteValueParser.cs
@@ -4,6 +4,7 @@
 namespace McMaster.Extensions.CommandLineUtils.Abstractions
 {
     using System;
+    using System.Globalization;
 
     internal class ByteValueParser : IValueParser
     {
@@ -14,12 +15,13 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
 
         public Type TargetType { get; } = typeof(byte);
 
-        public object Parse(string argName, string value)
+        public object Parse(string argName, string value, CultureInfo culture)
         {
-            if (!byte.TryParse(value, out var result))
+            if (!byte.TryParse(value, NumberStyles.Integer, culture.NumberFormat, out var result))
             {
                 throw new FormatException($"Invalid value specified for {argName}. '{value}' is not a valid number.");
             }
+
             return result;
         }
     }

--- a/src/CommandLineUtils/Internal/ValueParsers/DoubleValueParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/DoubleValueParser.cs
@@ -4,6 +4,7 @@
 namespace McMaster.Extensions.CommandLineUtils.Abstractions
 {
     using System;
+    using System.Globalization;
 
     internal class DoubleValueParser : IValueParser
     {
@@ -14,12 +15,13 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
 
         public Type TargetType { get; } = typeof(double);
 
-        public object Parse(string argName, string value)
+        public object Parse(string argName, string value, CultureInfo culture)
         {
-            if (!double.TryParse(value, out var result))
+            if (!double.TryParse(value, NumberStyles.Float | NumberStyles.AllowThousands, culture.NumberFormat, out var result))
             {
                 throw new FormatException($"Invalid value specified for {argName}. '{value}' is not a valid floating-point number.");
             }
+
             return result;
         }
     }

--- a/src/CommandLineUtils/Internal/ValueParsers/EnumParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/EnumParser.cs
@@ -5,6 +5,8 @@ using System;
 
 namespace McMaster.Extensions.CommandLineUtils.Abstractions
 {
+    using System.Globalization;
+
     internal class EnumParser : IValueParser
     {
         private readonly Type _enumType;
@@ -23,7 +25,7 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
             }
         }
 
-        public object Parse(string argName, string value)
+        public object Parse(string argName, string value, CultureInfo culture)
         {
             try
             {

--- a/src/CommandLineUtils/Internal/ValueParsers/FloatValueParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/FloatValueParser.cs
@@ -4,6 +4,7 @@
 namespace McMaster.Extensions.CommandLineUtils.Abstractions
 {
     using System;
+    using System.Globalization;
 
     internal class FloatValueParser : IValueParser
     {
@@ -14,12 +15,13 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
 
         public Type TargetType { get; } = typeof(float);
 
-        public object Parse(string argName, string value)
+        public object Parse(string argName, string value, CultureInfo culture)
         {
-            if (!float.TryParse(value, out var result))
+            if (!float.TryParse(value, NumberStyles.Float | NumberStyles.AllowThousands, culture.NumberFormat, out var result))
             {
                 throw new FormatException($"Invalid value specified for {argName}. '{value}' is not a valid floating-point number.");
             }
+
             return result;
         }
     }

--- a/src/CommandLineUtils/Internal/ValueParsers/HashSetParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/HashSetParser.cs
@@ -7,17 +7,21 @@ using System.Reflection;
 
 namespace McMaster.Extensions.CommandLineUtils.Abstractions
 {
+    using System.Globalization;
+
     internal class HashSetParser : ICollectionParser
     {
         private readonly IValueParser _elementParser;
         private readonly Type _listType;
         private readonly MethodInfo _addMethod;
+        private readonly CultureInfo _parserCulture;
 
-        public HashSetParser(Type elementType, IValueParser elementParser)
+        public HashSetParser(Type elementType, IValueParser elementParser, CultureInfo parserCulture)
         {
             _elementParser = elementParser;
             _listType = typeof(HashSet<>).MakeGenericType(elementType);
             _addMethod = _listType.GetRuntimeMethod("Add", new[] { elementType });
+            _parserCulture = parserCulture;
         }
 
         public object Parse(string argName, IReadOnlyList<string> values)
@@ -25,7 +29,7 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
             var set = Activator.CreateInstance(_listType, Constants.EmptyArray);
             for (var i = 0; i < values.Count; i++)
             {
-                _addMethod.Invoke(set, new object[] { _elementParser.Parse(argName, values[i]) });
+                _addMethod.Invoke(set, new object[] { _elementParser.Parse(argName, values[i], _parserCulture) });
             }
             return set;
         }

--- a/src/CommandLineUtils/Internal/ValueParsers/Int16ValueParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/Int16ValueParser.cs
@@ -4,6 +4,7 @@
 namespace McMaster.Extensions.CommandLineUtils.Abstractions
 {
     using System;
+    using System.Globalization;
 
     internal class Int16ValueParser : IValueParser
     {
@@ -14,9 +15,9 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
 
         public Type TargetType { get; } = typeof(short);
 
-        public object Parse(string argName, string value)
+        public object Parse(string argName, string value, CultureInfo culture)
         {
-            if (!short.TryParse(value, out var result))
+            if (!short.TryParse(value, NumberStyles.Integer, culture, out var result))
             {
                 throw new FormatException($"Invalid value specified for {argName}. '{value}' is not a valid number.");
             }

--- a/src/CommandLineUtils/Internal/ValueParsers/Int32ValueParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/Int32ValueParser.cs
@@ -4,6 +4,7 @@
 namespace McMaster.Extensions.CommandLineUtils.Abstractions
 {
     using System;
+    using System.Globalization;
 
     internal class Int32ValueParser : IValueParser
     {
@@ -14,12 +15,13 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
 
         public Type TargetType { get; } = typeof(int);
 
-        public object Parse(string argName, string value)
+        public object Parse(string argName, string value, CultureInfo culture)
         {
-            if (!int.TryParse(value, out var result))
+            if (!int.TryParse(value, NumberStyles.Integer, culture.NumberFormat, out var result))
             {
                 throw new FormatException($"Invalid value specified for {argName}. '{value}' is not a valid number.");
             }
+
             return result;
         }
     }

--- a/src/CommandLineUtils/Internal/ValueParsers/Int64ValueParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/Int64ValueParser.cs
@@ -4,6 +4,7 @@
 namespace McMaster.Extensions.CommandLineUtils.Abstractions
 {
     using System;
+    using System.Globalization;
 
     internal class Int64ValueParser : IValueParser
     {
@@ -14,12 +15,13 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
 
         public Type TargetType { get; } = typeof(long);
 
-        public object Parse(string argName, string value)
+        public object Parse(string argName, string value, CultureInfo culture)
         {
-            if (!long.TryParse(value, out var result))
+            if (!long.TryParse(value, NumberStyles.Integer, culture.NumberFormat, out var result))
             {
                 throw new FormatException($"Invalid value specified for {argName}. '{value}' is not a valid number.");
             }
+
             return result;
         }
     }

--- a/src/CommandLineUtils/Internal/ValueParsers/ListParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/ListParser.cs
@@ -7,15 +7,19 @@ using System.Collections.Generic;
 
 namespace McMaster.Extensions.CommandLineUtils.Abstractions
 {
+    using System.Globalization;
+
     internal class ListParser : ICollectionParser
     {
         private readonly IValueParser _elementParser;
         private readonly Type _listType;
+        private readonly CultureInfo _parserCulture;
 
-        public ListParser(Type elementType, IValueParser elementParser)
+        public ListParser(Type elementType, IValueParser elementParser, CultureInfo parserCulture)
         {
             _elementParser = elementParser;
             _listType = typeof(List<>).MakeGenericType(elementType);
+            _parserCulture = parserCulture;
         }
 
         public object Parse(string argName, IReadOnlyList<string> values)
@@ -23,7 +27,7 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
             var list = (IList)Activator.CreateInstance(_listType, new object[] { values.Count });
             for (var i = 0; i < values.Count; i++)
             {
-                list.Add(_elementParser.Parse(argName, values[i]));
+                list.Add(_elementParser.Parse(argName, values[i], _parserCulture));
             }
             return list;
         }

--- a/src/CommandLineUtils/Internal/ValueParsers/NullableValueParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/NullableValueParser.cs
@@ -4,6 +4,7 @@
 namespace McMaster.Extensions.CommandLineUtils.Abstractions
 {
     using System;
+    using System.Globalization;
 
     internal class NullableValueParser : IValueParser
     {
@@ -23,14 +24,14 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
         }
 
 
-        public object Parse(string argName, string value)
+        public object Parse(string argName, string value, CultureInfo culture)
         {
             if (string.IsNullOrWhiteSpace(value))
             {
                 return null;
             }
 
-            return _wrapped.Parse(argName, value);
+            return _wrapped.Parse(argName, value, culture);
         }
     }
 }

--- a/src/CommandLineUtils/Internal/ValueParsers/StringValueParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/StringValueParser.cs
@@ -5,6 +5,7 @@
 namespace McMaster.Extensions.CommandLineUtils.Abstractions
 {
     using System;
+    using System.Globalization;
 
     internal class StringValueParser : IValueParser
     {
@@ -15,6 +16,6 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
 
         public Type TargetType { get; } = typeof(string);
 
-        public object Parse(string argName, string value) => value;
+        public object Parse(string argName, string value, CultureInfo culture) => value;
     }
 }

--- a/src/CommandLineUtils/Internal/ValueParsers/TupleValueParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/TupleValueParser.cs
@@ -5,6 +5,8 @@ using System;
 
 namespace McMaster.Extensions.CommandLineUtils.Abstractions
 {
+    using System.Globalization;
+
     internal class TupleValueParser<T> : ITupleValueParser
     {
         private readonly IValueParser _typeParser;
@@ -14,7 +16,7 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
             _typeParser = typeParser;
         }
 
-        public object Parse(bool hasValue, string argName, string value)
+        public object Parse(bool hasValue, string argName, string value, CultureInfo culture)
         {
             if (!hasValue)
             {
@@ -26,7 +28,7 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
                 return Tuple.Create<bool, T>(true, default);
             }
 
-            return Tuple.Create(true, (T)_typeParser.Parse(argName, value));
+            return Tuple.Create(true, (T)_typeParser.Parse(argName, value, culture));
         }
     }
 }

--- a/src/CommandLineUtils/Internal/ValueParsers/UInt16ValueParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/UInt16ValueParser.cs
@@ -4,6 +4,7 @@
 namespace McMaster.Extensions.CommandLineUtils.Abstractions
 {
     using System;
+    using System.Globalization;
 
     internal class UInt16ValueParser : IValueParser
     {
@@ -14,9 +15,9 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
 
         public Type TargetType { get; } = typeof(ushort);
 
-        public object Parse(string argName, string value)
+        public object Parse(string argName, string value, CultureInfo culture)
         {
-            if (!ushort.TryParse(value, out var result))
+            if (!ushort.TryParse(value, NumberStyles.Integer, culture, out var result))
             {
                 throw new FormatException($"Invalid value specified for {argName}. '{value}' is not a valid, non-negative number.");
             }

--- a/src/CommandLineUtils/Internal/ValueParsers/UInt32ValueParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/UInt32ValueParser.cs
@@ -4,6 +4,7 @@
 namespace McMaster.Extensions.CommandLineUtils.Abstractions
 {
     using System;
+    using System.Globalization;
 
     internal class UInt32ValueParser : IValueParser
     {
@@ -14,9 +15,9 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
 
         public Type TargetType { get; } = typeof(uint);
 
-        public object Parse(string argName, string value)
+        public object Parse(string argName, string value, CultureInfo culture)
         {
-            if (!uint.TryParse(value, out var result))
+            if (!uint.TryParse(value, NumberStyles.Integer, culture, out var result))
             {
                 throw new FormatException($"Invalid value specified for {argName}. '{value}' is not a valid, non-negative number.");
             }

--- a/src/CommandLineUtils/Internal/ValueParsers/UInt64ValueParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/UInt64ValueParser.cs
@@ -4,6 +4,7 @@
 namespace McMaster.Extensions.CommandLineUtils.Abstractions
 {
     using System;
+    using System.Globalization;
 
     internal class UInt64ValueParser : IValueParser
     {
@@ -14,9 +15,9 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
 
         public Type TargetType { get; } = typeof(ulong);
 
-        public object Parse(string argName, string value)
+        public object Parse(string argName, string value, CultureInfo culture)
         {
-            if (!ulong.TryParse(value, out var result))
+            if (!ulong.TryParse(value, NumberStyles.Integer, culture, out var result))
             {
                 throw new FormatException($"Invalid value specified for {argName}. '{value}' is not a valid, non-negative number.");
             }

--- a/src/CommandLineUtils/Internal/ValueParsers/ValueTupleValueParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/ValueTupleValueParser.cs
@@ -4,6 +4,8 @@
 
 namespace McMaster.Extensions.CommandLineUtils.Abstractions
 {
+    using System.Globalization;
+
     internal class ValueTupleValueParser<T> : ITupleValueParser
     {
         private readonly IValueParser _typeParser;
@@ -13,7 +15,7 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
             _typeParser = typeParser;
         }
 
-        public object Parse(bool hasValue, string argName, string value)
+        public object Parse(bool hasValue, string argName, string value, CultureInfo culture)
         {
             if (!hasValue)
             {
@@ -25,7 +27,7 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
                 return (true, default(T));
             }
 
-            return (true, (T)_typeParser.Parse(argName, value));
+            return (true, (T)_typeParser.Parse(argName, value, culture));
         }
     }
 }

--- a/test/CommandLineUtils.Tests/ValueParserProviderTests.cs
+++ b/test/CommandLineUtils.Tests/ValueParserProviderTests.cs
@@ -8,6 +8,8 @@ using Xunit;
 
 namespace McMaster.Extensions.CommandLineUtils.Tests
 {
+    using System.Linq;
+
     public class ValueParserProviderTests
     {
         public enum Color
@@ -397,6 +399,21 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             var parsed = CommandLineParser.ParseArgs<Program>("--color-opt", color.ToString().ToLowerInvariant());
             Assert.True(parsed.ColorOpt.HasValue, "Option should have value");
             Assert.Equal(color, parsed.ColorOpt);
+        }
+
+        [Theory]
+        [InlineData(nameof(Program.Float), "--float", "123.456,7", "de-DE", 123456.7f)]
+        [InlineData(nameof(Program.Double), "--double", "123.456,789", "de-DE", 123456.789)]
+        public void DefaultCultureCanBeChanged(string property, string option, string test, string culture, object expected)
+        {
+            var cultureInfo = new CultureInfo(culture);
+            var app = new CommandLineApplication<Program>();
+            app.ValueParsers.ParseCulture = cultureInfo;
+            app.Conventions.UseAttributes();
+            app.Parse(option, test);
+
+            var actual = typeof(Program).GetProperty(property).GetMethod.Invoke(app.Model, null);
+            Assert.Equal(expected, actual);
         }
 
         private class ArgumentProgram


### PR DESCRIPTION
This change allows the default culture used to parse values to be changed for the whole command line application.

The default culture is still `CurrentCulture`.

Note: the `TryParse` methods for number types require a `NumberStyles` argument. The values I added mirror the defaults found on referencesource.microsoft.com.

Closes #60