### PR TITLE
Add support for parsing DateTime,DateTimeOffset,TimeSpan parameters

### DIFF
--- a/src/CommandLineUtils/Abstractions/ValueParserProvider.cs
+++ b/src/CommandLineUtils/Abstractions/ValueParserProvider.cs
@@ -33,6 +33,9 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
                     StockValueParsers.Float,
                     StockValueParsers.Double,
                     StockValueParsers.Uri,
+                    StockValueParsers.DateTime,
+                    StockValueParsers.DateTimeOffset,
+                    StockValueParsers.TimeSpan
                 });
         }
 

--- a/test/CommandLineUtils.Tests/ValueParserProviderCustomTests.cs
+++ b/test/CommandLineUtils.Tests/ValueParserProviderCustomTests.cs
@@ -104,8 +104,9 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             ValueTuple<int, double, string>? expectedComplexValue = null;
 
             var app = new CommandLineApplication<CustomParserProgram>();
-
-            app.ValueParsers.AddRange(new IValueParser[] { new MyDateTimeOffsetParser(), new ComplexTupleParser() });
+            
+            app.ValueParsers.Add(new ComplexTupleParser());
+            app.ValueParsers.AddOrReplace(new MyDateTimeOffsetParser());
             app.ValueParsers.AddOrReplace(new MyDoubleParser());
 
             app.Conventions.UseAttributes();
@@ -138,7 +139,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             var cultureInfo = new CultureInfo(culture);
             var app = new CommandLineApplication<DateParserProgram>();
             app.ValueParsers.ParseCulture = cultureInfo;
-            app.ValueParsers.Add(new MyDateTimeOffsetParser());
+            app.ValueParsers.AddOrReplace(new MyDateTimeOffsetParser());
             app.Conventions.UseAttributes();
             app.Parse(test);
 
@@ -175,7 +176,8 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         {
             var app = new CommandLineApplication<CustomParserProgram>();
 
-            app.ValueParsers.AddRange(new IValueParser[] { new MyDateTimeOffsetParser(), new ComplexTupleParser() });
+            app.ValueParsers.Add(new ComplexTupleParser());
+            app.ValueParsers.AddOrReplace(new MyDateTimeOffsetParser());
             app.ValueParsers.AddOrReplace(new MyDoubleParser());
 
             var optionMapper = CommandOptionTypeMapper.Default;
@@ -214,8 +216,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         public void CustomParsersAreAvailableToSubCommands()
         {
             var expectedDate = new DateTimeOffset(2018, 02, 16, 21, 30, 33, 45, TimeSpan.FromHours(10));
-
-
+            
             var app = new CommandLineApplication<CustomParserProgramAttributes>();
             app.ValueParsers.AddOrReplace(new MyDateTimeOffsetParser());
             app.Conventions.UseDefaultConventions();

--- a/test/CommandLineUtils.Tests/ValueParserProviderTests.cs
+++ b/test/CommandLineUtils.Tests/ValueParserProviderTests.cs
@@ -101,6 +101,15 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
 
             [Option("--uri")]
             public Uri Uri { get; set; }
+
+            [Option("--datetime")]
+            public DateTime DateTime { get; }
+
+            [Option("--datetime-offset")]
+            public DateTimeOffset DateTimeOffset { get; }
+
+            [Option("--timespan")]
+            public TimeSpan TimeSpan { get; }
         }
 
         private sealed class InCulture : IDisposable
@@ -416,6 +425,38 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         {
             var parsed = CommandLineParser.ParseArgs<Program>("--uri", uriString);
             Assert.Equal(uriString, parsed.Uri.ToString());
+        }
+
+        [Theory]
+        [InlineData("2009-06-15")]
+        [InlineData("2009-06-15T13:45:30")]
+        [InlineData("2009-06-15T13:45:30Z")]
+        public void ParseDateTime(string dateTimeString)
+        {
+            var parsed = CommandLineParser.ParseArgs<Program>("--datetime", dateTimeString);
+            var expected = DateTime.Parse(dateTimeString, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+            Assert.Equal(expected, parsed.DateTime);
+            Assert.Equal(expected.Kind, parsed.DateTime.Kind);
+        }
+
+        [Theory]
+        [InlineData("2009-06-15")]
+        [InlineData("2009-06-15T13:45:30Z")]
+        [InlineData("2009-06-15T13:45:30+08:00")]
+        public void ParseDateTimeOffset(string dateTimeOffsetString)
+        {
+            var parsed = CommandLineParser.ParseArgs<Program>("--datetime-offset", dateTimeOffsetString);
+            Assert.Equal(DateTimeOffset.Parse(dateTimeOffsetString), parsed.DateTimeOffset);
+        }
+
+        [Theory]
+        [InlineData("00:30:00")]
+        [InlineData("-10:27:22")]
+        [InlineData("1:1:57:54")]
+        public void ParseTimeSpan(string timeSpanString)
+        {
+            var parsed = CommandLineParser.ParseArgs<Program>("--timespan", timeSpanString);
+            Assert.Equal(TimeSpan.Parse(timeSpanString), parsed.TimeSpan);
         }
 
         [Theory]


### PR DESCRIPTION
Add default value parsers for DateTime types: 

- DateTime
- DateTimeOffset
- TimeSpan

Fix #172 


