### PR TITLE
Custom app initializer

### DIFF
--- a/samples/Conventions/CustomDemo.cs
+++ b/samples/Conventions/CustomDemo.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Threading.Tasks;
+using McMaster.Extensions.CommandLineUtils;
+using McMaster.Extensions.CommandLineUtils.Conventions;
+
+/// <summary>
+/// A custom class for demonstration / learning with debug purposes.
+/// It acts as a model and has sub-commands specified both ways (through API and through attributes).
+/// </summary>
+[Subcommand("nestedCmd", typeof(NestedAttrbutedCommand))]
+public class CustomDemo
+{
+
+    public CustomDemo()
+    {
+    }
+
+    public static int Main(string[] args)
+    {
+        //var app = new CommandLineApplication();
+        var app = new CommandLineApplication<CustomDemo>();
+        app.HelpOption(inherited: true);
+        var debugOption = app.Option("--debug", "Application outputs even since debug log events to the console", CommandOptionType.NoValue);
+        var verboseOption = app.Option("-verb|--verbose", "Application outputs even since verbose log events to the console", CommandOptionType.NoValue);
+
+        app.Conventions
+            .UseDefaultConventions();
+            //.AddConvention(new CustomConvention);
+
+        // cmd1 command
+        app.Command("cmd1", cmd =>
+        {
+            cmd.FullName = "App - cmd1";
+            cmd.Description = "cmd1 description";
+            cmd.OnExecute(() =>
+            {
+                Console.WriteLine(cmd.FullName);
+                return 0;
+            });
+        });
+
+        // cmd2 command
+        app.Command("cmd2", cmd =>
+        {
+            cmd.FullName = "App - cmd2";
+            cmd.Description = "cmd2 description";
+            cmd.OnExecute(() =>
+            {
+                Console.WriteLine(cmd.FullName);
+                return 0;
+            });
+        });
+
+        // the main command
+        app.OnExecute(async () =>
+        {
+            await Task.Delay(1000);
+            return 0;
+        });
+
+        app.OnParsingComplete((parseResult) =>
+        {
+            var isDebug = debugOption.HasValue();
+            var isVerbose = verboseOption.HasValue();
+            //configure logger with given level output to console
+            // LogerUtils.Initialize(..., LogerUtils.GetConsoleLogLevelAmendment(isDebug, isVerbose), ...);
+        });
+
+        return app.Execute(args);
+    }
+
+
+    [Command(Name = "nestedCmd", Description = "The nested command.", ExtendedHelpText = "extended help text")]
+    class NestedAttrbutedCommand
+    {
+        private void OnExecute(IConsole console)
+        {
+            console.WriteLine("nestedCmd execution...");
+        }
+    }
+}
+
+class CustomConvention : IConvention
+{
+    public static  int ApplyCount = 0;
+
+    public CustomConvention()
+    {
+    }
+
+    public void Apply(ConventionContext context)
+    {
+        ApplyCount++;
+    }
+}

--- a/samples/Conventions/CustomDemo.cs
+++ b/samples/Conventions/CustomDemo.cs
@@ -25,7 +25,7 @@ public class CustomDemo
 
         app.Conventions
             .UseDefaultConventions()
-            .AddConvention(new AppInitializerConvention());
+            .UseAppInitializerInterface();
             //.AddConvention(new CustomConvention);
 
         // cmd1 command

--- a/samples/Conventions/CustomDemo.cs
+++ b/samples/Conventions/CustomDemo.cs
@@ -24,7 +24,8 @@ public class CustomDemo
         var verboseOption = app.Option("-verb|--verbose", "Application outputs even since verbose log events to the console", CommandOptionType.NoValue);
 
         app.Conventions
-            .UseDefaultConventions();
+            .UseDefaultConventions()
+            .AddConvention(new AppInitializerConvention());
             //.AddConvention(new CustomConvention);
 
         // cmd1 command
@@ -70,9 +71,14 @@ public class CustomDemo
     }
 
 
