### PR TITLE
Make IUnhandledExceptionHandler optional and always call StopApplication

### DIFF
--- a/src/Hosting.CommandLine/Internal/CommandLineLifetime.cs
+++ b/src/Hosting.CommandLine/Internal/CommandLineLifetime.cs
@@ -28,7 +28,7 @@ namespace McMaster.Extensions.Hosting.CommandLine.Internal
         public CommandLineLifetime(IApplicationLifetime applicationLifetime,
             ICommandLineService cliService,
             IConsole console,
-            IUnhandledExceptionHandler unhandledExceptionHandler)
+            IUnhandledExceptionHandler unhandledExceptionHandler = null)
         {
             _applicationLifetime = applicationLifetime;
             _cliService = cliService;
@@ -75,8 +75,10 @@ namespace McMaster.Extensions.Hosting.CommandLine.Internal
                         ExceptionDispatchInfo.Capture(e).Throw();
                     }
                 }
-
-                _applicationLifetime.StopApplication();
+                finally
+                {
+                    _applicationLifetime.StopApplication();
+                }
             });
 
             // Ensures services are disposed before the application exits.


### PR DESCRIPTION
As long as everything works out as intended StopApplication is called, but if not the Host will probably never stop on it's own.