### PR TITLE
Rearrange the order that commands are listed in the USAGE block and l…

### DIFF
--- a/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
+++ b/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
@@ -113,14 +113,16 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
                 output.Write(stack.Pop());
             }
 
-            if (visibleArguments.Any())
-            {
-                output.Write(" [arguments]");
-            }
-
             if (visibleOptions.Any())
             {
                 output.Write(" [options]");
+            }
+
+            foreach (var argument in visibleArguments)
+            {
+                output.Write(" <");
+                output.Write(argument.Name);
+                output.Write(">");
             }
 
             if (visibleCommands.Any())

--- a/test/CommandLineUtils.Tests/CommandLineApplicationTests.cs
+++ b/test/CommandLineUtils.Tests/CommandLineApplicationTests.cs
@@ -732,7 +732,7 @@ Examples:
                 var outData = outWriter.ToString();
 
                 Assert.True(helpOption.HasValue());
-                Assert.Contains("Usage: lvl1 lvl2 [arguments] [options]", outData);
+                Assert.Contains("Usage: lvl1 lvl2 [options] <lvl-arg>", outData);
 
                 inputs = new[] { helpOptionString };
                 app.Execute(inputs);

--- a/test/CommandLineUtils.Tests/HelpOptionAttributeTests.cs
+++ b/test/CommandLineUtils.Tests/HelpOptionAttributeTests.cs
@@ -174,7 +174,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             var outData = sb.ToString();
 
             Assert.True(app.OptionHelp.HasValue());
-            Assert.Contains("Usage: lvl1 lvl2 [arguments] [options]", outData);
+            Assert.Contains("Usage: lvl1 lvl2 [options] <lvl-arg>", outData);
         }
 
         [Theory]


### PR DESCRIPTION
Fix issue #223 

This doesn't go quite as far as I'd like, in that the USAGE doesn't clearly state which arguments are required and which are not, I didn't see an easy way to do it.