### PR TITLE
Preserve the default CLR values of option and arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+Bug fixes:
+
+ - Don't assign option and argument options if no value was provided, preserving the default CLR value unless there is user-input.
+
 ## [v2.2.0]
 
 **March 30,2018**

--- a/src/CommandLineUtils/Conventions/ArgumentAttributeConvention.cs
+++ b/src/CommandLineUtils/Conventions/ArgumentAttributeConvention.cs
@@ -109,6 +109,11 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
 
                 convention.Application.OnParsingComplete(r =>
                 {
+                    if (argument.Values.Count == 0)
+                    {
+                        return;
+                    }
+
                     if (r.SelectedCommand is IModelAccessor cmd)
                     {
                         setter.Invoke(cmd.GetModel(), collectionParser.Parse(argument.Name, argument.Values));
@@ -125,6 +130,11 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
 
                 convention.Application.OnParsingComplete(r =>
                 {
+                    if (argument.Values.Count == 0)
+                    {
+                        return;
+                    }
+
                     if (r.SelectedCommand is IModelAccessor cmd)
                     {
                         setter.Invoke(

--- a/src/CommandLineUtils/Conventions/OptionAttributeConventionBase.cs
+++ b/src/CommandLineUtils/Conventions/OptionAttributeConventionBase.cs
@@ -23,7 +23,9 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                 option.Validators.Add(new AttributeValidator(attr));
             }
 
-            if (option.OptionType == CommandOptionType.NoValue && prop.PropertyType != typeof(bool))
+            if (option.OptionType == CommandOptionType.NoValue
+                && prop.PropertyType != typeof(bool)
+                && prop.PropertyType != typeof(bool?))
             {
                 throw new InvalidOperationException(Strings.NoValueTypesMustBeBoolean);
             }
@@ -59,7 +61,13 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                         throw new InvalidOperationException(Strings.CannotDetermineParserType(prop));
                     }
                     context.Application.OnParsingComplete(_ =>
-                        setter.Invoke(context.ModelAccessor.GetModel(), collectionParser.Parse(option.LongName, option.Values)));
+                    {
+                        if (!option.HasValue())
+                        {
+                            return;
+                        }
+                        setter.Invoke(context.ModelAccessor.GetModel(), collectionParser.Parse(option.LongName, option.Values));
+                    });
                     break;
                 case CommandOptionType.SingleOrNoValue:
                 case CommandOptionType.SingleValue:
@@ -78,7 +86,14 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                     });
                     break;
                 case CommandOptionType.NoValue:
-                    context.Application.OnParsingComplete(_ => setter.Invoke(context.ModelAccessor.GetModel(), option.HasValue()));
+                    context.Application.OnParsingComplete(_ =>
+                    {
+                        if (!option.HasValue())
+                        {
+                            return;
+                        }
+                        setter.Invoke(context.ModelAccessor.GetModel(), option.HasValue());
+                    });
                     break;
                 default:
                     throw new NotImplementedException();

--- a/test/CommandLineUtils.Tests/ArgumentAttributeTests.cs
+++ b/test/CommandLineUtils.Tests/ArgumentAttributeTests.cs
@@ -67,5 +67,33 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
                 Strings.OnlyLastArgumentCanAllowMultipleValues("Words"),
                 ex.Message);
         }
+
+        private class ArgHasDefaultValues
+        {
+            [Argument(0)]
+            public string Arg1 { get; } = "a";
+
+            [Argument(1)]
+            public string[] Arg2 { get; } = new[] { "b", "c" };
+        }
+
+        [Fact]
+        public void KeepsDefaultValues()
+        {
+            var app1 = Create<ArgHasDefaultValues>();
+            app1.Parse("z", "y");
+            Assert.Equal("z", app1.Model.Arg1);
+            Assert.Equal(new[] { "y" }, app1.Model.Arg2);
+
+            var app2 = Create<ArgHasDefaultValues>();
+            app2.Parse("z");
+            Assert.Equal("z", app2.Model.Arg1);
+            Assert.Equal(new[] { "b", "c" }, app2.Model.Arg2);
+
+            var app3 = Create<ArgHasDefaultValues>();
+            app3.Parse();
+            Assert.Equal("a", app3.Model.Arg1);
+            Assert.Equal(new[] { "b", "c" }, app3.Model.Arg2);
+        }
     }
 }

--- a/test/CommandLineUtils.Tests/OptionAttributeTests.cs
+++ b/test/CommandLineUtils.Tests/OptionAttributeTests.cs
@@ -133,6 +133,49 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         }
 
 
+        private class OptionHasDefaultValues
+        {
+            [Option("-a1")]
+            public string Arg1 { get; } = "a";
+
+            [Option("-a2")]
+            public string[] Arg2 { get; } = new[] { "b", "c" };
+
+            [Option("-a3")]
+            public bool? Arg3 { get; }
+
+            [Option("-a4")]
+            public (bool hasValue, string value) Arg4 { get; } = (false, "Yellow");
+        }
+
+        [Fact]
+        public void KeepsDefaultValues()
+        {
+            var app1 = Create<OptionHasDefaultValues>();
+            app1.Parse("-a1", "z", "-a2", "y");
+            Assert.Equal("z", app1.Model.Arg1);
+            Assert.Equal(new[] { "y" }, app1.Model.Arg2);
+
+            var app2 = Create<OptionHasDefaultValues>();
+            app2.Parse("-a1", "z");
+            Assert.Equal("z", app2.Model.Arg1);
+            Assert.Equal(new[] { "b", "c" }, app2.Model.Arg2);
+
+            var app3 = Create<OptionHasDefaultValues>();
+            app3.Parse();
+            Assert.Equal("a", app3.Model.Arg1);
+            Assert.Equal(new[] { "b", "c" }, app3.Model.Arg2);
+            Assert.False(app3.Model.Arg3.HasValue, "Should not have value");
+            Assert.False(app3.Model.Arg4.hasValue, "Should not have value");
+            Assert.Equal((false, "Yellow"), app3.Model.Arg4);
+
+            var app4 = Create<OptionHasDefaultValues>();
+            app4.Parse("-a3", "-a4");
+            Assert.True(app4.Model.Arg3.HasValue);
+            Assert.True(app4.Model.Arg4.hasValue);
+            Assert.True(app4.Model.Arg3.Value);
+            Assert.Equal((true, null), app4.Model.Arg4);
+        }
 
         private class PrivateSetterProgram
         {


### PR DESCRIPTION
If not value has been specified by user input, preserve the default CLR value.

FYI @atruskie  - I think i'm probably touching areas of the code that you might be working on too.