### PR TITLE
Handle nested HelpOptions with inheritance

### DIFF
--- a/test/CommandLineUtils.Tests/CommandLineApplicationTests.cs
+++ b/test/CommandLineUtils.Tests/CommandLineApplicationTests.cs
@@ -853,6 +853,18 @@ Examples:
         }
 
         [Fact]
+        public void NonClusteredOptionCanBeSymbolic()
+        {
+            var app = new CommandLineApplication();
+            var option = app.Option("-!|-o|--out", "Output", CommandOptionType.NoValue);
+            var otherOption = app.Option("-o2|--option2", "Option2", CommandOptionType.NoValue);
+
+            app.Execute("-!");
+            Assert.True(option.HasValue(), "Output option should be set");
+            Assert.False(otherOption.HasValue(), "Option2 should not be set");
+        }
+
+        [Fact]
         public void OptionsCanVaryByCase()
         {
             var app = new CommandLineApplication();

--- a/test/CommandLineUtils.Tests/HelpOptionAttributeTests.cs
+++ b/test/CommandLineUtils.Tests/HelpOptionAttributeTests.cs
@@ -167,7 +167,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         {
             var sb = new StringBuilder();
             var outWriter = new StringWriter(sb);
-            var app = new CommandLineApplication<Parent> { Out = outWriter };
+            var app = new CommandLineApplication<Parent> {Out = outWriter};
             app.Conventions.UseDefaultConventions();
             app.Commands.ForEach(f => f.Out = outWriter);
             app.Execute("lvl2", "--help");
@@ -175,6 +175,47 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
 
             Assert.True(app.OptionHelp.HasValue());
             Assert.Contains("Usage: lvl1 lvl2 [arguments] [options]", outData);
+        }
+
+        [Theory]
+        [InlineData(new[] { "get", "--help" }, 0, "Gets a list of things.")]
+        [InlineData(new[] { "get", "-h" }, 0, "Gets a list of things.")]
+        [InlineData(new[] { "get", "-?" }, 0, "Gets a list of things.")]
+        [InlineData(new[] { "--help" }, 0, "Usage: updater [options] [command]")]
+        [InlineData(new[] { "-h" }, 0, "Usage: updater [options] [command]")]
+        [InlineData(new[] { "-?" }, 0, "Usage: updater [options] [command]")]
+        public void NestedHelpOptionsChoosesHelpOptionNearestSelectedCommand(string[] args, int exitCode, string helpNeedle)
+        {
+            var sb = new StringBuilder();
+            var outWriter = new StringWriter(sb);
+
+            var app = new CommandLineApplication { Name = "updater", Out = outWriter };
+            app.HelpOption(true);
+
+            app.Command("get", getCommand =>
+            {
+                getCommand.Description = "Gets a list of things.";
+                getCommand.HelpOption();
+                
+                getCommand.OnExecute(() =>
+                {
+                    getCommand.ShowHelp();
+                    return 1;
+                });
+            });
+
+            app.OnExecute(() => {
+                app.ShowHelp();
+                return 1;
+            });
+
+            app.Commands.ForEach(f => f.Out = outWriter);
+
+            var resultQuestionMarkHelp = app.Execute(args);
+            var outData = sb.ToString();
+
+            Assert.Equal(exitCode, resultQuestionMarkHelp);
+            Assert.Contains(helpNeedle, outData);
         }
     }
 }

--- a/test/CommandLineUtils.Tests/HelpOptionAttributeTests.cs
+++ b/test/CommandLineUtils.Tests/HelpOptionAttributeTests.cs
@@ -178,13 +178,13 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         }
 
         [Theory]
-        [InlineData(new[] { "get", "--help" }, 0, "Gets a list of things.")]
-        [InlineData(new[] { "get", "-h" }, 0, "Gets a list of things.")]
-        [InlineData(new[] { "get", "-?" }, 0, "Gets a list of things.")]
-        [InlineData(new[] { "--help" }, 0, "Usage: updater [options] [command]")]
-        [InlineData(new[] { "-h" }, 0, "Usage: updater [options] [command]")]
-        [InlineData(new[] { "-?" }, 0, "Usage: updater [options] [command]")]
-        public void NestedHelpOptionsChoosesHelpOptionNearestSelectedCommand(string[] args, int exitCode, string helpNeedle)
+        [InlineData(new[] { "get", "--help" }, "Usage: updater get [options]")]
+        [InlineData(new[] { "get", "-h" }, "Usage: updater get [options]")]
+        [InlineData(new[] { "get", "-?" }, "Usage: updater get [options]")]
+        [InlineData(new[] { "--help" }, "Usage: updater [options] [command]")]
+        [InlineData(new[] { "-h" }, "Usage: updater [options] [command]")]
+        [InlineData(new[] { "-?" }, "Usage: updater [options] [command]")]
+        public void NestedHelpOptionsChoosesHelpOptionNearestSelectedCommand(string[] args, string helpNeedle)
         {
             var sb = new StringBuilder();
             var outWriter = new StringWriter(sb);
@@ -211,10 +211,9 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
 
             app.Commands.ForEach(f => f.Out = outWriter);
 
-            var resultQuestionMarkHelp = app.Execute(args);
+            app.Execute(args);
             var outData = sb.ToString();
 
-            Assert.Equal(exitCode, resultQuestionMarkHelp);
             Assert.Contains(helpNeedle, outData);
         }
     }


### PR DESCRIPTION
When the `HelpOption` with  is set with `inherited = true` and nested subcommands set the `HelpOption` too then the `HelpOption` nearest to the selected command is used.

Extracted the search for options by `ShortName`, `SymbolName`, `LongName` into a new method called `FindOption`.

Added Unit Tests for each branch that calls the `FindOption` method.

Fixes #86 