### PR TITLE
Don't immediately throw in ConstructorInjectionConvention

### DIFF
--- a/src/CommandLineUtils/Conventions/ConstructorInjectionConvention.cs
+++ b/src/CommandLineUtils/Conventions/ConstructorInjectionConvention.cs
@@ -62,34 +62,16 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                 throw new InvalidOperationException(Strings.NoAnyPublicConstuctorFound(typeof(TModel)));
             }
 
-            var (matchedCtor, matchedArgs) = (constructors.Length == 1)
-                // shortcut for single constructor
-                ? FindMatchedConstructor(constructors, context.Application,
-                    throwIfNoParameterTypeRegistered: true)
-                // find the constructor with the most parameters first
-                : FindMatchedConstructor(constructors, context.Application,
-                    throwIfNoParameterTypeRegistered: false);
+            var factory = FindMatchedConstructor<TModel>(constructors, context.Application,
+                constructors.Length == 1);
 
-            var parameterLessCtor = Array.Find(constructors, c => c.GetParameters().Length == 0);
-
-            if (matchedCtor == null && parameterLessCtor != null)
+            if (factory != null)
             {
-                return;
-            }
-
-            if (matchedCtor == null && parameterLessCtor == null)
-            {
-                throw new InvalidOperationException(Strings.NoMatchedConstructorFound(typeof(TModel)));
-            }
-
-            if (matchedCtor != null)
-            {
-                (context.Application as CommandLineApplication<TModel>).ModelFactory =
-                    () => (TModel)matchedCtor.Invoke(matchedArgs);
+                ((CommandLineApplication<TModel>) context.Application).ModelFactory = factory;
             }
         }
 
-        private (ConstructorInfo matchedCtor, object[] matchedArgs) FindMatchedConstructor(
+        private static Func<TModel> FindMatchedConstructor<TModel>(
             ConstructorInfo[] constructors,
             IServiceProvider services,
             bool throwIfNoParameterTypeRegistered = false)
@@ -97,6 +79,11 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
             foreach (var ctorCandidate in constructors.OrderByDescending(c => c.GetParameters().Length))
             {
                 var parameters = ctorCandidate.GetParameters().ToArray();
+                if (parameters.Length == 0)
+                {
+                    return null;
+                }
+
                 var args = new object[parameters.Length];
                 for (var i = 0; i < parameters.Length; i++)
                 {
@@ -106,22 +93,25 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                     {
                         if (!throwIfNoParameterTypeRegistered)
                         {
-                            continue;
+                            goto nextCtor;
                         }
-                        throw new InvalidOperationException(Strings.NoParameterTypeRegistered(ctorCandidate.DeclaringType, paramType));
+
+                        return () =>
+                            throw new InvalidOperationException(
+                                Strings.NoParameterTypeRegistered(ctorCandidate.DeclaringType, paramType));
                     }
+
                     args[i] = service;
                     if (i == parameters.Length - 1)
                     {
-                        var matchedArgsLength = args.Count(x => x != null);
-                        if (parameters.Length == matchedArgsLength)
-                        {
-                            return (ctorCandidate, args);
-                        }
+                        return () => (TModel) ctorCandidate.Invoke(args);
                     }
                 }
+
+                nextCtor: ;
             }
-            return (null, null);
+
+            return () => throw new InvalidOperationException(Strings.NoMatchedConstructorFound(typeof(TModel)));
         }
     }
 }

--- a/src/CommandLineUtils/Conventions/ConstructorInjectionConvention.cs
+++ b/src/CommandLineUtils/Conventions/ConstructorInjectionConvention.cs
@@ -57,11 +57,6 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                 .GetTypeInfo()
                 .GetConstructors(BindingFlags.Public | BindingFlags.Instance);
 
-            if (constructors.Length == 0)
-            {
-                throw new InvalidOperationException(Strings.NoAnyPublicConstuctorFound(typeof(TModel)));
-            }
-
             var factory = FindMatchedConstructor<TModel>(constructors, context.Application,
                 constructors.Length == 1);
 
@@ -76,6 +71,11 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
             IServiceProvider services,
             bool throwIfNoParameterTypeRegistered = false)
         {
+            if (constructors.Length == 0)
+            {
+                return () => throw new InvalidOperationException(Strings.NoAnyPublicConstuctorFound(typeof(TModel)));
+            }
+
             foreach (var ctorCandidate in constructors.OrderByDescending(c => c.GetParameters().Length))
             {
                 var parameters = ctorCandidate.GetParameters().ToArray();

--- a/test/CommandLineUtils.Tests/ConstructorInjectionConventionTests.cs
+++ b/test/CommandLineUtils.Tests/ConstructorInjectionConventionTests.cs
@@ -130,9 +130,9 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         public void ThrowsWhenNoAnyPublicConstructorFound()
         {
             var app = new CommandLineApplication<TestAppWithoutPublicConstructor>();
-            var ex = Assert.Throws<TargetInvocationException>(() => app.Conventions.UseConstructorInjection());
-            Assert.IsType<InvalidOperationException>(ex.InnerException);
-            Assert.Equal(Strings.NoAnyPublicConstuctorFound(typeof(TestAppWithoutPublicConstructor)), ex.InnerException.Message);
+            app.Conventions.UseConstructorInjection();
+            var ex = Assert.Throws<InvalidOperationException>(() => app.Model);
+            Assert.Equal(Strings.NoAnyPublicConstuctorFound(typeof(TestAppWithoutPublicConstructor)), ex.Message);
         }
 
         private class TestAppWithoutMatchedConstructor

--- a/test/CommandLineUtils.Tests/ConstructorInjectionConventionTests.cs
+++ b/test/CommandLineUtils.Tests/ConstructorInjectionConventionTests.cs
@@ -149,9 +149,9 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         public void ThrowsWhenNoMatchedConstructorFound()
         {
             var app = new CommandLineApplication<TestAppWithoutMatchedConstructor>();
-            var ex = Assert.Throws<TargetInvocationException>(() => app.Conventions.UseConstructorInjection());
-            Assert.IsType<InvalidOperationException>(ex.InnerException);
-            Assert.Equal(Strings.NoParameterTypeRegistered(typeof(TestAppWithoutMatchedConstructor), typeof(TestConsole)), ex.InnerException.Message);
+            app.Conventions.UseConstructorInjection();
+            var ex = Assert.Throws<InvalidOperationException>(() => app.ModelFactory());
+            Assert.Equal(Strings.NoParameterTypeRegistered(typeof(TestAppWithoutMatchedConstructor), typeof(TestConsole)), ex.Message);
         }
 
         private class TestAppWithAlternativeConstructor


### PR DESCRIPTION
rather let the ModelFactory throw as the convention is applied twice in hosting case.

It took me some time to discover why the unit-test of my pull-request #178 started failing. I immediately suspected #175, but it took me an hour to realize that the convention is immediately applied when added to the builder.  Worse: in CommandLineService it is applied twice!

```
_application.Conventions
    .UseDefaultConventions() // this will apply ConstructorInjectionConvention and throw
    .UseConstructorInjection(serviceProvider); // this would work
```

By setting the ModelFactory to a throw-implementation we get to the second invocation were we set up the real deal. Effect for other apps is that the exceptions are a bit later, but also less nested. This also gives room for other conventions to set-up ModelFactories.