### PR TITLE
ValueParsers are now inherited in subcommands

### DIFF
--- a/src/CommandLineUtils/CommandLineApplication.cs
+++ b/src/CommandLineUtils/CommandLineApplication.cs
@@ -93,7 +93,7 @@ namespace McMaster.Extensions.CommandLineUtils
             ValidationErrorHandler = DefaultValidationErrorHandler;
             SetContext(context);
             _services = new Lazy<IServiceProvider>(() => new ServiceProvider(this));
-            ValueParsers = new ValueParserProvider();
+            ValueParsers = parent?.ValueParsers ?? new ValueParserProvider();
 
             _conventionContext = CreateConventionContext();
 


### PR DESCRIPTION
Before this commit, subcommands did not inherit the value parsers. This is frustrating because we would need to add custom value parsers for every subcommand. In the general case, it is optimal that one set of value parsers are used for all argument parsing in the application.