### PR TITLE
Allow retrieving already registered parsers

### DIFF
--- a/src/CommandLineUtils/Abstractions/ValueParserProvider.cs
+++ b/src/CommandLineUtils/Abstractions/ValueParserProvider.cs
@@ -46,7 +46,7 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
 
         private static readonly MethodInfo s_GetParserGeneric
             = typeof(ValueParserProvider).GetTypeInfo()
-                .GetMethods(BindingFlags.Instance | BindingFlags.NonPublic)
+                .GetMethods(BindingFlags.Instance | BindingFlags.Public)
                 .Single(m => m.Name == nameof(GetParser) && m.IsGenericMethod);
 
         /// <summary>

--- a/src/CommandLineUtils/Abstractions/ValueParserProvider.cs
+++ b/src/CommandLineUtils/Abstractions/ValueParserProvider.cs
@@ -49,13 +49,26 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
                 .GetMethods(BindingFlags.Instance | BindingFlags.NonPublic)
                 .Single(m => m.Name == nameof(GetParser) && m.IsGenericMethod);
 
-        internal IValueParser GetParser(Type type)
+        /// <summary>
+        /// Returns a parser registered for the given type.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        public IValueParser GetParser(Type type)
         {
             var method = s_GetParserGeneric.MakeGenericMethod(type);
             return (IValueParser)method.Invoke(this, Constants.EmptyArray);
         }
 
-        internal IValueParser<T> GetParser<T>()
+        /// <summary>
+        /// Returns a parser for the generic type T.
+        /// </summary>
+        /// <remarks>
+        /// If parser is not registered, null is returned.
+        /// </remarks>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public IValueParser<T> GetParser<T>()
         {
             var parser = GetParserImpl<T>();
             if (parser == null)
@@ -71,7 +84,7 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
             return new GenericParserAdapter<T>(parser);
         }
 
-        private IValueParser GetParserImpl<T>()
+        internal IValueParser GetParserImpl<T>()
         {
             var type = typeof(T);
             if (_parsers.TryGetValue(type, out var parser))


### PR DESCRIPTION
Fixes #109 by exposing `GetParser` methods

Co-authored-by: Brandon Ording <bording@gmail.com>
Co-authored-by: Sean Feldman <feldman.sean@gmail.com>