### PR TITLE
Full name enhancements

### DIFF
--- a/samples/Conventions/CustomDemo.cs
+++ b/samples/Conventions/CustomDemo.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Threading.Tasks;
+using McMaster.Extensions.CommandLineUtils;
+using McMaster.Extensions.CommandLineUtils.Conventions;
+
+/// <summary>
+/// A custom class for demonstration / learning with debug purposes.
+/// It acts as a model and has sub-commands specified both ways (through API and through attributes).
+/// </summary>
+[Subcommand("nestedCmd", typeof(NestedAttrbutedCommand))]
+public class CustomDemo
+{
+
+    public CustomDemo()
+    {
+    }
+
+    public static int Main(string[] args)
+    {
+        //var app = new CommandLineApplication();
+        var app = new CommandLineApplication<CustomDemo>();
+        app.HelpOption(inherited: true);
+        var debugOption = app.Option("--debug", "Application outputs even since debug log events to the console", CommandOptionType.NoValue);
+        var verboseOption = app.Option("-verb|--verbose", "Application outputs even since verbose log events to the console", CommandOptionType.NoValue);
+
+        app.Conventions
+            .UseDefaultConventions();
+            //.AddConvention(new CustomConvention);
+
+        // cmd1 command
+        app.Command("cmd1", cmd =>
+        {
+            cmd.FullName = "App - cmd1";
+            cmd.Description = "cmd1 description";
+            cmd.OnExecute(() =>
+            {
+                Console.WriteLine(cmd.FullName);
+                return 0;
+            });
+        });
+
+        // cmd2 command
+        app.Command("cmd2", cmd =>
+        {
+            cmd.FullName = "App - cmd2";
+            cmd.Description = "cmd2 description";
+            cmd.OnExecute(() =>
+            {
+                Console.WriteLine(cmd.FullName);
+                return 0;
+            });
+        });
+
+        // the main command
+        app.OnExecute(async () =>
+        {
+            await Task.Delay(1000);
+            return 0;
+        });
+
+        app.OnParsingComplete((parseResult) =>
+        {
+            var isDebug = debugOption.HasValue();
+            var isVerbose = verboseOption.HasValue();
+            //configure logger with given level output to console
+            // LogerUtils.Initialize(..., LogerUtils.GetConsoleLogLevelAmendment(isDebug, isVerbose), ...);
+        });
+
+        return app.Execute(args);
+    }
+
+
+    [Command(Name = "nestedCmd", Description = "The nested command.", ExtendedHelpText = "extended help text")]
+    class NestedAttrbutedCommand
+    {
+        private void OnExecute(IConsole console)
+        {
+            console.WriteLine("nestedCmd execution...");
+        }
+    }
+}
+
+class CustomConvention : IConvention
+{
+    public static  int ApplyCount = 0;
+
+    public CustomConvention()
+    {
+    }
+
+    public void Apply(ConventionContext context)
+    {
+        ApplyCount++;
+    }
+}

--- a/samples/Conventions/CustomDemo.cs
+++ b/samples/Conventions/CustomDemo.cs
@@ -20,6 +20,9 @@ public class CustomDemo
         //var app = new CommandLineApplication();
         var app = new CommandLineApplication<CustomDemo>();
         app.HelpOption(inherited: true);
+        app.TemplatedFullName = string.Concat("----------------------------------", Environment.NewLine, "", " Demo App ({0})", Environment.NewLine, "----------------------------------");
+        app.VersionOption("-ver| --version", "0.1.0");
+
         var debugOption = app.Option("--debug", "Application outputs even since debug log events to the console", CommandOptionType.NoValue);
         var verboseOption = app.Option("-verb|--verbose", "Application outputs even since verbose log events to the console", CommandOptionType.NoValue);
 
