### PR TITLE
Naive approach to prevent uncaught exceptions and ease handling

### DIFF
--- a/src/Hosting.CommandLine/IUnhandledExceptionHandler.cs
+++ b/src/Hosting.CommandLine/IUnhandledExceptionHandler.cs
@@ -1,9 +1,19 @@
 using System;
+using McMaster.Extensions.CommandLineUtils;
+using McMaster.Extensions.Hosting.CommandLine.Internal;
 
 namespace McMaster.Extensions.Hosting.CommandLine
 {
+    /// <summary>
+    /// Used by <see cref="CommandLineLifetime"/> to handle exceptions that are emitted from the
+    /// <see cref="CommandLineApplication{TModel}"/> e.g. during parsing or execution
+    /// </summary>
     public interface IUnhandledExceptionHandler
     {
+        /// <summary>
+        /// Handle otherwise uncaught exception. You are free to log, rethrow, … the exception 
+        /// </summary>
+        /// <param name="e">An otherwise uncaught exception</param>
         void HandleException(Exception e);
     }
 }

--- a/src/Hosting.CommandLine/IUnhandledExceptionHandler.cs
+++ b/src/Hosting.CommandLine/IUnhandledExceptionHandler.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace McMaster.Extensions.Hosting.CommandLine
+{
+    public interface IUnhandledExceptionHandler
+    {
+        void HandleException(Exception e);
+    }
+}

--- a/src/Hosting.CommandLine/Internal/StoreExceptionHandler.cs
+++ b/src/Hosting.CommandLine/Internal/StoreExceptionHandler.cs
@@ -6,12 +6,12 @@ namespace McMaster.Extensions.Hosting.CommandLine.Internal
     /// Implementation of <see cref="IUnhandledExceptionHandler"/> that stores an unhandled exception so it can later be
     /// rethrown by <see cref="CommandLineService{T}"/>.
     /// </summary>
-    public class StoreExceptionHandler : IUnhandledExceptionHandler
+    internal class StoreExceptionHandler : IUnhandledExceptionHandler
     {
         /// <summary>
         /// The captured exception, if any
         /// </summary>
-        public Exception StoredException { get; private set; } = null;
+        public Exception StoredException { get; private set; }
 
         /// <summary>
         /// This will store the first unhandled exception and throw an <see cref="AggregateException"/> if called a

--- a/src/Hosting.CommandLine/Internal/StoreExceptionHandler.cs
+++ b/src/Hosting.CommandLine/Internal/StoreExceptionHandler.cs
@@ -2,10 +2,24 @@ using System;
 
 namespace McMaster.Extensions.Hosting.CommandLine.Internal
 {
+    /// <summary>
+    /// Implementation of <see cref="IUnhandledExceptionHandler"/> that stores an unhandled exception so it can later be
+    /// rethrown by <see cref="CommandLineService{T}"/>.
+    /// </summary>
     public class StoreExceptionHandler : IUnhandledExceptionHandler
     {
+        /// <summary>
+        /// The captured exception, if any
+        /// </summary>
         public Exception StoredException { get; private set; } = null;
 
+        /// <summary>
+        /// This will store the first unhandled exception and throw an <see cref="AggregateException"/> if called a
+        /// second time.
+        /// </summary>
+        /// <param name="e">The unhandled exception to store</param>
+        /// <exception cref="AggregateException">If called a second time an <see cref="AggregateException"/> containing
+        /// both exceptions is raised</exception>
         public void HandleException(Exception e)
         {
             if (StoredException != null)

--- a/src/Hosting.CommandLine/Internal/StoreExceptionHandler.cs
+++ b/src/Hosting.CommandLine/Internal/StoreExceptionHandler.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace McMaster.Extensions.Hosting.CommandLine.Internal
+{
+    public class StoreExceptionHandler : IUnhandledExceptionHandler
+    {
+        public Exception StoredException { get; private set; } = null;
+
+        public void HandleException(Exception e)
+        {
+            if (StoredException != null)
+            {
+                throw new AggregateException("Second exception received!", StoredException, e);
+            }
+
+            StoredException = e;
+        }
+    }
+}


### PR DESCRIPTION
Currently the way the app is registered with the Lifetime leads to uncatchable exceptions e.g. during parsing. Inspired by #187 this tries to make all exceptions catchable and tries to eliminate TargetInvocationExceptions along the way.