### PR TITLE
Alternative SingleOrNoValue notation with tests

### DIFF
--- a/src/CommandLineUtils/CommandOption.cs
+++ b/src/CommandLineUtils/CommandOption.cs
@@ -26,7 +26,10 @@ namespace McMaster.Extensions.CommandLineUtils
             Template = template;
             OptionType = optionType;
 
-            foreach (var part in Template.Split(new[] { ' ', '|', ':', '=' }, StringSplitOptions.RemoveEmptyEntries))
+            var separators = (optionType == CommandOptionType.SingleOrNoValue)
+                ? new[] { ' ', '|', ':', '=', '[', ']' }
+                : new[] { ' ', '|', ':', '=' };
+            foreach (var part in Template.Split(separators, StringSplitOptions.RemoveEmptyEntries))
             {
                 if (part.StartsWith("--"))
                 {
@@ -213,14 +216,12 @@ namespace McMaster.Extensions.CommandLineUtils
             {
                 if (OptionType == CommandOptionType.SingleOrNoValue)
                 {
-                    sb.Append(":<");
+                    sb.Append("[:<").Append(ValueName).Append(">]");
                 }
                 else
                 {
-                    sb.Append(" <");
+                    sb.Append(" <").Append(ValueName).Append('>');
                 }
-
-                sb.Append(ValueName).Append('>');
             }
 
             return sb.ToString();

--- a/test/CommandLineUtils.Tests/CommandOptionTests.cs
+++ b/test/CommandLineUtils.Tests/CommandOptionTests.cs
@@ -26,9 +26,22 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         [InlineData("--name=<VALUE>", null, null, "name", "VALUE")]
         [InlineData("-a:<VALUE> --name:<VALUE>", "a", null, "name", "VALUE")]
         [InlineData("-a=<VALUE> --name=<VALUE>", "a", null, "name", "VALUE")]
-        public void ItParsesTemplate(string template, string shortName, string symbolName, string longName, string valueName)
+        public void ItParsesSingleValueTemplate(string template, string shortName, string symbolName, string longName, string valueName)
         {
             var opt = new CommandOption(template, CommandOptionType.SingleValue);
+            Assert.Equal(template, opt.Template);
+            Assert.Equal(shortName, opt.ShortName);
+            Assert.Equal(symbolName, opt.SymbolName);
+            Assert.Equal(longName, opt.LongName);
+            Assert.Equal(valueName, opt.ValueName);
+        }
+
+        [Theory]
+        [InlineData("--name[:<VALUE>]", null, null, "name", "VALUE")]
+        [InlineData("--name[=<VALUE>]", null, null, "name", "VALUE")]
+        public void ItParsesSingleOrNoValueTemplate(string template, string shortName, string symbolName, string longName, string valueName)
+        {
+            var opt = new CommandOption(template, CommandOptionType.SingleOrNoValue);
             Assert.Equal(template, opt.Template);
             Assert.Equal(shortName, opt.ShortName);
             Assert.Equal(symbolName, opt.SymbolName);


### PR DESCRIPTION
This pull-request enables `SingleOrNoValue` command options to use the following notations (see #113):
```
--name[=<VALUE>]
```
-AND-
```
--name[:<VALUE>]
```

The changes should be backwards compatible with the exception of how `SingleOrNoValue` options are now rendered.

Looking forward to your feedback.