### PR TITLE
Async all the way through

### DIFF
--- a/src/Hosting.CommandLine/Internal/CommandLineService.cs
+++ b/src/Hosting.CommandLine/Internal/CommandLineService.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Logging;
 
 namespace McMaster.Extensions.Hosting.CommandLine.Internal
 {
-    /// <inheritdoc />
+    /// <inheritdoc cref="ICommandLineService" />
     internal class CommandLineService<T> : IDisposable, ICommandLineService where T : class
     {
         private readonly CommandLineApplication _application;
@@ -44,10 +44,12 @@ namespace McMaster.Extensions.Hosting.CommandLine.Internal
         }
 
         /// <inheritdoc />
-        public Task<int> RunAsync(CancellationToken cancellationToken)
+        public async Task<int> RunAsync(CancellationToken cancellationToken)
         {
             _logger.LogDebug("Running");
-            return Task.Run(() => _state.ExitCode = _application.Execute(_state.Arguments), cancellationToken);
+            var exitCode = await _application.ExecuteAsync(_state.Arguments);
+            _state.ExitCode = exitCode;
+            return exitCode;
         }
 
         public void Dispose()


### PR DESCRIPTION
I am not 100% sure, but to me it feels that Thread.FromResult should be synchronous and I don't know if it is enough to use await deeper down the rabbit hole. Thus this will try to make the *Async methods do await on other *Async methods until Invoke/InvokeAsync may finally be a sync or async method.

The cancellationToken in CommandLineService.RunAsync requires more changes and thus deserves a separate pull-request.