### PR TITLE
Improve the error message when parameter type is not registered

### DIFF
--- a/src/CommandLineUtils/Conventions/ConstructorInjectionConvention.cs
+++ b/src/CommandLineUtils/Conventions/ConstructorInjectionConvention.cs
@@ -59,34 +59,69 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
 
             if (constructors.Length == 0)
             {
-                throw new InvalidOperationException("Could not find any public constructors on " + typeof(TModel).FullName);
+                throw new InvalidOperationException(Strings.NoAnyPublicConstuctorFound(typeof(TModel)));
             }
 
-            // find the constructor with the most parameters first
-            foreach (var ctorCandidate in constructors.OrderByDescending(c => c.GetParameters().Count()))
+            var (matchedCtor, matchedArgs) = (constructors.Length == 1)
+                // shortcut for single constructor
+                ? FindMatchedConstructor(constructors, context.Application,
+                    throwIfNoParameterTypeRegistered: true)
+                // find the constructor with the most parameters first
+                : FindMatchedConstructor(constructors, context.Application,
+                    throwIfNoParameterTypeRegistered: false);
+
+            var parameterLessCtor = Array.Find(constructors, c => c.GetParameters().Length == 0);
+
+            if (matchedCtor == null && parameterLessCtor != null)
+            {
+                return;
+            }
+
+            if (matchedCtor == null && parameterLessCtor == null)
+            {
+                throw new InvalidOperationException(Strings.NoMatchedConstructorFound(typeof(TModel)));
+            }
+
+            if (matchedCtor != null)
+            {
+                (context.Application as CommandLineApplication<TModel>).ModelFactory =
+                    () => (TModel)matchedCtor.Invoke(matchedArgs);
+            }
+        }
+
+        private (ConstructorInfo matchedCtor, object[] matchedArgs) FindMatchedConstructor(
+            ConstructorInfo[] constructors,
+            IServiceProvider services,
+            bool throwIfNoParameterTypeRegistered = false)
+        {
+            foreach (var ctorCandidate in constructors.OrderByDescending(c => c.GetParameters().Length))
             {
                 var parameters = ctorCandidate.GetParameters().ToArray();
                 var args = new object[parameters.Length];
-                var matched = false;
                 for (var i = 0; i < parameters.Length; i++)
                 {
                     var paramType = parameters[i].ParameterType;
-                    var service = ((IServiceProvider)context.Application).GetService(paramType);
+                    var service = services.GetService(paramType);
                     if (service == null)
                     {
-                        throw new InvalidOperationException(Strings.NoParameterTypeRegistered(typeof(TModel), paramType));
+                        if (!throwIfNoParameterTypeRegistered)
+                        {
+                            continue;
+                        }
+                        throw new InvalidOperationException(Strings.NoParameterTypeRegistered(ctorCandidate.DeclaringType, paramType));
                     }
                     args[i] = service;
-                    matched = i == parameters.Length - 1;
-                }
-
-                if (matched)
-                {
-                    (context.Application as CommandLineApplication<TModel>).ModelFactory =
-                        () => (TModel)ctorCandidate.Invoke(args);
-                    return;
+                    if (i == parameters.Length - 1)
+                    {
+                        var matchedArgsLength = args.Count(x => x != null);
+                        if (parameters.Length == matchedArgsLength)
+                        {
+                            return (ctorCandidate, args);
+                        }
+                    }
                 }
             }
+            return (null, null);
         }
     }
 }

--- a/src/CommandLineUtils/Conventions/ConstructorInjectionConvention.cs
+++ b/src/CommandLineUtils/Conventions/ConstructorInjectionConvention.cs
@@ -74,7 +74,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                     var service = ((IServiceProvider)context.Application).GetService(paramType);
                     if (service == null)
                     {
-                        break;
+                        throw new InvalidOperationException(Strings.NoParameterTypeRegistered(typeof(TModel), paramType));
                     }
                     args[i] = service;
                     matched = i == parameters.Length - 1;

--- a/src/CommandLineUtils/Properties/Strings.cs
+++ b/src/CommandLineUtils/Properties/Strings.cs
@@ -91,5 +91,8 @@ namespace McMaster.Extensions.CommandLineUtils
 
         public static string NoPropertyOrMethodFound(string memberName, Type type)
             => $"Could not find a property or method named {memberName} on type {type.FullName}";
+
+        public static string NoParameterTypeRegistered(Type modelType, Type paramType)
+            => $"The constructor of type '{modelType}' contains the parameter of type '{paramType}' is not registered, Ensure the type '{paramType}' are registered in additional services with CommandLineApplication.Conventions.UseConstructorInjection(IServiceProvider additionalServices)";
     }
 }

--- a/src/CommandLineUtils/Properties/Strings.cs
+++ b/src/CommandLineUtils/Properties/Strings.cs
@@ -94,5 +94,11 @@ namespace McMaster.Extensions.CommandLineUtils
 
         public static string NoParameterTypeRegistered(Type modelType, Type paramType)
             => $"The constructor of type '{modelType}' contains the parameter of type '{paramType}' is not registered, Ensure the type '{paramType}' are registered in additional services with CommandLineApplication.Conventions.UseConstructorInjection(IServiceProvider additionalServices)";
+
+        public static string NoAnyPublicConstuctorFound(Type modelType)
+            => $"Could not find any public constructors of type '{modelType}'";
+
+        public static string NoMatchedConstructorFound(Type modelType)
+            => $"Could not found any matched constructors of type '{modelType}'";
     }
 }

--- a/test/CommandLineUtils.Tests/ConstructorInjectionConventionTests.cs
+++ b/test/CommandLineUtils.Tests/ConstructorInjectionConventionTests.cs
@@ -1,8 +1,10 @@
 // Copyright (c) Nate McMaster.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 using Xunit.Abstractions;
@@ -115,6 +117,24 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             var subcmd = Assert.IsType<CommandLineApplication<Child>>(result.SelectedCommand);
             Assert.NotNull(subcmd.Model.Parent);
             Assert.Same(app.Model, subcmd.Model.Parent);
+        }
+
+        private class InjectedTestConsole
+        {
+            public TestConsole Console { get; }
+
+            public InjectedTestConsole(TestConsole console)
+            {
+                Console = console;
+            }
+        }
+
+        [Fact]
+        public void ThrowsWhenParameterTypeNotRegistered(){
+            var app = new CommandLineApplication<InjectedTestConsole>();
+            var ex = Assert.Throws<TargetInvocationException>(() => app.Conventions.UseConstructorInjection());
+            Assert.IsType<InvalidOperationException>(ex.InnerException);
+            Assert.Equal(Strings.NoParameterTypeRegistered(typeof(InjectedTestConsole), typeof(TestConsole)), ex.InnerException.Message);
         }
     }
 }


### PR DESCRIPTION
Throws InvalidOperationException with following message when parameter type is not registered in ConstructorInjectionConvention:

```
The constructor of type '{modelType}' contains the parameter of type '{paramType}' is not registered, Ensure the type '{paramType}' are registered in additional services with CommandLineApplication.Conventions.UseConstructorInjection(IServiceProvider additionalServices)
```

Fix #174 