### PR TITLE
feat: support hierarchical option/argument names (#233)

### DIFF
--- a/test/CommandLineUtils.Tests/CommandOptionTests.cs
+++ b/test/CommandLineUtils.Tests/CommandOptionTests.cs
@@ -26,6 +26,9 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         [InlineData("--name=<VALUE>", null, null, "name", "VALUE")]
         [InlineData("-a:<VALUE> --name:<VALUE>", "a", null, "name", "VALUE")]
         [InlineData("-a=<VALUE> --name=<VALUE>", "a", null, "name", "VALUE")]
+        [InlineData("--nested:option <test>", null, null, "nested:option", "test")]
+        [InlineData("--nested:option:<test>", null, null, "nested:option", "test")]
+        [InlineData("-n|--nested:option:<test>", "n", null, "nested:option", "test")]
         public void ItParsesSingleValueTemplate(string template, string shortName, string symbolName, string longName, string valueName)
         {
             var opt = new CommandOption(template, CommandOptionType.SingleValue);

--- a/test/CommandLineUtils.Tests/ValueParserProviderTests.cs
+++ b/test/CommandLineUtils.Tests/ValueParserProviderTests.cs
@@ -110,6 +110,9 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
 
             [Option("--timespan")]
             public TimeSpan TimeSpan { get; }
+
+            [Option("--nested:option:<VALUE>")]
+            public string NestedOption { get; }
         }
 
         private sealed class InCulture : IDisposable
@@ -372,6 +375,18 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             var parsed = CommandLineParser.ParseArgs<Program>(input);
             Assert.True(parsed.ValueTuple.HasValue);
             Assert.Equal(expected, parsed.ValueTuple.Value);
+        }
+
+        [Theory]
+        [InlineData(new string[] { "--nested:option", "value" }, "value")]
+        [InlineData(new string[] { "--nested:option=value" }, "value")]
+        [InlineData(new string[] { "--nested:option:value" }, "value")]
+        [InlineData(new string[] { "--nested:option:" }, "")]
+        [InlineData(new string[] { "--nested:option: " }, " ")]
+        public void ParsesHierarchicalName(string[] input, string expected)
+        {
+            var parsed = CommandLineParser.ParseArgs<Program>(input);
+            Assert.Equal(expected, parsed.NestedOption);
         }
 
         [Theory]


### PR DESCRIPTION
The idea is to support `--nested:option:<value>` since this is the way hierarchical configuration is normalized into key/value pairs with Microsoft.Extensions.Configuration.

I took me a while to get around to it,  Instead of going with customizable splitting characters, I've decided to try and make it work such that ':' are only split on the last one.

With regards to templates, I was able to achieve this based on the last ':' needing to be followed by '<'

For parsing arguments, there is no '<' or '>' delimiters so it now checks against the known options.

I'm hoping this is a better solution than customizable separators