### PR TITLE
Model injecting convention

### DIFF
--- a/src/CommandLineUtils/Conventions/ConventionBuilderExtensions.cs
+++ b/src/CommandLineUtils/Conventions/ConventionBuilderExtensions.cs
@@ -209,6 +209,21 @@ namespace McMaster.Extensions.CommandLineUtils
             => builder.AddConvention(new ConstructorInjectionConvention(additionalServices));
 
         /// <summary>
+        /// Enables using injection to provide the model.
+        /// </summary>
+        /// <param name="builder"></param>
+        public static IConventionBuilder UseInjectedModel(this IConventionBuilder builder)
+            => builder.AddConvention(new InjectedModelConvention());
+
+        /// <summary>
+        /// Enables using injection to provide the model.
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="additionalServices">Additional services that should be passed to the service provider.</param>
+        public static IConventionBuilder UseInjectedModel(this IConventionBuilder builder, IServiceProvider additionalServices)
+            => builder.AddConvention(new InjectedModelConvention(additionalServices));
+
+        /// <summary>
         /// Sets the subcommand name using the model type, if available and not otherwise set using <see cref="CommandAttribute"/>.
         /// </summary>
         /// <param name="builder"></param>

--- a/src/CommandLineUtils/Conventions/InjectedModelConvention.cs
+++ b/src/CommandLineUtils/Conventions/InjectedModelConvention.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace McMaster.Extensions.CommandLineUtils.Conventions
+{
+    /// <summary>
+    /// Uses an instance of <see cref="IServiceProvider" /> to provide externally initialized model
+    /// </summary>
+    public class InjectedModelConvention : IConvention
+    {
+        private readonly IServiceProvider _additionalServices;
+
+        /// <summary>
+        /// Initializes an instance of <see cref="InjectedModelConvention" />.
+        /// </summary>
+        public InjectedModelConvention()
+        {
+        }
+
+        /// <summary>
+        /// Initializes an instance of <see cref="InjectedModelConvention" />.
+        /// </summary>
+        /// <param name="additionalServices">Additional services use to inject the constructor of the model</param>
+        public InjectedModelConvention(IServiceProvider additionalServices)
+        {
+            _additionalServices = additionalServices;
+        }
+
+        /// <inheritdoc />
+        public virtual void Apply(ConventionContext context)
+        {
+            if (_additionalServices != null)
+            {
+                context.Application.AdditionalServices = _additionalServices;
+            }
+
+            if (context.ModelType == null)
+            {
+                return;
+            }
+
+            s_applyMethod.MakeGenericMethod(context.ModelType).Invoke(this, new object[] {context});
+        }
+
+        private static readonly MethodInfo s_applyMethod
+            = typeof(InjectedModelConvention).GetRuntimeMethods().Single(m => m.Name == nameof(ApplyImpl));
+
+        private void ApplyImpl<TModel>(ConventionContext context)
+            where TModel : class
+        {
+            var service = ((IServiceProvider) context.Application).GetService(typeof(TModel));
+
+            if (service != null)
+            {
+                ((CommandLineApplication<TModel>) context.Application).ModelFactory = () => (TModel) service;
+            }
+        }
+    }
+}

--- a/test/CommandLineUtils.Tests/InjectedModelConventionTests.cs
+++ b/test/CommandLineUtils.Tests/InjectedModelConventionTests.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Nate McMaster.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace McMaster.Extensions.CommandLineUtils.Tests
+{
+    public class InjectedModelConventionTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public InjectedModelConventionTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void ItInjectsModelFromDefaultServices()
+        {
+            var app = new CommandLineApplication<IConsole>();
+            app.Conventions.UseInjectedModel();
+            app.Parse();
+            Assert.NotNull(app.Model);
+            Assert.IsType<PhysicalConsole>(app.Model);
+        }
+
+        [Fact]
+        public void ItSupportsCustomServices()
+        {
+            var testConsole = new TestConsole(_output);
+            var services = new ServiceCollection()
+                .AddSingleton<IConsole>(testConsole)
+                .BuildServiceProvider();
+            var app = new CommandLineApplication<IConsole>();
+            app.Conventions.UseInjectedModel(services);
+            Assert.Same(testConsole, app.Model);
+        }
+
+        private interface ITestApp
+        {
+
+        }
+
+        private class TestApp : ITestApp
+        {
+
+        }
+
+        [Fact]
+        public void ItSupportsInterfaceModels()
+        {
+            var testApp = new TestApp();
+            var services = new ServiceCollection()
+                .AddSingleton<ITestApp>(testApp)
+                .BuildServiceProvider();
+            var app = new CommandLineApplication<ITestApp>();
+            app.Conventions.UseInjectedModel(services);
+            Assert.Same(testApp, app.Model);
+        }
+
+        [Fact]
+        public void ThrowsWhenNoModelFound()
+        {
+            var app = new CommandLineApplication<ITestApp>();
+            app.Conventions.UseInjectedModel();
+            var ex = Assert.Throws<MissingParameterlessConstructorException>(() => app.Model);
+            Assert.Equal(typeof(ITestApp), ex.Type);
+        }
+    }
+}


### PR DESCRIPTION
This would enable models to be externally provided.

This depends on #181 and currently lacks tests and an extension-method on ConventionBuilder hence WIP.