### PR TITLE
Fix #163 - Specifying type when Activator.CreateInstance fails

### DIFF
--- a/src/CommandLineUtils/CommandLineApplication{T}.cs
+++ b/src/CommandLineUtils/CommandLineApplication{T}.cs
@@ -16,7 +16,7 @@ namespace McMaster.Extensions.CommandLineUtils
         where TModel : class
     {
         private Lazy<TModel> _lazy;
-        private Func<TModel> _modelFactory = () => Activator.CreateInstance<TModel>();
+        private Func<TModel> _modelFactory = DefaultModelFactory;
 
         /// <summary>
         /// Initializes a new instance of <see cref="CommandLineApplication"/>.
@@ -72,6 +72,18 @@ namespace McMaster.Extensions.CommandLineUtils
         private void Initialize()
         {
             _lazy = new Lazy<TModel>(CreateModel);
+        }
+
+        private static TModel DefaultModelFactory()
+        {
+            try
+            {
+                return Activator.CreateInstance<TModel>();
+            }
+            catch (MissingMethodException ex)
+            {
+                throw new MissingParameterlessConstructorException<TModel>(ex);
+            }
         }
 
         /// <summary>

--- a/src/CommandLineUtils/CommandLineApplication{T}.cs
+++ b/src/CommandLineUtils/CommandLineApplication{T}.cs
@@ -82,7 +82,7 @@ namespace McMaster.Extensions.CommandLineUtils
             }
             catch (MissingMethodException ex)
             {
-                throw new MissingParameterlessConstructorException<TModel>(ex);
+                throw new MissingParameterlessConstructorException(typeof(TModel), ex);
             }
         }
 

--- a/src/CommandLineUtils/MissingParameterlessConstructorException.cs
+++ b/src/CommandLineUtils/MissingParameterlessConstructorException.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace McMaster.Extensions.CommandLineUtils
+{
+    /// <summary>
+    /// The exception that is thrown when trying to intianciate a model with no parameterless constructor.
+    /// </summary>
+    /// <typeparam name="TModel">The type of the model to instanciate</typeparam>
+    public class MissingParameterlessConstructorException<TModel> : Exception
+    {
+        /// <summary>
+        /// Initializes an instance of <see cref="MissingParameterlessConstructorException{TModel}"/>.
+        /// </summary>
+        /// <param name="innerException">The original exception.</param>
+        public MissingParameterlessConstructorException(Exception innerException) : base($"Class {typeof(TModel).FullName} does not have a parameterless constructor", innerException) { }
+    }
+}

--- a/src/CommandLineUtils/MissingParameterlessConstructorException.cs
+++ b/src/CommandLineUtils/MissingParameterlessConstructorException.cs
@@ -3,15 +3,23 @@
 namespace McMaster.Extensions.CommandLineUtils
 {
     /// <summary>
-    /// The exception that is thrown when trying to intianciate a model with no parameterless constructor.
+    /// The exception that is thrown when trying to instantiate a model with no parameterless constructor.
     /// </summary>
-    /// <typeparam name="TModel">The type of the model to instanciate</typeparam>
-    public class MissingParameterlessConstructorException<TModel> : Exception
+    public class MissingParameterlessConstructorException : Exception
     {
         /// <summary>
-        /// Initializes an instance of <see cref="MissingParameterlessConstructorException{TModel}"/>.
+        /// Gets the type that caused the exception.
         /// </summary>
+        public Type Type { get; private set; }
+
+        /// <summary>
+        /// Initializes an instance of <see cref="MissingParameterlessConstructorException" />.
+        /// </summary>
+        /// <param name="type">The type missing a parameterless constructor.</param>
         /// <param name="innerException">The original exception.</param>
-        public MissingParameterlessConstructorException(Exception innerException) : base($"Class {typeof(TModel).FullName} does not have a parameterless constructor", innerException) { }
+        public MissingParameterlessConstructorException(Type type, Exception innerException) : base($"Class {type.FullName} does not have a parameterless constructor", innerException)
+        {
+            Type = type;
+        }
     }
 }

--- a/test/CommandLineUtils.Tests/CommandLineApplicationOfTTests.cs
+++ b/test/CommandLineUtils.Tests/CommandLineApplicationOfTTests.cs
@@ -71,5 +71,17 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
                 () => CommandLineParser.ParseArgs<SimpleProgram>(_output, "-f"));
             Assert.StartsWith("Unrecognized option '-f'", ex.Message);
         }
+
+        private class TestClass
+        {
+            public TestClass(string _) { }
+        }
+
+        [Fact]
+        public void ThrowsForNoParameterlessConstructor()
+        {
+            var app = new CommandLineApplication<TestClass>();
+            Assert.Throws<MissingParameterlessConstructorException<TestClass>>(() => app.Execute());
+        }
     }
 }

--- a/test/CommandLineUtils.Tests/CommandLineApplicationOfTTests.cs
+++ b/test/CommandLineUtils.Tests/CommandLineApplicationOfTTests.cs
@@ -81,7 +81,8 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         public void ThrowsForNoParameterlessConstructor()
         {
             var app = new CommandLineApplication<TestClass>();
-            Assert.Throws<MissingParameterlessConstructorException<TestClass>>(() => app.Execute());
+            var exception = Assert.Throws<MissingParameterlessConstructorException>(() => app.Execute());
+            Assert.Equal(typeof(TestClass), exception.Type);
         }
     }
 }


### PR DESCRIPTION
Created a new MissingParameterlessConstructorException that includes the type causing the exception in the message.