-    [Command(Name = "nestedCmd", Description = "The nested command.", ExtendedHelpText = "extended help text")]
-    class NestedAttrbutedCommand
+    [Command(Name = "nestedCmd", Description = "The nested command.", ExtendedHelpText = "Only a constant extended help text available")]
+    class NestedAttrbutedCommand : IAppInitializer
     {
+        void IAppInitializer.InitializeApp(CommandLineApplication app)
+        {
+            app.ExtendedHelpText = "Something got on runtime (like configuration details and so on)";
+        }
+
         private void OnExecute(IConsole console)
         {
             console.WriteLine("nestedCmd execution...");

--- a/samples/Conventions/Program.cs
+++ b/samples/Conventions/Program.cs
@@ -5,6 +5,8 @@ public class Program
 {
     static void Main(string[] args)
     {
+        CustomDemo.Main(args);
+
         // This sample shows you how to use dependency injection along with the constructor injection convention
         DependencyInjectionProgram.Main(args);
 

--- a/src/CommandLineUtils/Conventions/AppInitializerConvention.cs
+++ b/src/CommandLineUtils/Conventions/AppInitializerConvention.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Nate McMaster.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+
+namespace McMaster.Extensions.CommandLineUtils.Conventions
+{
+    /// <summary>
+    /// Calls a method with Application parameter when model is created.
+    /// It can be handy for the attributed approach of creation of models, where the application parameters can be set only from constants.
+    /// <see cref="IAppInitializer.InitializeApp" />
+    /// </summary>
+    public class AppInitializerConvention : IConvention
+    {
+        /// <summary>
+        /// Initializes instance of <see cref="AppInitializerConvention" /> class. 
+        /// </summary>
+        public AppInitializerConvention()
+        {                
+        }
+
+        /// <inheritdoc />
+        public void Apply(ConventionContext context)
+        {
+            if (context.ModelType == null)
+            {
+                return;
+            }
+
+            var model = context.ModelAccessor.GetModel();
+            if (model is IAppInitializer appInitializerModel)
+            {
+                appInitializerModel.InitializeApp(context.Application);
+            }
+        }
+    }
+}

--- a/src/CommandLineUtils/Conventions/ConventionBuilderExtensions.cs
+++ b/src/CommandLineUtils/Conventions/ConventionBuilderExtensions.cs
@@ -188,5 +188,14 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="additionalServices">Additional services that should be passed to the service provider.</param>
         public static IConventionBuilder UseConstructorInjection(this IConventionBuilder builder, IServiceProvider additionalServices)
             => builder.AddConvention(new ConstructorInjectionConvention(additionalServices));
+
+        /// <summary>
+        /// Sets a method named "InitializeApp" on the model type to handle during application initialization for application modification.
+        /// <see cref="IAppInitializer.InitializeApp" />
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <returns>The builder.</returns>
+        public static IConventionBuilder UseAppInitializerInterface(this IConventionBuilder builder)
+            => builder.AddConvention(new AppInitializerConvention());
     }
 }

--- a/src/CommandLineUtils/IAppInitializer.cs
+++ b/src/CommandLineUtils/IAppInitializer.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Nate McMaster.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// This file has been modified from the original form. See Notice.txt in the project root for more information.
+
+
+namespace McMaster.Extensions.CommandLineUtils
+{
+    /// <summary>
+    /// The command interface.
+    /// </summary>
+    public interface IAppInitializer
+
+    {
+        /// <summary>
+        /// Initialize the application. 
+        /// </summary>
+        /// <param name="app"></param>
+        void InitializeApp(CommandLineApplication app);
+    }
+}


### PR DESCRIPTION
Hello,
Dealing with an  application designed with sub-commands defined through attributes I allowed to offer my implementation of an convention allowing in such sub-commands to change state of ComandLineApplication instance, that wouldn't be possible just using the attributes.

To the feature example usage:
The simple example of usage is in CustomDemo class, the NestedAttrbutedCommand implements IAppInitializer, (the  explicit implementation of the interface suits here)
Then it is needed to add UseAppInitializerInterface() to  the root app.Conventions .
(I pre-prepared the CustomDemo class for the learning/testing the IConvention. The feature branch )

The feature  can actually exist fully off  the CommandLineUtils library, thanks to the library convention extensibility - so there is definitely no push...

I would point  about other think to consider. I can see it as a kind of  "raw" convention - then the client code is  able to modify the app with whatever inside of IAppInitializer.InitializeApp(CommandLineApplication app) method. Of course as long as the app allows doing that through its public interface.

In case of put inside library, it can be also considered whether to put as default feature (currently is not).

I have used it so-far (I actually implemented it on 2.1 version,with  tokaly different implementation not based on extension of IConvention) for an additional setting of  application inside sub commands.
It will also solve my recent problem to define sub-comands in the attributed model on runtime.





 