@@ -30,7 +33,7 @@ public class CustomDemo
         // cmd1 command
         app.Command("cmd1", cmd =>
         {
-            cmd.FullName = "App - cmd1";
+            cmd.FullName = "Demo App - cmd1 command";
             cmd.Description = "cmd1 description";
             cmd.OnExecute(() =>
             {
@@ -42,7 +45,7 @@ public class CustomDemo
         // cmd2 command
         app.Command("cmd2", cmd =>
         {
-            cmd.FullName = "App - cmd2";
+            cmd.FullName = "Demo App - cmd2 command";
             cmd.Description = "cmd2 description";
             cmd.OnExecute(() =>
             {
@@ -70,7 +73,7 @@ public class CustomDemo
     }
 
 
-    [Command(Name = "nestedCmd", Description = "The nested command.", ExtendedHelpText = "extended help text")]
+    [Command(Name = "nestedCmd", FullName = "Demo App - nested command", Description = "The nested command.", ExtendedHelpText = "extended help text")]
     class NestedAttrbutedCommand
     {
         private void OnExecute(IConsole console)

--- a/samples/Conventions/CustomDemo.cs
+++ b/samples/Conventions/CustomDemo.cs
@@ -7,6 +7,7 @@ using McMaster.Extensions.CommandLineUtils.Conventions;
 /// A custom class for demonstration / learning with debug purposes.
 /// It acts as a model and has sub-commands specified both ways (through API and through attributes).
 /// </summary>
+[PrefixRootFullName]
 [Subcommand("nestedCmd", typeof(NestedAttrbutedCommand))]
 public class CustomDemo
 {
@@ -33,7 +34,7 @@ public class CustomDemo
         // cmd1 command
         app.Command("cmd1", cmd =>
         {
-            cmd.FullName = "Demo App - cmd1 command";
+            cmd.FullName = "cmd1 command";
             cmd.Description = "cmd1 description";
             cmd.OnExecute(() =>
             {
@@ -45,7 +46,7 @@ public class CustomDemo
         // cmd2 command
         app.Command("cmd2", cmd =>
         {
-            cmd.FullName = "Demo App - cmd2 command";
+            cmd.FullName = "cmd2 command";
             cmd.Description = "cmd2 description";
             cmd.OnExecute(() =>
             {
@@ -73,7 +74,7 @@ public class CustomDemo
     }
 
 
-    [Command(Name = "nestedCmd", FullName = "Demo App - nested command", Description = "The nested command.", ExtendedHelpText = "extended help text")]
+    [Command(Name = "nestedCmd", FullName = "nested command", Description = "The nested command.", ExtendedHelpText = "extended help text")]
     class NestedAttrbutedCommand
     {
         private void OnExecute(IConsole console)

--- a/samples/Conventions/Program.cs
+++ b/samples/Conventions/Program.cs
@@ -5,6 +5,8 @@ public class Program
 {
     static void Main(string[] args)
     {
+        CustomDemo.Main(args);
+
         // This sample shows you how to use dependency injection along with the constructor injection convention
         DependencyInjectionProgram.Main(args);
 

--- a/src/CommandLineUtils/Attributes/PrefixRootFullNameAttribute.cs
+++ b/src/CommandLineUtils/Attributes/PrefixRootFullNameAttribute.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Nate McMaster.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace McMaster.Extensions.CommandLineUtils
+{
+    /// <summary>
+    /// The attribute used to determine if PrefixRootFullName should be used by default. This should only be used once per command line app.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class PrefixRootFullNameAttribute : Attribute
+    {
+        /// <summary>
+        /// Determines whether to prefix the root full name.
+        /// </summary>
+        public bool Prefix { get; set; }
+
+
+        /// <summary>
+        /// Initializes a new <see cref="PrefixRootFullNameAttribute"/>.
+        /// </summary>
+        public PrefixRootFullNameAttribute()
+            : this(true)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new <see cref="PrefixRootFullNameAttribute"/>.
+        /// </summary>
+        /// <param name="prefix">Determines whether to prefix the root full name.</param>
+        public PrefixRootFullNameAttribute(bool prefix)
+        {
+            this.Prefix = prefix;
+        }
+
+        internal void Configure(CommandLineApplication app)
+        {
+            app.PrefixRootFullName = this.Prefix;
+        }
+    }
+}

--- a/src/CommandLineUtils/CommandLineApplication.cs
+++ b/src/CommandLineUtils/CommandLineApplication.cs
@@ -118,6 +118,23 @@ namespace McMaster.Extensions.CommandLineUtils
         public CommandLineApplication Parent { get; set; }
 
         /// <summary>
+        /// A calculated link to the root command (in case of root command it points to it self).
+        /// </summary>
+        public CommandLineApplication Root
+        {
+            get
+            {
+                var rootCmd = this;
+                while (rootCmd.Parent != null)
+                {
+                    rootCmd = rootCmd.Parent;
+                }
+
+                return rootCmd;
+            }
+        }
+
+        /// <summary>
         /// The help text generator to use.
         /// </summary>
         public IHelpTextGenerator HelpTextGenerator
@@ -232,6 +249,32 @@ namespace McMaster.Extensions.CommandLineUtils
         /// Determines if '--' can be used to separate known arguments and options from additional content passed to <see cref="RemainingArguments"/>.
         /// </summary>
         public bool AllowArgumentSeparator { get; set; }
+
+        /// <summary>
+        /// Determines if '--' the prefixRootFullName was set from client.
+        /// </summary>
+        private bool _prefixRootFullNameClientSet = false;
+
+        /// <summary>
+        /// Determines if '--' the RootFullName (with version) is always shown before the actual sub-command full name (backing field).
+        /// </summary>
+        private bool _prefixRootFullName;
+
+        /// <summary>
+        /// Determines if '--' the RootFullName (with version) is always shown before the actual sub-command full name.
+        /// </summary>
+        public bool PrefixRootFullName
+        {
+            get
+            {
+                return _prefixRootFullName;
+            }
+            set
+            {
+                _prefixRootFullNameClientSet = true;
+                _prefixRootFullName = value;
+            }
+        }
 
         /// <summary>
         /// <para>
@@ -541,6 +584,17 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary>
+        /// The internal inheritance call of the <see cref="PrefixRootFullName" /> from the parent value.
+        /// </summary>
+        internal void DeterminePrefixRootFullNameByInheritance()
+        {
+            if (!_prefixRootFullNameClientSet && Parent != null)
+            {
+                _prefixRootFullName = Parent._prefixRootFullName;
+            }
+        }
+
+        /// <summary>
         /// Handle the result of parsing command line arguments.
         /// </summary>
         /// <param name="parseResult">The parse result.</param>
@@ -801,10 +855,45 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <returns></returns>
         public string GetFullNameAndVersion()
         {
-            var shortVersion = ShortVersionGetter?.Invoke();
-            return (TemplatedFullName == null)
-                ? string.IsNullOrEmpty(shortVersion) ? FullName : string.Format("{0} ({1})", FullName, shortVersion)
-                : string.Format(TemplatedFullName, shortVersion);
+            var sb = new StringBuilder();
+            if (PrefixRootFullName)
+            {
+                var root = Root;
+                if (root != this)
+                {
+                    sb.Append(root.GetFullNameAndVersion());
+                    sb.Append(Environment.NewLine);
+                }
+            }
+            if (TemplatedFullName == null)
+            {
+                if (ShortVersionGetter == null)
+                {
+                    sb.Append(FullName);
+                }
+                else
+                {
+                    sb.Append(FullName);
+                    sb.Append(" (");
+                    sb.Append(ShortVersionGetter());
+                    sb.Append(")");
+                }
+            }
+            else
+            {
+                try
+                {
+                    var verPlaceHolderExist = TemplatedFullName.IndexOf("{0}") != -1;                    
+                    var verText = ShortVersionGetter?.Invoke() ?? string.Empty;
+                    var fnvText = verPlaceHolderExist ? string.Format(TemplatedFullName, verText) : TemplatedFullName;
+                    sb.Append(fnvText);
+                }
+                catch (FormatException ex)
+                {
+                    throw new Exception("Bad format of the TemplatedFullName - it does not contain only one placeholder \"{0}\"!", ex);
+                }
+            }
+            return sb.ToString();        
         }
 
         /// <summary>
@@ -812,13 +901,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// </summary>
         public void ShowRootCommandFullNameAndVersion()
         {
-            var rootCmd = this;
-            while (rootCmd.Parent != null)
-            {
-                rootCmd = rootCmd.Parent;
-            }
-
-            Out.WriteLine(rootCmd.GetFullNameAndVersion());
+            Out.WriteLine(Root.GetFullNameAndVersion());
             Out.WriteLine();
         }
 

--- a/src/CommandLineUtils/CommandLineApplication.cs
+++ b/src/CommandLineUtils/CommandLineApplication.cs
@@ -137,6 +137,11 @@ namespace McMaster.Extensions.CommandLineUtils
         public string FullName { get; set; }
 
         /// <summary>
+        /// The full name of the command to show in the help text (with a placeholder for a  short version) .
+        /// </summary>
+        public string TemplatedFullName { get; set; }
+
+        /// <summary>
         /// A description of the command.
         /// </summary>
         public string Description { get; set; }
@@ -797,9 +802,9 @@ namespace McMaster.Extensions.CommandLineUtils
         public string GetFullNameAndVersion()
         {
             var shortVersion = ShortVersionGetter?.Invoke();
-            return string.IsNullOrEmpty(shortVersion)
-                ? FullName
-                : $"{FullName} {shortVersion}";
+            return (TemplatedFullName == null)
+                ? string.IsNullOrEmpty(shortVersion) ? FullName : string.Format("{0} ({1})", FullName, shortVersion)
+                : string.Format(TemplatedFullName, shortVersion);
         }
 
         /// <summary>

--- a/src/CommandLineUtils/Conventions/ConventionBuilderExtensions.cs
+++ b/src/CommandLineUtils/Conventions/ConventionBuilderExtensions.cs
@@ -29,6 +29,7 @@ namespace McMaster.Extensions.CommandLineUtils
                 .SetRemainingArgsPropertyOnModel()
                 .SetSubcommandPropertyOnModel()
                 .SetParentPropertyOnModel()
+                .UsePrefixRootFullName()
                 .UseOnExecuteMethodFromModel()
                 .UseOnValidateMethodFromModel()
                 .UseOnValidationErrorMethodFromModel()
@@ -148,6 +149,21 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <returns>The builder.</returns>
         public static IConventionBuilder UseSubcommandAttributes(this IConventionBuilder builder)
             => builder.AddConvention(new SubcommandAttributeConvention());
+
+
+        /// <summary>
+        /// Uses a property named "PrefixRootFullName" on the commands for showing the
+        /// the root command full name as the prefix of the actual sub-command full name.
+        /// This means the natural looking inheritance value from the parent command property value,
+        /// if not specified else (and possibility to set through the attribute.
+        /// (If the convention is not set, then by setting "PrefixRootFullName" property
+        ///  enables the showing of the root command prefix just for given particular sub-command
+        ///  and the attribute does not have any effect).
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <returns>The builder.</returns>
+        public static IConventionBuilder UsePrefixRootFullName(this IConventionBuilder builder)
+            => builder.AddConvention(new InheritPrefixRootFullNameConvention());
 
         /// <summary>
         /// Invokes a method named "OnValidate" on the model type after parsing.

--- a/src/CommandLineUtils/Conventions/InheritPrefixRootFullNameConvention.cs
+++ b/src/CommandLineUtils/Conventions/InheritPrefixRootFullNameConvention.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Nate McMaster.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+
+namespace McMaster.Extensions.CommandLineUtils.Conventions
+{
+    /// <summary>
+    /// Adds settings from <see cref="PrefixRootFullNameAttribute"/> set
+    /// on the model type for <see cref="CommandLineApplication{TModel}"/>.
+    /// </summary>
+    public class InheritPrefixRootFullNameConvention : IConvention
+    {
+        /// <inheritdoc />
+        public virtual void Apply(ConventionContext context)
+        {
+            var setByAttr = false;
+            if (context.ModelType != null)
+            {
+                var attribute = context.ModelType.GetTypeInfo().GetCustomAttribute<PrefixRootFullNameAttribute>();
+                if (attribute != null)
+                {
+                    attribute.Configure(context.Application);
+                    setByAttr = true;
+                }
+            }
+
+            if (!setByAttr)
+            {
+                context.Application.DeterminePrefixRootFullNameByInheritance();
+            }
+            
+        }
+    }
+}

--- a/test/CommandLineUtils.Tests/PrefixRootFullNamePropertyConventionTests.cs
+++ b/test/CommandLineUtils.Tests/PrefixRootFullNamePropertyConventionTests.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) Nate McMaster.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace McMaster.Extensions.CommandLineUtils.Tests
+{
+    public class PrefixRootFullNamePropertyConventionTests
+    {
+        [Subcommand("addVegetable", typeof(AddVegetable))]
+        [Subcommand("addFruit", typeof(AddFruit))]
+        [PrefixRootFullName]
+        private class Program
+        {
+            [Subcommand("cucumber", typeof(Cucumber))]
+            [Subcommand("onion", typeof(Onion))]
+            private class AddVegetable
+            {
+                private class Cucumber
+                {
+                }
+
+                private class Onion
+                {
+                }
+            }
+
+            [PrefixRootFullName(false)]
+            [Subcommand("apple", typeof(Apple))]
+            [Subcommand("pear", typeof(Pear))]
+            private class AddFruit
+            {
+                private class Apple
+                {
+                }
+
+                private class Pear
+                {
+                }
+            }
+
+        }
+
+        [Fact]
+        public void InheritanceAndAttribsByDefault()
+        {
+            var app = new CommandLineApplication<Program>();
+            app.Conventions
+                .UseDefaultConventions();
+            var result1 = app.Parse("addVegetable onion".Split(' '));
+            var result2 = app.Parse("addFruit apple".Split(' '));
+            Assert.True(result1.SelectedCommand.PrefixRootFullName);
+            Assert.False(result2.SelectedCommand.PrefixRootFullName);
+        }
+
+        [Fact]
+        public void InheritanceAndAttribs()
+        {
+            var app = new CommandLineApplication<Program>();
+            app.Conventions
+                .SetSubcommandPropertyOnModel()
+                .UseSubcommandAttributes()
+                .UsePrefixRootFullName();
+            var result1 = app.Parse("addVegetable onion".Split(' '));
+            var result2 = app.Parse("addFruit apple".Split(' '));
+            Assert.True(result1.SelectedCommand.PrefixRootFullName);
+            Assert.False(result2.SelectedCommand.PrefixRootFullName);
+        }
+
+        [Fact]
+        public void FeatureNotSet()
+        {
+            var app = new CommandLineApplication<Program>();
+            app.Conventions
+                .SetSubcommandPropertyOnModel()
+                .UseSubcommandAttributes();
+            var result1 = app.Parse("addVegetable onion".Split(' '));
+            var result2 = app.Parse("addFruit apple".Split(' '));
+            Assert.False(result1.SelectedCommand.PrefixRootFullName);
+            Assert.False(result2.SelectedCommand.PrefixRootFullName);
+        }
+
+    }
+}


### PR DESCRIPTION
There are two parts (commits)

1) Allow to have  FullName as a template

It suits to my opinionated Full name like
. . . . . . . . . . . . . . . . . . . .
App Name (ver X.Y.Z)
. . . . . . . . . . . . . . . . . . . .

2) Allow to automatically show the root command FullName as prefix of sub command full name

then the help outupt  end up with something like :
. . . . . . . . . . . . . . . . . . . .
App Name (ver X.Y.Z)
. . . . . . . . . . . . . . . . . . . .
Sub-command FullName

This feature can be set through API/ PrefixRootFullName attribute on the root command
There is InheritPrefixRootFullNameConvention, included in the default conventions. Which helps that PrefixRootFullName can be set at the root command and then the value is automatically distributed to sub=commands. Of course, the inheritance can be "updated" by specifying on particular command in the client code. 

Please see the simple usage example on the  CustomDemo changes

The feature come from my own opinion, so  it is up to you whether you see it valuable or not :)







