### PR TITLE
Run the app on the same thread used to start generic host

### DIFF
--- a/src/Hosting.CommandLine/Internal/CommandLineService.cs
+++ b/src/Hosting.CommandLine/Internal/CommandLineService.cs
@@ -47,7 +47,9 @@ namespace McMaster.Extensions.Hosting.CommandLine.Internal
         public Task<int> RunAsync(CancellationToken cancellationToken)
         {
             _logger.LogDebug("Running");
-            return Task.Run(() => _state.ExitCode = _application.Execute(_state.Arguments), cancellationToken);
+            // TODO support cancellation tokens. See #111
+            _state.ExitCode = _application.Execute(_state.Arguments);
+            return Task.FromResult(_state.ExitCode);
         }
 
         public void Dispose()


### PR DESCRIPTION
cc @TheConstructor @vlm---

We need to add support for cancellation tokens, but that won't happen until after 2.3. In the meantime, this removes the Task.Run which should resolve #195