### PR TITLE
Option to use Pager to display help text

### DIFF
--- a/src/CommandLineUtils/CommandLineApplication.cs
+++ b/src/CommandLineUtils/CommandLineApplication.cs
@@ -172,7 +172,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <summary>
         /// Whether a Pager should be used to display help text.
         /// </summary>
-        public bool HelpUsePager { get; set; } = true;
+        public bool UsePagerForHelpText { get; set; } = true;
 
         /// <summary>
         /// All names by which the command can be referenced. This includes <see cref="Name"/> and an aliases added in <see cref="AddName"/>.
@@ -844,7 +844,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <summary>
         /// Show full help.
         /// </summary>
-        public void ShowHelp() => ShowHelp(usePager: HelpUsePager);
+        public void ShowHelp() => ShowHelp(usePager: UsePagerForHelpText);
 
         /// <summary>
         /// Show full help.

--- a/src/CommandLineUtils/CommandLineApplication.cs
+++ b/src/CommandLineUtils/CommandLineApplication.cs
@@ -170,6 +170,11 @@ namespace McMaster.Extensions.CommandLineUtils
         public List<CommandOption> Options { get; private set; }
 
         /// <summary>
+        /// Whether a Pager should be used to display help text.
+        /// </summary>
+        public bool HelpUsePager { get; set; } = true;
+
+        /// <summary>
         /// All names by which the command can be referenced. This includes <see cref="Name"/> and an aliases added in <see cref="AddName"/>.
         /// </summary>
         public IEnumerable<string> Names
@@ -839,7 +844,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <summary>
         /// Show full help.
         /// </summary>
-        public void ShowHelp() => ShowHelp(usePager: true);
+        public void ShowHelp() => ShowHelp(usePager: HelpUsePager);
 
         /// <summary>
         /// Show full help.


### PR DESCRIPTION
Hello,

This commit makes using a Pager to display help text optional.

HelpUsePager is initialized to true as to not break default behaviour.

Re: Test - I'm not sure how to write a test for this since the value is always initialized and `ShowHelp` then refers to that value. `Assert.True(app.HelpUsePager)`?