### PR TITLE
Add basic support for parsing Uri parameters

### DIFF
--- a/src/CommandLineUtils/Abstractions/ValueParserProvider.cs
+++ b/src/CommandLineUtils/Abstractions/ValueParserProvider.cs
@@ -32,6 +32,7 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
                     UInt64ValueParser.Singleton,
                     FloatValueParser.Singleton,
                     DoubleValueParser.Singleton,
+                    UriValueParser.Singleton,
                 });
         }
 

--- a/src/CommandLineUtils/Internal/ValueParsers/UriValueParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/UriValueParser.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Nate McMaster.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+
+namespace McMaster.Extensions.CommandLineUtils.Abstractions
+{
+    internal class UriValueParser : IValueParser<Uri>
+    {
+        private UriValueParser()
+        { }
+
+        public static UriValueParser Singleton { get; } = new UriValueParser();
+
+        public Type TargetType { get; } = typeof(Uri);
+
+        public Uri Parse(string argName, string value, CultureInfo culture) => new Uri(value, UriKind.RelativeOrAbsolute);
+
+        object IValueParser.Parse(string argName, string value, CultureInfo culture)
+            => this.Parse(argName, value, culture);
+    }
+}

--- a/test/CommandLineUtils.Tests/ValueParserProviderTests.cs
+++ b/test/CommandLineUtils.Tests/ValueParserProviderTests.cs
@@ -95,6 +95,9 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
 
             [Option("--color-value-tuple:<VALUE>")]
             public (bool HasValue, Color Value) EnumValueTuple { get; }
+
+            [Option("--uri")]
+            public Uri Uri { get; set; }
         }
 
         public static IEnumerable<object[]> GetFloatingPointSymbolsData()
@@ -369,6 +372,16 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             var parsed = CommandLineParser.ParseArgs<Program>("--color-opt", color.ToString().ToLowerInvariant());
             Assert.True(parsed.ColorOpt.HasValue, "Option should have value");
             Assert.Equal(color, parsed.ColorOpt);
+        }
+
+        [Theory]
+        [InlineData("http://example.com/")]
+        [InlineData("http://example.com/foo/bar")]
+        [InlineData("/foo/bar")]
+        public void ParsesUri(string uriString)
+        {
+            var parsed = CommandLineParser.ParseArgs<Program>("--uri", uriString);
+            Assert.Equal(uriString, parsed.Uri.ToString());
         }
 
         [Theory]


### PR DESCRIPTION
Parses URIs as `UriKind.RelativeOrAbsolute`. Next behavioural step would be to add an annotation that specifies a specific `UriKind` (e.g. to force absolute URIs).

Seemed like a good use of my lunch break :joy:

Fix for #97 