### PR TITLE
feat: support C# 8 and nullable reference types

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,32 +18,32 @@ indent_size = 2
 indent_size                                                            = 4
 
 # Style I care about
-csharp_style_expression_bodied_constructors                            = false : error
-csharp_prefer_braces                                                   = true : error
-dotnet_sort_system_directives_first                                    = true : error
+csharp_style_expression_bodied_constructors                            = false
+csharp_prefer_braces                                                   = true
+dotnet_sort_system_directives_first                                    = true
 
 # Stuff that is usually best
-csharp_style_inlined_variable_declaration                              = true : warning
-csharp_style_var_elsewhere                                             = true : warning
-csharp_space_after_cast                                                = true : warning
-csharp_style_pattern_matching_over_as_with_null_check                  = true : warning
-csharp_style_pattern_matching_over_is_with_cast_check                  = true : warning
-csharp_style_var_for_built_in_types                                    = true : warning
-csharp_style_var_when_type_is_apparent                                 = true : warning
-csharp_new_line_before_catch                                           = true : warning
-csharp_new_line_before_else                                            = true : warning
-csharp_new_line_before_finally                                         = true : warning
-csharp_indent_case_contents                                            = true : warning
+csharp_style_inlined_variable_declaration                              = true
+csharp_style_var_elsewhere                                             = true
+csharp_space_after_cast                                                = true
+csharp_style_pattern_matching_over_as_with_null_check                  = true
+csharp_style_pattern_matching_over_is_with_cast_check                  = true
+csharp_style_var_for_built_in_types                                    = true
+csharp_style_var_when_type_is_apparent                                 = true
+csharp_new_line_before_catch                                           = true
+csharp_new_line_before_else                                            = true
+csharp_new_line_before_finally                                         = true
+csharp_indent_case_contents                                            = true
 csharp_new_line_before_open_brace                                      = all
-csharp_indent_switch_labels                                            = true : warning
+csharp_indent_switch_labels                                            = true
 csharp_indent_labels                                                   = one_less_than_current
-csharp_prefer_simple_default_expression                                = true : warning
+csharp_prefer_simple_default_expression                                = true
 
 # Good defaults, but not always
-dotnet_style_object_initializer                                        = true : suggestion
-csharp_style_expression_bodied_indexers                                = true : suggestion
-csharp_style_expression_bodied_accessors                               = true : suggestion
-csharp_style_throw_expression                                          = true : suggestion
+dotnet_style_object_initializer                                        = true
+csharp_style_expression_bodied_indexers                                = true
+csharp_style_expression_bodied_accessors                               = true
+csharp_style_throw_expression                                          = true
 
 # Naming styles
 

--- a/CommandLineUtils.sln
+++ b/CommandLineUtils.sln
@@ -1,8 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2026
-MinimumVisualStudioVersion = 15.0.26124.0
+# Visual Studio 16
+VisualStudioVersion = 16.0.0.0
+MinimumVisualStudioVersion = 16.0.0.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{95D4B35E-0A21-4D64-8BAF-27DD6C019FC5}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "McMaster.Extensions.CommandLineUtils", "src\CommandLineUtils\McMaster.Extensions.CommandLineUtils.csproj", "{CBCFAFF3-A3B1-4C41-B2D1-092BF7307A4E}"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,7 +22,10 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <PackageIconUrl>https://natemcmaster.github.io/CommandLineUtils/logo.png</PackageIconUrl>
     <NoPackageAnalysis>true</NoPackageAnalysis>
-    <LangVersion>7.2</LangVersion>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <!-- Some previews of .NET Core 3 don't have the rename yet -->
+    <NullableContextOptions>enable</NullableContextOptions>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)src\StrongName.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <AzureKeyVaultUrl>https://nmcmaster.vault.azure.net</AzureKeyVaultUrl>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -31,7 +31,7 @@
     <CodeSignCertName>DigiCertCodeSign</CodeSignCertName>
 
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <GenerateFullPaths Condition="'$(VSCODE_CWD)' != ''">true</GenerateFullPaths>
+    <GenerateFullPaths Condition="'$(TERM_PROGRAM)' == 'vscode'">true</GenerateFullPaths>
     <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory).build\obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
     <BaseOutputPath>$(MSBuildThisFileDirectory).build\bin\$(MSBuildProjectName)\</BaseOutputPath>
   </PropertyGroup>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ variables:
 jobs:
 - job: Windows
   pool:
-    vmImage: vs2017-win2016
+    vmImage: windows-2019
   steps:
   - task: UseDotNet@2
     displayName: Install .NET Core 3 SDK

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,10 +19,11 @@ jobs:
     vmImage: vs2017-win2016
   steps:
   - task: UseDotNet@2
-    displayName: Install .NET Core 3.0 SDK
+    displayName: Install .NET Core 3 SDK
     inputs:
-      version: '3.0.x'
+      version: '3.x'
       packageType: sdk
+      includePreviewVersions: true
   - task: UseDotNet@2
     displayName: Install .NET Core 2.2 runtime
     inputs:
@@ -54,10 +55,11 @@ jobs:
     vmImage: 'Ubuntu-16.04'
   steps:
   - task: UseDotNet@2
-    displayName: Install .NET Core 3.0 SDK
+    displayName: Install .NET Core 3 SDK
     inputs:
-      version: '3.0.x'
+      version: '3.x'
       packageType: sdk
+      includePreviewVersions: true
   - task: UseDotNet@2
     displayName: Install .NET Core 2.2 runtime
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,10 +18,16 @@ jobs:
   pool:
     vmImage: vs2017-win2016
   steps:
-  - task: DotNetCoreInstaller@0
-    displayName: Install .NET Core 2.2
+  - task: UseDotNet@2
+    displayName: Install .NET Core 3.0 SDK
     inputs:
-      version: '2.2.102'
+      version: '3.0.x'
+      packageType: sdk
+  - task: UseDotNet@2
+    displayName: Install .NET Core 2.2 runtime
+    inputs:
+      version: '2.2.x'
+      packageType: runtime
   - powershell: ./build.ps1 -ci
     displayName: Invoke build.ps1
     condition: eq(variables['kv-access-token'], '')
@@ -47,10 +53,16 @@ jobs:
   pool:
     vmImage: 'Ubuntu-16.04'
   steps:
-  - task: DotNetCoreInstaller@0
-    displayName: Install .NET Core 2.2
+  - task: UseDotNet@2
+    displayName: Install .NET Core 3.0 SDK
     inputs:
-      version: '2.2.102'
+      version: '3.0.x'
+      packageType: sdk
+  - task: UseDotNet@2
+    displayName: Install .NET Core 2.2 runtime
+    inputs:
+      version: '2.2.x'
+      packageType: runtime
   - script: ./build.ps1 -ci
     displayName: Invoke build.ps1
   - task: PublishTestResults@2

--- a/docs/generate.ps1
+++ b/docs/generate.ps1
@@ -24,7 +24,7 @@ try {
         exec git worktree add $targetDir gh-pages 2>&1 | out-null
     }
 
-    $docfxVersion = '2.40.5'
+    $docfxVersion = '2.43.1'
     $docfxRoot = "$buildRoot/packages/docfx.console/$docfxVersion"
     $docfx = "$docfxRoot/tools/docfx.exe"
     if (-not (Test-Path $docfx)) {

--- a/docs/samples/Directory.Build.props
+++ b/docs/samples/Directory.Build.props
@@ -1,0 +1,11 @@
+<Project>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
+
+  <PropertyGroup>
+    <!-- Set samples to use the latest stable C# until C# 8 is released -->
+    <LangVersion>7.3</LangVersion>
+    <Nullable />
+    <NullableContextOptions />
+  </PropertyGroup>
+
+</Project>

--- a/src/CommandLineUtils/Abstractions/IValueParser.cs
+++ b/src/CommandLineUtils/Abstractions/IValueParser.cs
@@ -24,6 +24,6 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
         /// <param name="culture">The culture that should be used to parse values.</param>
         /// <returns>The parsed value object.</returns>
         /// <throws name="System.FormatException">When the value cannot be parsed.</throws>
-        object Parse(string argName, string value, CultureInfo culture);
+        object Parse(string? argName, string? value, CultureInfo culture);
     }
 }

--- a/src/CommandLineUtils/Abstractions/IValueParser.cs
+++ b/src/CommandLineUtils/Abstractions/IValueParser.cs
@@ -24,6 +24,6 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
         /// <param name="culture">The culture that should be used to parse values.</param>
         /// <returns>The parsed value object.</returns>
         /// <throws name="System.FormatException">When the value cannot be parsed.</throws>
-        object Parse(string? argName, string? value, CultureInfo culture);
+        object? Parse(string? argName, string? value, CultureInfo culture);
     }
 }

--- a/src/CommandLineUtils/Abstractions/IValueParser{T}.cs
+++ b/src/CommandLineUtils/Abstractions/IValueParser{T}.cs
@@ -18,6 +18,6 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
         /// <param name="culture">The culture that should be used to parse values.</param>
         /// <returns>The parsed value object.</returns>
         /// <throws name="System.FormatException">When the value cannot be parsed.</throws>
-        new T Parse(string argName, string value, CultureInfo culture);
+        new T Parse(string? argName, string? value, CultureInfo culture);
     }
 }

--- a/src/CommandLineUtils/Abstractions/ParseResult.cs
+++ b/src/CommandLineUtils/Abstractions/ParseResult.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.ComponentModel;
 
 namespace McMaster.Extensions.CommandLineUtils.Abstractions
 {
@@ -25,6 +26,7 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
         /// The recommended replacement is <see cref="ParseResult(CommandLineApplication)" />
         /// </summary>
         [Obsolete("This constructor is obsolete and will be removed in a future version. The recommended replacement is ctor(CommandLineApplication selectedCommand)")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public ParseResult()
         {
         }

--- a/src/CommandLineUtils/Abstractions/ParseResult.cs
+++ b/src/CommandLineUtils/Abstractions/ParseResult.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Nate McMaster.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace McMaster.Extensions.CommandLineUtils.Abstractions
 {
     /// <summary>
@@ -8,6 +10,26 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
     /// </summary>
     public class ParseResult
     {
+        /// <summary>
+        /// Initializes <see cref="ParseResult"/>.
+        /// </summary>
+        /// <param name="selectedCommand">The command selected for execution.</param>
+        public ParseResult(CommandLineApplication selectedCommand)
+        {
+            SelectedCommand = selectedCommand ?? throw new ArgumentNullException(nameof(selectedCommand));
+        }
+
+#pragma warning disable CS8618 // Non-nullable field is uninitialized.
+        /// <summary>
+        /// This constructor is obsolete and will be removed in a future version.
+        /// The recommended replacement is <see cref="ParseResult(CommandLineApplication)" />
+        /// </summary>
+        [Obsolete("This constructor is obsolete and will be removed in a future version. The recommended replacement is ctor(CommandLineApplication selectedCommand)")]
+        public ParseResult()
+        {
+        }
+#pragma warning restore CS8618 // Non-nullable field is uninitialized.
+
         /// <summary>
         /// The application or subcommand that matches the command line arguments.
         /// </summary>

--- a/src/CommandLineUtils/Abstractions/ValueParserProvider.cs
+++ b/src/CommandLineUtils/Abstractions/ValueParserProvider.cs
@@ -71,7 +71,7 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
         /// </remarks>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        public IValueParser<T> GetParser<T>()
+        public IValueParser<T>? GetParser<T>()
         {
             var parser = GetParserImpl<T>();
             if (parser == null)
@@ -87,7 +87,7 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
             return new GenericParserAdapter<T>(parser);
         }
 
-        internal IValueParser GetParserImpl<T>()
+        internal IValueParser? GetParserImpl<T>()
         {
             var type = typeof(T);
             if (_parsers.TryGetValue(type, out var parser))
@@ -219,7 +219,7 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
 
         private sealed class GenericParserAdapter<T> : IValueParser<T>
         {
-            private IValueParser _inner;
+            private readonly IValueParser _inner;
 
             public GenericParserAdapter(IValueParser inner)
             {

--- a/src/CommandLineUtils/Abstractions/ValueParserProvider.cs
+++ b/src/CommandLineUtils/Abstractions/ValueParserProvider.cs
@@ -102,7 +102,7 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
                 return EnumParser.Create(type);
             }
 
-            if (ReflectionHelper.IsNullableType(typeInfo, out var wrappedType))
+            if (ReflectionHelper.IsNullableType(typeInfo, out var wrappedType) && wrappedType != null)
             {
                 if (wrappedType.GetTypeInfo().IsEnum)
                 {
@@ -187,7 +187,7 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
                 throw new ArgumentNullException(nameof(parser));
             }
 
-            var targetType = parser.TargetType;
+            Type targetType = parser.TargetType;
 
             if (targetType == null)
             {
@@ -197,7 +197,7 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
             }
 
             // strip nullable wrappers since we have a dedicated nullable value parser
-            targetType = ReflectionHelper.IsNullableType(targetType.GetTypeInfo(), out var wrappedType)
+            targetType = ReflectionHelper.IsNullableType(targetType.GetTypeInfo(), out var wrappedType) && wrappedType != null
                 ? wrappedType
                 : targetType;
 
@@ -228,9 +228,9 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
 
             public Type TargetType => _inner.TargetType;
 
-            public T Parse(string argName, string value, CultureInfo culture) => (T)_inner.Parse(argName, value, culture);
+            public T Parse(string? argName, string? value, CultureInfo culture) => (T)_inner.Parse(argName, value, culture)!;
 
-            object IValueParser.Parse(string argName, string value, CultureInfo culture) => _inner.Parse(argName, value, culture);
+            object? IValueParser.Parse(string? argName, string? value, CultureInfo culture) => _inner.Parse(argName, value, culture);
         }
     }
 }

--- a/src/CommandLineUtils/Attributes/ArgumentAttribute.cs
+++ b/src/CommandLineUtils/Attributes/ArgumentAttribute.cs
@@ -27,7 +27,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// </summary>
         /// <param name="order">The order</param>
         /// <param name="name">The name</param>
-        public ArgumentAttribute(int order, string name)
+        public ArgumentAttribute(int order, string? name)
             : this(order, name, null)
         { }
 
@@ -37,7 +37,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="order">The order</param>
         /// <param name="name">The name</param>
         /// <param name="description">The description</param>
-        public ArgumentAttribute(int order, string name, string description)
+        public ArgumentAttribute(int order, string? name, string? description)
         {
             Order = order;
             Name = name;
@@ -52,7 +52,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <summary>
         /// The name of the argument. <seealso cref="CommandArgument.Name"/>.
         /// </summary>
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         /// <summary>
         /// Determines if the argument appears in the generated help-text.  <seealso cref="CommandArgument.ShowInHelpText"/>.
@@ -62,7 +62,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <summary>
         /// A description of the argument.  <seealso cref="CommandArgument.Description"/>.
         /// </summary>
-        public string Description { get; set; }
+        public string? Description { get; set; }
 
         internal CommandArgument Configure(PropertyInfo prop)
         {

--- a/src/CommandLineUtils/Attributes/CommandAttribute.cs
+++ b/src/CommandLineUtils/Attributes/CommandAttribute.cs
@@ -44,10 +44,20 @@ namespace McMaster.Extensions.CommandLineUtils
         /// The name of the command line application. When this is a subcommand, it is the name of the word used to invoke the subcommand.
         /// <seealso cref="CommandLineApplication.Name" />
         /// </summary>
-        public string Name
+        public string? Name
         {
             get => _names.Length > 0 ? _names[0] : null;
-            set => _names = new[] { value };
+            set
+            {
+                if (value != null)
+                {
+                    _names = new[] { value };
+                }
+                else
+                {
+                    _names = Util.EmptyArray<string>();
+                }
+            }
         }
 
         /// <summary>
@@ -58,12 +68,12 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <summary>
         /// The full name of the command line application to show in help text. <seealso cref="CommandLineApplication.FullName" />
         /// </summary>
-        public string FullName { get; set; }
+        public string? FullName { get; set; }
 
         /// <summary>
         /// A description of the command. <seealso cref="CommandLineApplication.Description"/>
         /// </summary>
-        public string Description { get; set; }
+        public string? Description { get; set; }
 
         /// <summary>
         /// Determines if this command appears in generated help text. <seealso cref="CommandLineApplication.ShowInHelpText"/>
@@ -73,7 +83,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <summary>
         /// Additional text that appears at the bottom of generated help text. <seealso cref="CommandLineApplication.ExtendedHelpText"/>
         /// </summary>
-        public string ExtendedHelpText { get; set; }
+        public string? ExtendedHelpText { get; set; }
 
         /// <summary>
         /// Throw when unexpected arguments are encountered. <seealso cref="CommandLineApplication.ThrowOnUnexpectedArgument"/>

--- a/src/CommandLineUtils/Attributes/HelpOptionAttribute.cs
+++ b/src/CommandLineUtils/Attributes/HelpOptionAttribute.cs
@@ -29,6 +29,11 @@ namespace McMaster.Extensions.CommandLineUtils
             Description = Strings.DefaultHelpOptionDescription;
         }
 
+        /// <summary>
+        /// The option template. This is parsed into the short and long name.
+        /// </summary>
+        public new string Template { get; set; }
+
         internal CommandOption Configure(CommandLineApplication app)
         {
             var opt = app.HelpOption(Template);

--- a/src/CommandLineUtils/Attributes/OptionAttribute.cs
+++ b/src/CommandLineUtils/Attributes/OptionAttribute.cs
@@ -53,7 +53,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="template">The template</param>
         /// <param name="description">The option description</param>
         /// <param name="optionType">The option type</param>
-        public OptionAttribute(string template, string description, CommandOptionType optionType)
+        public OptionAttribute(string? template, string? description, CommandOptionType optionType)
         {
             Template = template;
             Description = description;

--- a/src/CommandLineUtils/Attributes/OptionAttributeBase.cs
+++ b/src/CommandLineUtils/Attributes/OptionAttributeBase.cs
@@ -13,33 +13,33 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <summary>
         /// The option template. This is parsed into the short and long name.
         /// </summary>
-        public string Template { get; set; }
+        public string? Template { get; set; }
 
         /// <summary>
         /// The short command line flag used to identify this option. On command line, this is preceeded by a single '-{ShortName}'.
         /// </summary>
-        public string ShortName { get; set; }
+        public string? ShortName { get; set; }
 
         /// <summary>
         /// The long command line flag used to identify this option. On command line, this is preceeded by a double dash: '--{LongName}'.
         /// </summary>
-        public string LongName { get; set; }
+        public string? LongName { get; set; }
 
         /// <summary>
         /// Can be used in addition to <see cref="ShortName"/> to add a single, non-English character.
         /// Example "-?".
         /// </summary>
-        public string SymbolName { get; set; }
+        public string? SymbolName { get; set; }
 
         /// <summary>
         /// The name of value(s) shown in help text when OptionType is not <see cref="CommandOptionType.NoValue"/>.
         /// </summary>
-        public string ValueName { get; set; }
+        public string? ValueName { get; set; }
 
         /// <summary>
         /// A description of this option to show in generated help text. <seealso cref="CommandOption.Description"/>.
         /// </summary>
-        public string Description { get; set; }
+        public string? Description { get; set; }
 
         /// <summary>
         /// Determines if this option should be shown in generated help text. <seealso cref="CommandOption.ShowInHelpText"/>.

--- a/src/CommandLineUtils/Attributes/SubcommandAttribute.cs
+++ b/src/CommandLineUtils/Attributes/SubcommandAttribute.cs
@@ -26,6 +26,7 @@ namespace McMaster.Extensions.CommandLineUtils
         public SubcommandAttribute(string name, Type commandType)
         {
             CommandType = commandType;
+            Types = new[] { commandType };
             Name = name;
         }
 
@@ -63,7 +64,7 @@ namespace McMaster.Extensions.CommandLineUtils
         [Obsolete("This property is obsolete and will be removed in a future version. " +
                   "The recommended replacement is to use CommandAttribute to set names for subcommands.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         /// <summary>
         /// This property is obsolete and will be replaced in a future version.
@@ -77,7 +78,7 @@ namespace McMaster.Extensions.CommandLineUtils
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Type CommandType
         {
-            get => Types.Length > 0 ? Types[0] : null;
+            get => Types[0];
             set
             {
                 if (value == null)

--- a/src/CommandLineUtils/Attributes/VersionOptionAttribute.cs
+++ b/src/CommandLineUtils/Attributes/VersionOptionAttribute.cs
@@ -37,6 +37,11 @@ namespace McMaster.Extensions.CommandLineUtils
         /// </summary>
         public string Version { get; set; }
 
+        /// <summary>
+        /// The option template. This is parsed into the short and long name.
+        /// </summary>
+        public new string Template { get; set; }
+
         internal CommandOption Configure(CommandLineApplication app)
         {
             var opt = app.VersionOption(Template, Version);

--- a/src/CommandLineUtils/Attributes/VersionOptionFromMemberAttribute.cs
+++ b/src/CommandLineUtils/Attributes/VersionOptionFromMemberAttribute.cs
@@ -32,12 +32,17 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <summary>
         /// The name of the property or method that returns short version information.
         /// </summary>
-        public string MemberName { get; set; }
+        public string? MemberName { get; set; }
+
+        /// <summary>
+        /// The option template. This is parsed into the short and long name.
+        /// </summary>
+        public new string Template { get; set; }
 
         internal CommandOption Configure(CommandLineApplication app, Type type, Func<object> targetInstanceFactory)
         {
-            Func<string> shortFormGetter = null;
-            Func<string> longFormGetter = null;
+            Func<string>? shortFormGetter = null;
+            Func<string>? longFormGetter = null;
 
             if (MemberName != null)
             {
@@ -55,7 +60,7 @@ namespace McMaster.Extensions.CommandLineUtils
 
                 shortFormGetter = () =>
                 {
-                    return methods[0].Invoke(targetInstanceFactory?.Invoke(), Util.EmptyArray<object>()) as string;
+                    return (string)methods[0].Invoke(targetInstanceFactory.Invoke(), Util.EmptyArray<object>());
                 };
             }
 

--- a/src/CommandLineUtils/CommandArgument.cs
+++ b/src/CommandLineUtils/CommandArgument.cs
@@ -21,13 +21,13 @@ namespace McMaster.Extensions.CommandLineUtils
         /// </summary>
         public CommandArgument()
         {
-            Values = new List<string>();
+            Values = new List<string?>();
         }
 
         /// <summary>
         /// The name of the argument.
         /// </summary>
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         /// <summary>
         /// Determines if the argument appears in the generated help-text.
@@ -37,12 +37,12 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <summary>
         /// A description of the argument.
         /// </summary>
-        public string Description { get; set; }
+        public string? Description { get; set; }
 
         /// <summary>
         /// All values specified, if any.
         /// </summary>
-        public List<string> Values { get; private set; }
+        public List<string?> Values { get; private set; }
 
         /// <summary>
         /// Allow multiple values.
@@ -52,7 +52,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <summary>
         /// The first value from <see cref="Values"/>, if any.
         /// </summary>
-        public string Value => Values.FirstOrDefault();
+        public string? Value => Values.FirstOrDefault();
 
         /// <summary>
         /// A collection of validators that execute before invoking <see cref="CommandLineApplication.OnExecute(Func{int})"/>.

--- a/src/CommandLineUtils/CommandLineApplication.Validation.cs
+++ b/src/CommandLineUtils/CommandLineApplication.Validation.cs
@@ -80,7 +80,7 @@ namespace McMaster.Extensions.CommandLineUtils
             {
                 var context = factory.Create(option);
 
-                string name = null;
+                string? name = null;
                 if (option.LongName != null)
                 {
                     name = "--" + option.LongName;

--- a/src/CommandLineUtils/CommandLineApplicationExtensions.cs
+++ b/src/CommandLineUtils/CommandLineApplicationExtensions.cs
@@ -169,7 +169,7 @@ namespace McMaster.Extensions.CommandLineUtils
         public static CommandOption VersionOptionFromAssemblyAttributes(CommandLineApplication app, string template, Assembly assembly)
             => app.VersionOption(template, GetInformationalVersion(assembly));
 
-        private static string GetInformationalVersion(Assembly assembly)
+        private static string? GetInformationalVersion(Assembly assembly)
         {
             var infoVersion = assembly
                 ?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()

--- a/src/CommandLineUtils/CommandLineApplication{T}.cs
+++ b/src/CommandLineUtils/CommandLineApplication{T}.cs
@@ -18,6 +18,7 @@ namespace McMaster.Extensions.CommandLineUtils
         private Lazy<TModel> _lazy;
         private Func<TModel> _modelFactory = DefaultModelFactory;
 
+#nullable disable
         /// <summary>
         /// Initializes a new instance of <see cref="CommandLineApplication"/>.
         /// </summary>
@@ -68,6 +69,7 @@ namespace McMaster.Extensions.CommandLineUtils
         {
             Initialize();
         }
+#nullable enable
 
         private void Initialize()
         {

--- a/src/CommandLineUtils/CommandOption.cs
+++ b/src/CommandLineUtils/CommandOption.cs
@@ -83,38 +83,38 @@ namespace McMaster.Extensions.CommandLineUtils
         /// </summary>
         [Obsolete("This property is obsolete and will be removed in a future version.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public string Template { get; set; }
+        public string? Template { get; set; }
 
         /// <summary>
         /// The short command line flag used to identify this option. On command line, this is preceeded by a single '-{ShortName}'.
         /// </summary>
-        public string ShortName { get; set; }
+        public string? ShortName { get; set; }
 
         /// <summary>
         /// The long command line flag used to identify this option. On command line, this is preceeded by a double dash: '--{LongName}'.
         /// </summary>
-        public string LongName { get; set; }
+        public string? LongName { get; set; }
 
         /// <summary>
         /// Can be used in addition to <see cref="ShortName"/> to add a single, non-English character.
         /// Example "-?".
         /// </summary>
-        public string SymbolName { get; set; }
+        public string? SymbolName { get; set; }
 
         /// <summary>
         /// The name of value(s) shown in help text when <see cref="OptionType"/> is not <see cref="CommandOptionType.NoValue"/>.
         /// </summary>
-        public string ValueName { get; set; }
+        public string? ValueName { get; set; }
 
         /// <summary>
         /// A description of this option to show in generated help text.
         /// </summary>
-        public string Description { get; set; }
+        public string? Description { get; set; }
 
         /// <summary>
         /// Any values found during parsing, if any.
         /// </summary>
-        public List<string> Values { get; } = new List<string>();
+        public List<string?> Values { get; } = new List<string?>();
 
         /// <summary>
         /// Defines the type of the option.
@@ -143,7 +143,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
-        public bool TryParse(string value)
+        public bool TryParse(string? value)
         {
             switch (OptionType)
             {
@@ -187,7 +187,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// Returns the first element of <see cref="Values"/>, if any.
         /// </summary>
         /// <returns></returns>
-        public string Value()
+        public string? Value()
         {
             return HasValue() ? Values[0] : null;
         }

--- a/src/CommandLineUtils/Conventions/ConstructorInjectionConvention.cs
+++ b/src/CommandLineUtils/Conventions/ConstructorInjectionConvention.cs
@@ -13,7 +13,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
     /// </summary>
     public class ConstructorInjectionConvention : IConvention
     {
-        private readonly IServiceProvider _additionalServices;
+        private readonly IServiceProvider? _additionalServices;
 
         /// <summary>
         /// Initializes an instance of <see cref="ConstructorInjectionConvention" />.
@@ -66,7 +66,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
             }
         }
 
-        private static Func<TModel> FindMatchedConstructor<TModel>(
+        private static Func<TModel>? FindMatchedConstructor<TModel>(
             ConstructorInfo[] constructors,
             IServiceProvider services,
             bool throwIfNoParameterTypeRegistered = false)

--- a/src/CommandLineUtils/Conventions/ConventionContext.cs
+++ b/src/CommandLineUtils/Conventions/ConventionContext.cs
@@ -16,7 +16,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
         /// </summary>
         /// <param name="application">The application</param>
         /// <param name="modelType">The type of the model.</param>
-        public ConventionContext(CommandLineApplication application, Type modelType)
+        public ConventionContext(CommandLineApplication application, Type? modelType)
         {
             Application = application ?? throw new ArgumentNullException(nameof(application));
             ModelType = modelType;
@@ -31,7 +31,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
         /// The type of the application model. Can be null when applied to <see cref="CommandLineApplication" />
         /// instead of <see cref="CommandLineApplication{TModel}" />.
         /// </summary>
-        public Type ModelType { get; private set; }
+        public Type? ModelType { get; private set; }
 
         /// <summary>
         /// A convenience accessor for getting the application model object.

--- a/src/CommandLineUtils/Conventions/ConventionContext.cs
+++ b/src/CommandLineUtils/Conventions/ConventionContext.cs
@@ -38,6 +38,6 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
         /// Can be null when applied to <see cref="CommandLineApplication" /> instead of
         /// <see cref="CommandLineApplication{TModel}" />.
         /// </summary>
-        public IModelAccessor ModelAccessor => Application as IModelAccessor;
+        public IModelAccessor? ModelAccessor => Application as IModelAccessor;
     }
 }

--- a/src/CommandLineUtils/Conventions/ExecuteMethodConvention.cs
+++ b/src/CommandLineUtils/Conventions/ExecuteMethodConvention.cs
@@ -5,6 +5,7 @@ using System;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
+using McMaster.Extensions.CommandLineUtils.Abstractions;
 
 namespace McMaster.Extensions.CommandLineUtils.Conventions
 {
@@ -31,8 +32,8 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
             const BindingFlags binding = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
 
             var typeInfo = context.ModelType.GetTypeInfo();
-            MethodInfo method;
-            MethodInfo asyncMethod;
+            MethodInfo? method;
+            MethodInfo? asyncMethod;
             try
             {
                 method = typeInfo.GetMethod("OnExecute", binding);
@@ -56,7 +57,12 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
             }
 
             var arguments = ReflectionHelper.BindParameters(method, context.Application);
-            var model = context.ModelAccessor.GetModel();
+            var modelAccessor = context.ModelAccessor;
+            if (modelAccessor == null)
+            {
+                throw new InvalidOperationException(Strings.ConventionRequiresModel);
+            }
+            var model = modelAccessor.GetModel();
 
             if (method.ReturnType == typeof(Task) || method.ReturnType == typeof(Task<int>))
             {

--- a/src/CommandLineUtils/Conventions/HelpOptionAttributeConvention.cs
+++ b/src/CommandLineUtils/Conventions/HelpOptionAttributeConvention.cs
@@ -25,8 +25,8 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
 
             var props = ReflectionHelper.GetProperties(context.ModelType);
 
-            HelpOptionAttribute helpOptionAttr = null;
-            PropertyInfo property = null;
+            HelpOptionAttribute? helpOptionAttr = null;
+            PropertyInfo? property = null;
 
             foreach (var prop in props)
             {
@@ -54,7 +54,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                 EnsureDoesNotHaveArgumentAttribute(prop);
             }
 
-            if (helpOptionAttr == null)
+            if (helpOptionAttr == null || property == null)
             {
                 return;
             }

--- a/src/CommandLineUtils/Conventions/OptionAttributeConventionBase.cs
+++ b/src/CommandLineUtils/Conventions/OptionAttributeConventionBase.cs
@@ -18,6 +18,12 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
     {
         private protected void AddOption(ConventionContext context, CommandOption option, PropertyInfo prop)
         {
+            var modelAccessor = context.ModelAccessor;
+            if (modelAccessor == null)
+            {
+                throw new InvalidOperationException(Strings.ConventionRequiresModel);
+            }
+
             foreach (var attr in prop.GetCustomAttributes().OfType<ValidationAttribute>())
             {
                 option.Validators.Add(new AttributeValidator(attr));
@@ -67,7 +73,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                         {
                             return;
                         }
-                        setter.Invoke(context.ModelAccessor.GetModel(), collectionParser.Parse(option.LongName, option.Values));
+                        setter.Invoke(modelAccessor.GetModel(), collectionParser.Parse(option.LongName, option.Values));
                     });
                     break;
                 case CommandOptionType.SingleOrNoValue:
@@ -83,7 +89,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                         {
                             return;
                         }
-                        setter.Invoke(context.ModelAccessor.GetModel(), parser.Parse(option.LongName, option.Value(), context.Application.ValueParsers.ParseCulture));
+                        setter.Invoke(modelAccessor.GetModel(), parser.Parse(option.LongName, option.Value(), context.Application.ValueParsers.ParseCulture));
                     });
                     break;
                 case CommandOptionType.NoValue:
@@ -93,7 +99,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                         {
                             if (!option.HasValue())
                             {
-                                setter.Invoke(context.ModelAccessor.GetModel(), Util.EmptyArray<bool>());
+                                setter.Invoke(modelAccessor.GetModel(), Util.EmptyArray<bool>());
                             }
 
                             var count = new bool[option.Values.Count];
@@ -101,8 +107,8 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                             {
                                 count[i] = true;
                             }
-                            
-                            setter.Invoke(context.ModelAccessor.GetModel(), count);
+
+                            setter.Invoke(modelAccessor.GetModel(), count);
                         }
                         else
                         {
@@ -111,7 +117,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                                 return;
                             }
 
-                            setter.Invoke(context.ModelAccessor.GetModel(), option.HasValue());
+                            setter.Invoke(modelAccessor.GetModel(), option.HasValue());
                         }
                     });
                     break;

--- a/src/CommandLineUtils/Conventions/ParentPropertyConvention.cs
+++ b/src/CommandLineUtils/Conventions/ParentPropertyConvention.cs
@@ -15,7 +15,8 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
         /// <inheritdoc />
         public virtual void Apply(ConventionContext context)
         {
-            if (context.ModelType == null)
+            var modelAccessor = context.ModelAccessor;
+            if (context.ModelType == null || modelAccessor == null)
             {
                 return;
             }
@@ -29,14 +30,14 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
             var setter = ReflectionHelper.GetPropertySetter(parentProp);
             context.Application.OnParsingComplete(r =>
             {
-                var subcommand = r.SelectedCommand;
+                CommandLineApplication? subcommand = r.SelectedCommand;
                 while (subcommand != null)
                 {
                     if (ReferenceEquals(context.Application, subcommand))
                     {
                         if (subcommand.Parent is IModelAccessor parentAccessor)
                         {
-                            setter(context.ModelAccessor.GetModel(), parentAccessor.GetModel());
+                            setter(modelAccessor.GetModel(), parentAccessor.GetModel());
                         }
                         return;
                     }

--- a/src/CommandLineUtils/Conventions/RemainingArgsPropertyConvention.cs
+++ b/src/CommandLineUtils/Conventions/RemainingArgsPropertyConvention.cs
@@ -20,7 +20,8 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
         /// <inheritdoc />
         public virtual void Apply(ConventionContext context)
         {
-            if (context.ModelType == null)
+            var modelAccessor = context.ModelAccessor;
+            if (context.ModelType == null || modelAccessor == null)
             {
                 return;
             }
@@ -38,7 +39,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
             if (prop.PropertyType == typeof(string[]))
             {
                 context.Application.OnParsingComplete(r =>
-                    setter(context.ModelAccessor.GetModel(), r.SelectedCommand.RemainingArguments.ToArray()));
+                    setter(modelAccessor.GetModel(), r.SelectedCommand.RemainingArguments.ToArray()));
                 return;
             }
 
@@ -48,7 +49,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
             }
 
             context.Application.OnParsingComplete(r =>
-                setter(context.ModelAccessor.GetModel(), r.SelectedCommand.RemainingArguments));
+                setter(modelAccessor.GetModel(), r.SelectedCommand.RemainingArguments));
         }
     }
 }

--- a/src/CommandLineUtils/Conventions/SubcommandAttributeConvention.cs
+++ b/src/CommandLineUtils/Conventions/SubcommandAttributeConvention.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Nate McMaster.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using McMaster.Extensions.CommandLineUtils.Abstractions;
-using McMaster.Extensions.CommandLineUtils.Errors;
 using System;
 using System.Linq;
 using System.Reflection;
+using McMaster.Extensions.CommandLineUtils.Abstractions;
+using McMaster.Extensions.CommandLineUtils.Errors;
 
 namespace McMaster.Extensions.CommandLineUtils.Conventions
 {

--- a/src/CommandLineUtils/Conventions/SubcommandAttributeConvention.cs
+++ b/src/CommandLineUtils/Conventions/SubcommandAttributeConvention.cs
@@ -18,7 +18,8 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
         /// <inheritdoc />
         public virtual void Apply(ConventionContext context)
         {
-            if (context.ModelType == null)
+            var modelAccessor = context.ModelAccessor;
+            if (context.ModelType == null || modelAccessor == null)
             {
                 return;
             }
@@ -46,7 +47,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
             }
         }
 
-        private void AssertSubcommandIsNotCycled(Type modelType, CommandLineApplication parentCommand)
+        private void AssertSubcommandIsNotCycled(Type modelType, CommandLineApplication? parentCommand)
         {
             while (parentCommand != null)
             {
@@ -67,7 +68,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
             where TSubCommand : class
         {
 #pragma warning disable 618
-            context.Application.Command<TSubCommand>(subcommand.Name, subcommand.Configure);
+            context.Application.Command<TSubCommand>(subcommand.Name!, subcommand.Configure);
 #pragma warning restore 618
         }
     }

--- a/src/CommandLineUtils/Conventions/SubcommandPropertyConvention.cs
+++ b/src/CommandLineUtils/Conventions/SubcommandPropertyConvention.cs
@@ -15,7 +15,8 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
         /// <inheritdoc />
         public virtual void Apply(ConventionContext context)
         {
-            if (context.ModelType == null)
+            var modelAccessor = context.ModelAccessor;
+            if (context.ModelType == null || modelAccessor == null)
             {
                 return;
             }
@@ -29,14 +30,14 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
             var setter = ReflectionHelper.GetPropertySetter(subcommandProp);
             context.Application.OnParsingComplete(r =>
             {
-                var subCommand = r.SelectedCommand;
+                CommandLineApplication? subCommand = r.SelectedCommand;
                 while (subCommand != null)
                 {
                     if (ReferenceEquals(subCommand.Parent, context.Application))
                     {
                         if (subCommand is IModelAccessor subcmdAccessor)
                         {
-                            setter(context.ModelAccessor.GetModel(), subcmdAccessor.GetModel());
+                            setter(modelAccessor.GetModel(), subcmdAccessor.GetModel());
                         }
                         return;
                     }

--- a/src/CommandLineUtils/Conventions/ValidateMethodConvention.cs
+++ b/src/CommandLineUtils/Conventions/ValidateMethodConvention.cs
@@ -17,7 +17,8 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <inheritdoc />
         public void Apply(ConventionContext context)
         {
-            if (context.ModelType == null)
+            var modelAccessor = context.ModelAccessor;
+            if (context.ModelType == null || modelAccessor == null)
             {
                 return;
             }
@@ -38,7 +39,6 @@ namespace McMaster.Extensions.CommandLineUtils
                 throw new InvalidOperationException(Strings.InvalidOnValidateReturnType(context.ModelType));
             }
 
-            var accessor = context.ModelAccessor;
             var methodParams = method.GetParameters();
             context.Application.OnValidate(ctx =>
             {
@@ -62,7 +62,7 @@ namespace McMaster.Extensions.CommandLineUtils
                     }
                 }
 
-                return (ValidationResult)method.Invoke(accessor.GetModel(), arguments);
+                return (ValidationResult)method.Invoke(modelAccessor.GetModel(), arguments);
             });
         }
     }

--- a/src/CommandLineUtils/Conventions/ValidationErrorMethodConvention.cs
+++ b/src/CommandLineUtils/Conventions/ValidationErrorMethodConvention.cs
@@ -14,7 +14,8 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
         /// <inheritdoc />
         public virtual void Apply(ConventionContext context)
         {
-            if (context.ModelType == null)
+            var modelAccessor = context.ModelAccessor;
+            if (context.ModelType == null || modelAccessor == null)
             {
                 return;
             }
@@ -30,11 +31,10 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                 return;
             }
 
-            var accessor = context.ModelAccessor;
             context.Application.ValidationErrorHandler = (v) =>
             {
                 var arguments = ReflectionHelper.BindParameters(method, context.Application);
-                var result = method.Invoke(accessor.GetModel(), arguments);
+                var result = method.Invoke(modelAccessor.GetModel(), arguments);
                 if (method.ReturnType == typeof(int))
                 {
                     return (int)result;

--- a/src/CommandLineUtils/Conventions/VersionOptionAttributeConvention.cs
+++ b/src/CommandLineUtils/Conventions/VersionOptionAttributeConvention.cs
@@ -15,7 +15,8 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
         /// <inheritdoc />
         public virtual void Apply(ConventionContext context)
         {
-            if (context.ModelType == null)
+            var modelAccessor = context.ModelAccessor;
+            if (context.ModelType == null || modelAccessor == null)
             {
                 return;
             }
@@ -25,8 +26,8 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
 
             var props = ReflectionHelper.GetProperties(context.ModelType);
 
-            VersionOptionAttribute versionOptionAttr = null;
-            PropertyInfo property = null;
+            VersionOptionAttribute? versionOptionAttr = null;
+            PropertyInfo? property = null;
 
             foreach (var prop in props)
             {
@@ -54,7 +55,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                 EnsureDoesNotHaveArgumentAttribute(prop);
             }
 
-            if (versionOptionAttr == null)
+            if (versionOptionAttr == null || property == null)
             {
                 return;
             }

--- a/src/CommandLineUtils/Conventions/VersionOptionFromMemberAttributeConvention.cs
+++ b/src/CommandLineUtils/Conventions/VersionOptionFromMemberAttributeConvention.cs
@@ -14,13 +14,14 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
         /// <inheritdoc />
         public virtual void Apply(ConventionContext context)
         {
-            if (context.ModelType == null)
+            var modelAccessor = context.ModelAccessor;
+            if (context.ModelType == null || modelAccessor == null)
             {
                 return;
             }
 
             var versionOptionFromMember = context.ModelType.GetTypeInfo().GetCustomAttribute<VersionOptionFromMemberAttribute>();
-            versionOptionFromMember?.Configure(context.Application, context.ModelType, context.ModelAccessor.GetModel);
+            versionOptionFromMember?.Configure(context.Application, context.ModelType, modelAccessor.GetModel);
         }
     }
 }

--- a/src/CommandLineUtils/Errors/SubcommandCycleException.cs
+++ b/src/CommandLineUtils/Errors/SubcommandCycleException.cs
@@ -17,7 +17,7 @@ namespace McMaster.Extensions.CommandLineUtils.Errors
         public SubcommandCycleException(Type modelType)
             : base($"Subcommand cycle detected: trying to add command of model {modelType} as its own direct or indirect subcommand")
         {
-            ModelType = modelType;
+            ModelType = modelType ?? throw new ArgumentNullException(nameof(modelType));
         }
 
         /// <summary>

--- a/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
+++ b/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
@@ -74,7 +74,7 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
             var commands = application.Commands.Where(c => c.ShowInHelpText).ToList();
 
             var firstColumnWidth = 2 + Math.Max(
-                arguments.Count > 0 ? arguments.Max(a => a.Name.Length) : 0,
+                arguments.Count > 0 ? arguments.Max(a => a.Name?.Length ?? 0) : 0,
                 Math.Max(
                     options.Count > 0 ? options.Max(o => Format(o).Length) : 0,
                     commands.Count > 0 ? commands.Max(c => c.Name?.Length ?? 0) : 0));
@@ -101,8 +101,8 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
             IReadOnlyList<CommandLineApplication> visibleCommands)
         {
             output.Write("Usage:");
-            var stack = new Stack<string>();
-            for (var cmd = application; cmd != null; cmd = cmd.Parent)
+            var stack = new Stack<string?>();
+            for (CommandLineApplication? cmd = application; cmd != null; cmd = cmd.Parent)
             {
                 stack.Push(cmd.Name);
             }

--- a/src/CommandLineUtils/IO/Pager.cs
+++ b/src/CommandLineUtils/IO/Pager.cs
@@ -19,7 +19,7 @@ namespace McMaster.Extensions.CommandLineUtils
     /// </summary>
     public class Pager : IDisposable
     {
-        private readonly Lazy<Process> _less;
+        private readonly Lazy<Process?> _less;
         private readonly TextWriter _fallbackWriter;
         private bool _enabled;
         private bool _disposed;
@@ -52,7 +52,7 @@ namespace McMaster.Extensions.CommandLineUtils
 #error Update target frameworks
 #endif
 
-            _less = new Lazy<Process>(CreateWriter);
+            _less = new Lazy<Process?>(CreateWriter);
             _fallbackWriter = console.Out;
         }
 
@@ -105,13 +105,13 @@ namespace McMaster.Extensions.CommandLineUtils
         /// </summary>
         public void Kill()
         {
-            if (_less.IsValueCreated)
+            if (_less.IsValueCreated && _less.Value != null)
             {
                 _less.Value.Kill();
             }
         }
 
-        private Process CreateWriter()
+        private Process? CreateWriter()
         {
             if (!_enabled)
             {

--- a/src/CommandLineUtils/Internal/CollectionParserProvider.cs
+++ b/src/CommandLineUtils/Internal/CollectionParserProvider.cs
@@ -16,7 +16,7 @@ namespace McMaster.Extensions.CommandLineUtils
 
         public static CollectionParserProvider Default { get; } = new CollectionParserProvider();
 
-        public ICollectionParser GetParser(Type type, ValueParserProvider valueParsers)
+        public ICollectionParser? GetParser(Type type, ValueParserProvider valueParsers)
         {
             if (type.IsArray)
             {

--- a/src/CommandLineUtils/Internal/CommandLineProcessor.cs
+++ b/src/CommandLineUtils/Internal/CommandLineProcessor.cs
@@ -28,7 +28,7 @@ namespace McMaster.Extensions.CommandLineUtils
             set => _enumerator.CurrentCommand = value;
         }
 
-        private CommandArgumentEnumerator _currentCommandArguments;
+        private CommandArgumentEnumerator? _currentCommandArguments;
 
         public CommandLineProcessor(CommandLineApplication command,
             IReadOnlyList<string> arguments)
@@ -92,10 +92,7 @@ namespace McMaster.Extensions.CommandLineUtils
             _enumerator.Reset();
 
         finished:
-            return new ParseResult
-            {
-                SelectedCommand = _currentCommand
-            };
+            return new ParseResult(_currentCommand);
         }
 
         private bool ProcessNext()
@@ -166,7 +163,7 @@ namespace McMaster.Extensions.CommandLineUtils
 
         private bool ProcessOption()
         {
-            CommandOption option = null;
+            CommandOption? option = null;
             var arg = _enumerator.Current;
             var value = arg.Value;
             var name = arg.Name;
@@ -310,7 +307,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return true;
         }
 
-        private CommandOption FindOption(string name, Func<CommandOption, string> by)
+        private CommandOption? FindOption(string name, Func<CommandOption, string> by)
         {
             var options = _currentCommand
                 .GetOptions()
@@ -353,7 +350,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return false;
         }
 
-        private void HandleUnexpectedArg(string argTypeName, string argValue = null)
+        private void HandleUnexpectedArg(string argTypeName, string? argValue = null)
         {
             if (_currentCommand.ThrowOnUnexpectedArgument)
             {
@@ -440,20 +437,20 @@ namespace McMaster.Extensions.CommandLineUtils
             }
         }
 
-        private sealed class ParameterEnumerator : IEnumerator<Parameter>
+        private sealed class ParameterEnumerator : IEnumerator<Parameter?>
         {
             private readonly IEnumerator<string> _rawArgEnumerator;
-            private Parameter _current;
-            private IEnumerator<string> _rspEnumerator;
+            private Parameter? _current;
+            private IEnumerator<string>? _rspEnumerator;
 
             public ParameterEnumerator(IReadOnlyList<string> rawArguments)
             {
                 _rawArgEnumerator = rawArguments.GetEnumerator();
             }
 
-            public Parameter Current => _current;
+            public Parameter? Current => _current;
 
-            object IEnumerator.Current => _current;
+            object? IEnumerator.Current => _current;
 
             // currently this must be settable because some parsing behavior can be set per subcommand
             public CommandLineApplication CurrentCommand { get; set; }

--- a/src/CommandLineUtils/Internal/CommandOptionTypeMapper.cs
+++ b/src/CommandLineUtils/Internal/CommandOptionTypeMapper.cs
@@ -33,7 +33,7 @@ namespace McMaster.Extensions.CommandLineUtils
             }
         }
 
-        public CommandOptionType GetOptionType(Type clrType, ValueParserProvider valueParsers = null)
+        public CommandOptionType GetOptionType(Type clrType, ValueParserProvider? valueParsers = null)
         {
             if (clrType == typeof(bool) || clrType == typeof(bool[]))
             {

--- a/src/CommandLineUtils/Internal/Delegates.cs
+++ b/src/CommandLineUtils/Internal/Delegates.cs
@@ -3,5 +3,5 @@
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    internal delegate void SetPropertyDelegate(object obj, object value);
+    internal delegate void SetPropertyDelegate(object obj, object? value);
 }

--- a/src/CommandLineUtils/Internal/ICollectionParser.cs
+++ b/src/CommandLineUtils/Internal/ICollectionParser.cs
@@ -7,6 +7,6 @@ namespace McMaster.Extensions.CommandLineUtils
 {
     internal interface ICollectionParser
     {
-        object Parse(string argName, IReadOnlyList<string> values);
+        object Parse(string? argName, IReadOnlyList<string?> values);
     }
 }

--- a/src/CommandLineUtils/Internal/ReflectionHelper.cs
+++ b/src/CommandLineUtils/Internal/ReflectionHelper.cs
@@ -16,7 +16,7 @@ namespace McMaster.Extensions.CommandLineUtils
             var setter = prop.GetSetMethod(nonPublic: true);
             if (setter != null)
             {
-                return (obj, value) => setter.Invoke(obj, new object[] { value });
+                return (obj, value) => setter.Invoke(obj, new object?[] { value });
             }
             else
             {
@@ -82,18 +82,19 @@ namespace McMaster.Extensions.CommandLineUtils
                 }
                 else
                 {
-                    arguments[i]= command.AdditionalServices?.GetService(methodParam.ParameterType);
-                    if (arguments[i] == null)
+                    object? service = command.AdditionalServices?.GetService(methodParam.ParameterType);
+                    if (service == null)
                     {
                         throw new InvalidOperationException(Strings.UnsupportedParameterTypeOnMethod(method.Name, methodParam));
                     }
+                    arguments[i] = service;
                 }
             }
 
             return arguments;
         }
 
-        public static bool IsNullableType(TypeInfo typeInfo, out Type wrappedType)
+        public static bool IsNullableType(TypeInfo typeInfo, out Type? wrappedType)
         {
             var result = typeInfo.IsGenericType && typeInfo.GetGenericTypeDefinition() == typeof(Nullable<>);
             wrappedType = result ? typeInfo.GetGenericArguments().First() : null;

--- a/src/CommandLineUtils/Internal/StringDistance.cs
+++ b/src/CommandLineUtils/Internal/StringDistance.cs
@@ -143,7 +143,7 @@ namespace McMaster.Extensions.CommandLineUtils
         {
             if (distanceMethod == null || value == null || values == null)
             {
-                return null;
+                return Enumerable.Empty<string>();
             }
 
             return values

--- a/src/CommandLineUtils/Internal/StringDistance.cs
+++ b/src/CommandLineUtils/Internal/StringDistance.cs
@@ -136,9 +136,9 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="values">The values to search through.</param>
         /// <param name="threshold">A threshold for word possible match.</param>
         /// <returns>The index of the best match or -1 when none is found</returns>
-        internal static IEnumerable<string> GetBestMatchesSorted(Func<string, string, int> distanceMethod,
-            string value,
-            IEnumerable<string> values,
+        internal static IEnumerable<string> GetBestMatchesSorted(Func<string, string, int>? distanceMethod,
+            string? value,
+            IEnumerable<string>? values,
             double threshold)
         {
             if (distanceMethod == null || value == null || values == null)

--- a/src/CommandLineUtils/Internal/SuggestionCreator.cs
+++ b/src/CommandLineUtils/Internal/SuggestionCreator.cs
@@ -37,7 +37,10 @@ namespace McMaster.Extensions.CommandLineUtils
         {
             foreach (var cmd in command.Commands)
             {
-                yield return cmd.Name;
+                if (cmd.Name != null)
+                {
+                    yield return cmd.Name;
+                }
             }
 
             foreach (var option in command.GetOptions().Where(o => o.ShowInHelpText))

--- a/src/CommandLineUtils/Internal/ValueParsers/ArrayParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/ArrayParser.cs
@@ -21,7 +21,7 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
             _parserCulture = parserCulture;
         }
 
-        public object Parse(string argName, IReadOnlyList<string> values)
+        public object Parse(string? argName, IReadOnlyList<string?> values)
         {
             var array = Array.CreateInstance(_elementType, values.Count);
             for (var i = 0; i < values.Count; i++)

--- a/src/CommandLineUtils/Internal/ValueParsers/HashSetParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/HashSetParser.cs
@@ -24,12 +24,12 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
             _parserCulture = parserCulture;
         }
 
-        public object Parse(string argName, IReadOnlyList<string> values)
+        public object Parse(string? argName, IReadOnlyList<string?> values)
         {
             var set = Activator.CreateInstance(_listType, Util.EmptyArray<object>());
             for (var i = 0; i < values.Count; i++)
             {
-                _addMethod.Invoke(set, new object[] { _elementParser.Parse(argName, values[i], _parserCulture) });
+                _addMethod.Invoke(set, new object?[] { _elementParser.Parse(argName, values[i], _parserCulture) });
             }
             return set;
         }

--- a/src/CommandLineUtils/Internal/ValueParsers/ListParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/ListParser.cs
@@ -22,7 +22,7 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
             _parserCulture = parserCulture;
         }
 
-        public object Parse(string argName, IReadOnlyList<string> values)
+        public object Parse(string? argName, IReadOnlyList<string?> values)
         {
             var list = (IList)Activator.CreateInstance(_listType, new object[] { values.Count });
             for (var i = 0; i < values.Count; i++)

--- a/src/CommandLineUtils/Internal/ValueParsers/NullableValueParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/NullableValueParser.cs
@@ -24,7 +24,7 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
         }
 
 
-        public object Parse(string argName, string value, CultureInfo culture)
+        public object? Parse(string? argName, string? value, CultureInfo culture)
         {
             if (string.IsNullOrWhiteSpace(value))
             {

--- a/src/CommandLineUtils/Internal/ValueParsers/StockValueParsers.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/StockValueParsers.cs
@@ -30,18 +30,18 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
                 return result;
             });
 
-        public static readonly IValueParser<string> String = ValueParser.Create((_, value, __) => value);
+        public static readonly IValueParser<string?> String = ValueParser.Create((_, value, __) => value);
 
         public static readonly IValueParser<Uri> Uri = ValueParser.Create(
             (_, value, culture) => new Uri(value, UriKind.RelativeOrAbsolute));
 
-        private static FormatException InvalidValueException(string argName, string specifics) =>
+        private static FormatException InvalidValueException(string? argName, string specifics) =>
             new FormatException($"Invalid value specified for {argName}. {specifics}");
 
         private delegate bool NumberParser<T>(string s, NumberStyles styles, IFormatProvider provider, out T result);
 
         private static IValueParser<T> Create<T>(NumberParser<T> parser, NumberStyles styles,
-                                                 Func<string, string, FormatException> errorSelector)
+                                                 Func<string?, string?, FormatException> errorSelector)
         {
             if (parser == null) throw new ArgumentNullException(nameof(parser));
             if (errorSelector == null) throw new ArgumentNullException(nameof(errorSelector));
@@ -78,7 +78,7 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
 
         private delegate bool DateTimeParser<T>(string s, IFormatProvider provider, DateTimeStyles styles, out T result);
 
-        private static IValueParser<T> Create<T>(DateTimeParser<T> parser, DateTimeStyles styles, Func<string, string, FormatException> errorSelector)
+        private static IValueParser<T> Create<T>(DateTimeParser<T> parser, DateTimeStyles styles, Func<string?, string?, FormatException> errorSelector)
         {
             if (parser == null) throw new ArgumentNullException(nameof(parser));
             if (errorSelector == null) throw new ArgumentNullException(nameof(errorSelector));

--- a/src/CommandLineUtils/Internal/ValueParsers/TupleValueParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/TupleValueParser.cs
@@ -14,7 +14,7 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
             return
                 ValueParser.Create((argName, value, culture) =>
                     value == null
-                        ? Tuple.Create<bool, T>(false, default)
+                        ? Tuple.Create<bool, T>(false, default!)
                         : Tuple.Create(true, typeParser.Parse(argName, value, culture)));
         }
     }

--- a/src/CommandLineUtils/Internal/ValueParsers/ValueParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/ValueParser.cs
@@ -19,7 +19,7 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
         /// to parse and a culture to use for parsing.
         /// </summary>
 
-        public static IValueParser Create(Type targetType, Func<string, string, CultureInfo, object> parser) =>
+        public static IValueParser Create(Type targetType, Func<string?, string?, CultureInfo, object> parser) =>
             new DelegatingValueParser(targetType, Create(parser));
 
         /// <summary>
@@ -28,7 +28,7 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
         /// parse and a culture to use for parsing.
         /// </summary>
 
-        public static IValueParser<T> Create<T>(Func<string, string, CultureInfo, T> parser) =>
+        public static IValueParser<T> Create<T>(Func<string?, string?, CultureInfo, T> parser) =>
             new DelegatingValueParser<T>(parser);
 
         /// <summary>
@@ -53,14 +53,14 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
         /// unsuccessful.
         /// </summary>
 
-        public static IValueParser<T> Create<T>(Func<string, CultureInfo, (bool, T)> parser, Func<string, string, FormatException> errorSelector)
+        public static IValueParser<T> Create<T>(Func<string, CultureInfo, (bool, T)> parser, Func<string?, string?, FormatException> errorSelector)
         {
             if (parser == null) throw new ArgumentNullException(nameof(parser));
             if (errorSelector == null) throw new ArgumentNullException(nameof(errorSelector));
 
             return Create((argName, value, culture) =>
             {
-                if (value == null) return default;
+                if (value == null) return default!;
 
                 var (parsed, result) = parser(value, culture);
                 return parsed ? result : throw errorSelector(argName, value);
@@ -69,19 +69,19 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
 
         private sealed class DelegatingValueParser<T> : IValueParser<T>
         {
-            readonly Func<string, string, CultureInfo, T> _parser;
+            readonly Func<string?, string?, CultureInfo, T> _parser;
 
-            public DelegatingValueParser(Func<string, string, CultureInfo, T> parser)
+            public DelegatingValueParser(Func<string?, string?, CultureInfo, T> parser)
             {
                 _parser = parser ?? throw new ArgumentNullException(nameof(parser));
             }
 
             public Type TargetType => typeof(T);
 
-            public T Parse(string argName, string value, CultureInfo culture) =>
+            public T Parse(string? argName, string? value, CultureInfo culture) =>
                 _parser(argName, value, culture);
 
-            object IValueParser.Parse(string argName, string value, CultureInfo culture) =>
+            object? IValueParser.Parse(string? argName, string? value, CultureInfo culture) =>
                 Parse(argName, value, culture);
         }
 
@@ -97,7 +97,7 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
 
             public Type TargetType { get; }
 
-            public object Parse(string argName, string value, CultureInfo culture) =>
+            public object? Parse(string? argName, string? value, CultureInfo culture) =>
                 _parser.Parse(argName, value, culture);
         }
     }

--- a/src/CommandLineUtils/Internal/ValueParsers/ValueTupleValueParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/ValueTupleValueParser.cs
@@ -14,7 +14,7 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
             return
                 ValueParser.Create((argName, value, culture) =>
                     value == null
-                        ? (true, default)
+                        ? (true, default!)
                         : (true, typeParser.Parse(argName, value, culture)));
         }
     }

--- a/src/CommandLineUtils/McMaster.Extensions.CommandLineUtils.csproj
+++ b/src/CommandLineUtils/McMaster.Extensions.CommandLineUtils.csproj
@@ -6,6 +6,10 @@
     <TargetFrameworks>netstandard2.0;netstandard1.6;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);1591</WarningsNotAsErrors>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <!-- Until .NET Core 3.0 P6 is available -->
+    <NullableContextOptions>enable</NullableContextOptions>
     <IsPackable>true</IsPackable>
     <Description>Command-line parsing API.</Description>
     <PackageDescription>Command-line parsing API and utilities for console applications.

--- a/src/CommandLineUtils/McMaster.Extensions.CommandLineUtils.csproj
+++ b/src/CommandLineUtils/McMaster.Extensions.CommandLineUtils.csproj
@@ -6,10 +6,6 @@
     <TargetFrameworks>netstandard2.0;netstandard1.6;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);1591</WarningsNotAsErrors>
-    <LangVersion>8.0</LangVersion>
-    <Nullable>enable</Nullable>
-    <!-- Until .NET Core 3.0 P6 is available -->
-    <NullableContextOptions>enable</NullableContextOptions>
     <IsPackable>true</IsPackable>
     <Description>Command-line parsing API.</Description>
     <PackageDescription>Command-line parsing API and utilities for console applications.

--- a/src/CommandLineUtils/Properties/Strings.cs
+++ b/src/CommandLineUtils/Properties/Strings.cs
@@ -4,6 +4,7 @@
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.Reflection;
+using McMaster.Extensions.CommandLineUtils.Abstractions;
 
 namespace McMaster.Extensions.CommandLineUtils
 {
@@ -27,6 +28,9 @@ namespace McMaster.Extensions.CommandLineUtils
 
         public const string NoOnExecuteMethodFound
             = "No method named 'OnExecute' or 'OnExecuteAsync' could be found";
+
+        public const string ConventionRequiresModel
+            = "This convention cannot be used on a command that does not implement " + nameof(IModelAccessor);
 
         public static string InvalidOnExecuteReturnType(string methodName)
             => methodName + " must have a return type of int or void, or if the method is async, Task<int> or Task.";
@@ -62,7 +66,7 @@ namespace McMaster.Extensions.CommandLineUtils
         public static string DuplicateArgumentPosition(int order, PropertyInfo first, PropertyInfo second)
             => $"Duplicate value for argument order. Both {first.DeclaringType.FullName}.{first.Name} and {second.DeclaringType.FullName}.{second.Name} have set Order = {order}";
 
-        public static string OnlyLastArgumentCanAllowMultipleValues(string lastArgName)
+        public static string OnlyLastArgumentCanAllowMultipleValues(string? lastArgName)
             => $"The last argument '{lastArgName}' accepts multiple values. No more argument can be added.";
 
         public static string CannotDetermineParserType(Type type)

--- a/src/CommandLineUtils/Utilities/DotNetExe.cs
+++ b/src/CommandLineUtils/Utilities/DotNetExe.cs
@@ -28,7 +28,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// </para>
         /// </summary>
         /// <returns>The path or null</returns>
-        public static string FullPath { get; }
+        public static string? FullPath { get; }
 
         /// <summary>
         /// Finds the full filepath to the .NET Core CLI executable,
@@ -38,7 +38,7 @@ namespace McMaster.Extensions.CommandLineUtils
         public static string FullPathOrDefault()
             => FullPath ?? FileName;
 
-        private static string TryFindDotNetExePath()
+        private static string? TryFindDotNetExePath()
         {
             var fileName = FileName;
 #if NET45

--- a/src/CommandLineUtils/Utilities/Prompt.cs
+++ b/src/CommandLineUtils/Utilities/Prompt.cs
@@ -33,7 +33,7 @@ namespace McMaster.Extensions.CommandLineUtils
                 Write($"{prompt} {answerHint}", promptColor, promptBgColor);
                 Console.Write(' ');
 
-                string resp;
+                string? resp;
                 using (ShowCursor())
                 {
                     resp = Console.ReadLine()?.ToLower()?.Trim();
@@ -67,7 +67,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="promptColor">The console color to use for the prompt</param>
         /// <param name="promptBgColor">The console background color for the prompt</param>
         /// <returns>The response the user gave. Can be null or empty</returns>
-        public static string GetString(string prompt, string defaultValue = null, ConsoleColor? promptColor = null, ConsoleColor? promptBgColor = null)
+        public static string? GetString(string prompt, string? defaultValue = null, ConsoleColor? promptColor = null, ConsoleColor? promptBgColor = null)
         {
             if (defaultValue != null)
             {
@@ -162,7 +162,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <returns>A stream of characters as input by the user including Backspace for deletions.</returns>
         private static IEnumerable<char> ReadObfuscatedLine(string prompt, ConsoleColor? promptColor = null, ConsoleColor? promptBgColor = null)
         {
-            const string whiteOut = "\b \b";
+            const string WhiteOut = "\b \b";
             Write(prompt, promptColor, promptBgColor);
             Console.Write(' ');
             const ConsoleModifiers IgnoredModifiersMask = ConsoleModifiers.Alt | ConsoleModifiers.Control;
@@ -188,7 +188,7 @@ namespace McMaster.Extensions.CommandLineUtils
                     case ConsoleKey.Backspace:
                         if (readChars > 0)
                         {
-                            Console.Write(whiteOut);
+                            Console.Write(WhiteOut);
                             --readChars;
                             yield return Backspace;
                         }
@@ -197,7 +197,7 @@ namespace McMaster.Extensions.CommandLineUtils
                         // Reset the password
                         while (readChars > 0)
                         {
-                            Console.Write(whiteOut);
+                            Console.Write(WhiteOut);
                             yield return Backspace;
                             --readChars;
                         }
@@ -231,7 +231,7 @@ namespace McMaster.Extensions.CommandLineUtils
                 }
                 Console.Write(' ');
 
-                string resp;
+                string? resp;
                 using (ShowCursor())
                 {
                     resp = Console.ReadLine()?.ToLower()?.Trim();

--- a/src/CommandLineUtils/Validation/AttributeValidator.cs
+++ b/src/CommandLineUtils/Validation/AttributeValidator.cs
@@ -52,7 +52,7 @@ namespace McMaster.Extensions.CommandLineUtils.Validation
         public ValidationResult GetValidationResult(CommandArgument argument, ValidationContext context)
             => GetValidationResult(argument.Values, context);
 
-        private ValidationResult GetValidationResult(List<string> values, ValidationContext context)
+        private ValidationResult GetValidationResult(List<string?>? values, ValidationContext context)
         {
             if (values == null)
             {

--- a/src/CommandLineUtils/Validation/ValidationBuilder.cs
+++ b/src/CommandLineUtils/Validation/ValidationBuilder.cs
@@ -10,8 +10,8 @@ namespace McMaster.Extensions.CommandLineUtils.Validation
     /// </summary>
     public class ValidationBuilder : IOptionValidationBuilder, IArgumentValidationBuilder
     {
-        private readonly CommandArgument _argument;
-        private readonly CommandOption _option;
+        private readonly CommandArgument? _argument;
+        private readonly CommandOption? _option;
 
         /// <summary>
         /// Creates a new instance of <see cref="ValidationBuilder"/> for a given <see cref="CommandArgument"/>.

--- a/src/CommandLineUtils/Validation/ValidationExtensions.cs
+++ b/src/CommandLineUtils/Validation/ValidationExtensions.cs
@@ -20,7 +20,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="allowEmptyStrings">Indicates whether an empty string is allowed.</param>
         /// <param name="errorMessage">The custom error message to display. See also <seealso cref="ValidationAttribute.ErrorMessage"/>.</param>
         /// <returns>The option.</returns>
-        public static CommandOption IsRequired(this CommandOption option, bool allowEmptyStrings = false, string errorMessage = null)
+        public static CommandOption IsRequired(this CommandOption option, bool allowEmptyStrings = false, string? errorMessage = null)
         {
             var attribute = GetValidationAttr<RequiredAttribute>(errorMessage);
             attribute.AllowEmptyStrings = allowEmptyStrings;
@@ -36,7 +36,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="errorMessage">The custom error message to display. See also <seealso cref="ValidationAttribute.ErrorMessage"/>.</param>
         /// <returns>The option.</returns>
         public static CommandOption<T> IsRequired<T>(this CommandOption<T> option, bool allowEmptyStrings = false,
-            string errorMessage = null)
+            string? errorMessage = null)
         {
 
             IsRequired((CommandOption)option, allowEmptyStrings, errorMessage);
@@ -50,7 +50,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="allowEmptyStrings">Indicates whether an empty string is allowed.</param>
         /// <param name="errorMessage">The custom error message to display. See also <seealso cref="ValidationAttribute.ErrorMessage"/>.</param>
         /// <returns>The argument.</returns>
-        public static CommandArgument IsRequired(this CommandArgument argument, bool allowEmptyStrings = false, string errorMessage = null)
+        public static CommandArgument IsRequired(this CommandArgument argument, bool allowEmptyStrings = false, string? errorMessage = null)
         {
             var attribute = GetValidationAttr<RequiredAttribute>(errorMessage);
             attribute.AllowEmptyStrings = allowEmptyStrings;
@@ -65,7 +65,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="allowEmptyStrings">Indicates whether an empty string is allowed.</param>
         /// <param name="errorMessage">The custom error message to display. See also <seealso cref="ValidationAttribute.ErrorMessage"/>.</param>
         /// <returns>The argument.</returns>
-        public static CommandArgument<T> IsRequired<T>(this CommandArgument<T> argument, bool allowEmptyStrings = false, string errorMessage = null)
+        public static CommandArgument<T> IsRequired<T>(this CommandArgument<T> argument, bool allowEmptyStrings = false, string? errorMessage = null)
         {
             IsRequired((CommandArgument)argument, allowEmptyStrings, errorMessage);
             return argument;
@@ -249,7 +249,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="builder">The builder.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
-        public static IValidationBuilder EmailAddress(this IValidationBuilder builder, string errorMessage = null)
+        public static IValidationBuilder EmailAddress(this IValidationBuilder builder, string? errorMessage = null)
             => builder.Satisfies<EmailAddressAttribute>(errorMessage);
 
         /// <summary>
@@ -258,7 +258,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="builder">The builder.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
-        public static IValidationBuilder ExistingFile(this IValidationBuilder builder, string errorMessage = null)
+        public static IValidationBuilder ExistingFile(this IValidationBuilder builder, string? errorMessage = null)
             => builder.Satisfies<FileExistsAttribute>(errorMessage);
 
         /// <summary>
@@ -267,7 +267,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="builder">The builder.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
-        public static IValidationBuilder NonExistingFile(this IValidationBuilder builder, string errorMessage = null)
+        public static IValidationBuilder NonExistingFile(this IValidationBuilder builder, string? errorMessage = null)
             => builder.Satisfies<FileNotExistsAttribute>(errorMessage);
 
         /// <summary>
@@ -276,7 +276,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="builder">The builder.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
-        public static IValidationBuilder ExistingDirectory(this IValidationBuilder builder, string errorMessage = null)
+        public static IValidationBuilder ExistingDirectory(this IValidationBuilder builder, string? errorMessage = null)
             => builder.Satisfies<DirectoryExistsAttribute>(errorMessage);
 
         /// <summary>
@@ -285,7 +285,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="builder">The builder.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
-        public static IValidationBuilder NonExistingDirectory(this IValidationBuilder builder, string errorMessage = null)
+        public static IValidationBuilder NonExistingDirectory(this IValidationBuilder builder, string? errorMessage = null)
             => builder.Satisfies<DirectoryNotExistsAttribute>(errorMessage);
 
         /// <summary>
@@ -294,7 +294,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="builder">The builder.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
-        public static IValidationBuilder ExistingFileOrDirectory(this IValidationBuilder builder, string errorMessage = null)
+        public static IValidationBuilder ExistingFileOrDirectory(this IValidationBuilder builder, string? errorMessage = null)
             => builder.Satisfies<FileOrDirectoryExistsAttribute>(errorMessage);
 
         /// <summary>
@@ -303,7 +303,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="builder">The builder.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
-        public static IValidationBuilder NonExistingFileOrDirectory(this IValidationBuilder builder, string errorMessage = null)
+        public static IValidationBuilder NonExistingFileOrDirectory(this IValidationBuilder builder, string? errorMessage = null)
             => builder.Satisfies<FileOrDirectoryNotExistsAttribute>(errorMessage);
 
         /// <summary>
@@ -312,7 +312,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="builder">The builder.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
-        public static IValidationBuilder LegalFilePath(this IValidationBuilder builder, string errorMessage = null)
+        public static IValidationBuilder LegalFilePath(this IValidationBuilder builder, string? errorMessage = null)
             => builder.Satisfies<LegalFilePathAttribute>(errorMessage);
 
         /// <summary>
@@ -322,7 +322,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="length">The minimum length.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
-        public static IValidationBuilder MinLength(this IValidationBuilder builder, int length, string errorMessage = null)
+        public static IValidationBuilder MinLength(this IValidationBuilder builder, int length, string? errorMessage = null)
             => builder.Satisfies<MinLengthAttribute>(errorMessage, length);
 
         /// <summary>
@@ -332,7 +332,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="length">The maximum length.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
-        public static IValidationBuilder MaxLength(this IValidationBuilder builder, int length, string errorMessage = null)
+        public static IValidationBuilder MaxLength(this IValidationBuilder builder, int length, string? errorMessage = null)
             => builder.Satisfies<MaxLengthAttribute>(errorMessage, length);
 
         /// <summary>
@@ -342,7 +342,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="pattern">The regular expression.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
-        public static IValidationBuilder RegularExpression(this IValidationBuilder builder, string pattern, string errorMessage = null)
+        public static IValidationBuilder RegularExpression(this IValidationBuilder builder, string pattern, string? errorMessage = null)
             => builder.Satisfies<RegularExpressionAttribute>(errorMessage, pattern);
 
         /// <summary>
@@ -353,7 +353,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="ctorArgs">Constructor arguments for <typeparamref name="TAttribute"/>.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
-        public static IValidationBuilder Satisfies<TAttribute>(this IValidationBuilder builder, string errorMessage = null, params object[] ctorArgs)
+        public static IValidationBuilder Satisfies<TAttribute>(this IValidationBuilder builder, string? errorMessage = null, params object[] ctorArgs)
             where TAttribute : ValidationAttribute
         {
             var attribute = GetValidationAttr<TAttribute>(errorMessage, ctorArgs);
@@ -369,7 +369,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="maximum">The maximum allowed value.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
-        public static IValidationBuilder<int> Range(this IValidationBuilder<int> builder, int minimum, int maximum, string errorMessage = null)
+        public static IValidationBuilder<int> Range(this IValidationBuilder<int> builder, int minimum, int maximum, string? errorMessage = null)
         {
             var attribute = GetValidationAttr<RangeAttribute>(errorMessage, new object[] { minimum, maximum });
             builder.Use(new AttributeValidator(attribute));
@@ -384,7 +384,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="maximum">The maximum allowed value.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
-        public static IValidationBuilder<double> Range(this IValidationBuilder<double> builder, double minimum, double maximum, string errorMessage = null)
+        public static IValidationBuilder<double> Range(this IValidationBuilder<double> builder, double minimum, double maximum, string? errorMessage = null)
         {
             var attribute = GetValidationAttr<RangeAttribute>(errorMessage, new object[] { minimum, maximum });
             builder.Use(new AttributeValidator(attribute));
@@ -427,7 +427,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return option;
         }
 
-        private static T GetValidationAttr<T>(string errorMessage, object[] ctorArgs = null)
+        private static T GetValidationAttr<T>(string? errorMessage, object[]? ctorArgs = null)
             where T : ValidationAttribute
         {
             var attribute = (T)Activator.CreateInstance(typeof(T), ctorArgs ?? new object[0]);

--- a/src/Hosting.CommandLine/Internal/CommandLineLifetime.cs
+++ b/src/Hosting.CommandLine/Internal/CommandLineLifetime.cs
@@ -19,7 +19,7 @@ namespace McMaster.Extensions.Hosting.CommandLine.Internal
         private readonly IApplicationLifetime _applicationLifetime;
         private readonly ICommandLineService _cliService;
         private readonly IConsole _console;
-        private readonly IUnhandledExceptionHandler _unhandledExceptionHandler;
+        private readonly IUnhandledExceptionHandler? _unhandledExceptionHandler;
         private readonly ManualResetEvent _disposeComplete = new ManualResetEvent(false);
 
         /// <summary>
@@ -28,7 +28,7 @@ namespace McMaster.Extensions.Hosting.CommandLine.Internal
         public CommandLineLifetime(IApplicationLifetime applicationLifetime,
             ICommandLineService cliService,
             IConsole console,
-            IUnhandledExceptionHandler unhandledExceptionHandler = null)
+            IUnhandledExceptionHandler? unhandledExceptionHandler = null)
         {
             _applicationLifetime = applicationLifetime;
             _cliService = cliService;

--- a/src/Hosting.CommandLine/Internal/StoreExceptionHandler.cs
+++ b/src/Hosting.CommandLine/Internal/StoreExceptionHandler.cs
@@ -11,7 +11,7 @@ namespace McMaster.Extensions.Hosting.CommandLine.Internal
         /// <summary>
         /// The captured exception, if any
         /// </summary>
-        public Exception StoredException { get; private set; }
+        public Exception? StoredException { get; private set; }
 
         /// <summary>
         /// This will store the first unhandled exception and throw an <see cref="AggregateException"/> if called a

--- a/test/CommandLineUtils.Tests/AllowedValuesAttributeTests.cs
+++ b/test/CommandLineUtils.Tests/AllowedValuesAttributeTests.cs
@@ -19,7 +19,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         {
             [Argument(0)]
             [AllowedValues("red", "blue", "green")]
-            public string Option { get; }
+            public string? Option { get; }
 
             private void OnExecute() { }
         }
@@ -47,7 +47,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         {
             [Argument(0)]
             [AllowedValues("red", "blue", "green", IgnoreCase = true)]
-            public string Option { get; }
+            public string? Option { get; }
 
             private void OnExecute() { }
         }

--- a/test/CommandLineUtils.Tests/ApiTests.cs
+++ b/test/CommandLineUtils.Tests/ApiTests.cs
@@ -22,7 +22,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
                 {
                     var editorBrowsable = type.GetCustomAttribute<EditorBrowsableAttribute>();
                     Assert.True(editorBrowsable != null, $"Type: {type.FullName} should have [EditorBrowsable]");
-                    Assert.True(editorBrowsable.State == EditorBrowsableState.Never,
+                    Assert.True(editorBrowsable!.State == EditorBrowsableState.Never,
                         $"Type: {type.FullName} should have EditorBrowsable.State == Never");
                 }
 
@@ -43,7 +43,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
                     var editorBrowsable = member.GetCustomAttribute<EditorBrowsableAttribute>();
                     Assert.True(editorBrowsable != null,
                         $"{type.FullName}.{member.Name} should have [EditorBrowsable]");
-                    Assert.True(editorBrowsable.State == EditorBrowsableState.Never,
+                    Assert.True(editorBrowsable!.State == EditorBrowsableState.Never,
                         $"{type.FullName}.{member.Name} should have EditorBrowsable.State == Never");
                 }
             }

--- a/test/CommandLineUtils.Tests/AppNameFromEntryAssemblyConventionTests.cs
+++ b/test/CommandLineUtils.Tests/AppNameFromEntryAssemblyConventionTests.cs
@@ -27,7 +27,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         {
             var app = new CommandLineApplication();
             app.Conventions.SetAppNameFromEntryAssembly();
-            var subcmd = app.Command(null, null);
+            var subcmd = app.Command(null!, null!);
             Assert.Null(subcmd.Name);
         }
     }

--- a/test/CommandLineUtils.Tests/ArgumentAttributeTests.cs
+++ b/test/CommandLineUtils.Tests/ArgumentAttributeTests.cs
@@ -27,7 +27,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         private class DuplicateArguments
         {
             [Argument(0)]
-            public string First { get; }
+            public string? First { get; }
 
             [Argument(0)]
             public int AlsoFirst { get; }
@@ -50,10 +50,10 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         private class MultipleValuesMultipleArgs
         {
             [Argument(0)]
-            public string[] Words { get; }
+            public string[]? Words { get; }
 
             [Argument(1)]
-            public string[] MoreWords { get; }
+            public string[]? MoreWords { get; }
         }
 
         [Fact]

--- a/test/CommandLineUtils.Tests/AttributeConventionTests.cs
+++ b/test/CommandLineUtils.Tests/AttributeConventionTests.cs
@@ -49,9 +49,9 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         private class YellowMember
         {
             [MyAttributeConvention("yellow")]
-            private string _color;
+            private string? _color;
 
-            public string Color { get => _color; set => _color = value; }
+            public string? Color { get => _color; set => _color = value; }
         }
 
         [Fact]
@@ -78,7 +78,11 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
                 {
                     context.Application.OnParsingComplete(r =>
                     {
-                        field.SetValue(context.ModelAccessor.GetModel(), _value);
+                        var modelAccessor = context.ModelAccessor;
+                        if (modelAccessor != null)
+                        {
+                            field.SetValue(modelAccessor.GetModel(), _value);
+                        }
                     });
                 }
             }
@@ -87,9 +91,9 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         private class YellowMemberWithDefault
         {
             [MyDefaultValue("yellow")]
-            private string _color;
+            private string? _color;
 
-            public string Color { get => _color; set => _color = value; }
+            public string? Color { get => _color; set => _color = value; }
         }
 
         [Fact]
@@ -100,7 +104,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             Assert.Equal(16, app.Commands.Count);
         }
 
-#pragma warning disable CS0169, CS0649, CS0067
+#pragma warning disable CS0169, CS0649, CS0067, CS8618
         private class MemberProgram
         {
             [Custom]

--- a/test/CommandLineUtils.Tests/AttributeValidatorTests.cs
+++ b/test/CommandLineUtils.Tests/AttributeValidatorTests.cs
@@ -83,7 +83,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         private class EmailArgumentApp
         {
             [Argument(0), EmailAddress]
-            public string Email { get; }
+            public string? Email { get; }
             private void OnExecute() { }
         }
 
@@ -121,16 +121,16 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         private class OptionApp
         {
             [Option, EmailAddress]
-            public string Email { get; }
+            public string? Email { get; }
 
             [Option, MinLength(1)]
-            public string Name { get; }
+            public string? Name { get; }
 
             [Option, MaxLength(10)]
-            public string Address { get; }
+            public string? Address { get; }
 
             [Option, RegularExpression("^abc.*")]
-            public string Regex { get; }
+            public string? Regex { get; }
 
             private void OnExecute() { }
         }
@@ -166,9 +166,9 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         private sealed class ClassLevelValidationApp
         {
             [Option]
-            public string Arg1 { get; set; }
+            public string? Arg1 { get; set; }
             [Option]
-            public string Arg2 { get; set; }
+            public string? Arg2 { get; set; }
         }
 
         [AttributeUsage(AttributeTargets.Class)]
@@ -176,8 +176,8 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         {
             public override bool IsValid(object value)
                 => value is ClassLevelValidationApp app
-                    && app.Arg1.Contains("good")
-                    && app.Arg2.Contains("good");
+                    && app.Arg1 != null && app.Arg1.Contains("good")
+                    && app.Arg2 != null && app.Arg2.Contains("good");
         }
     }
 }

--- a/test/CommandLineUtils.Tests/CommandLineApplicationExecutorTests.cs
+++ b/test/CommandLineUtils.Tests/CommandLineApplicationExecutorTests.cs
@@ -22,7 +22,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         private class VoidExecuteMethodWithNoArgs
         {
             [Option]
-            public string Message { get; set; }
+            public string? Message { get; set; }
 
             private void OnExecute()
             {
@@ -104,7 +104,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
 
         private class BadReturnType
         {
-            private string OnExecute() => null;
+            private string? OnExecute() => null;
         }
 
         [Fact]
@@ -118,7 +118,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
 
         private class BadAsyncReturnType
         {
-            private Task<string> OnExecute() => null;
+            private Task<string>? OnExecute() => null;
         }
 
         [Fact]

--- a/test/CommandLineUtils.Tests/CommandLineApplicationOfTTests.cs
+++ b/test/CommandLineUtils.Tests/CommandLineApplicationOfTTests.cs
@@ -18,7 +18,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         private class AttributesNotUsedClass
         {
             public int OptionA { get; set; }
-            public string OptionB { get; set; }
+            public string? OptionB { get; set; }
         }
 
         [Fact]
@@ -37,13 +37,13 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         private class SimpleProgram
         {
             [Argument(0)]
-            public string Command { get; set; }
+            public string? Command { get; set; }
 
             [Option]
-            public string Message { get; set; }
+            public string? Message { get; set; }
 
             [Option("-F <file>")]
-            public string File { get; set; }
+            public string? File { get; set; }
 
             [Option]
             public bool Amend { get; set; }

--- a/test/CommandLineUtils.Tests/CommandLineApplicationTests.cs
+++ b/test/CommandLineUtils.Tests/CommandLineApplicationTests.cs
@@ -58,8 +58,8 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         [Fact]
         public void RemainingArgsArePassed()
         {
-            CommandArgument first = null;
-            CommandArgument second = null;
+            CommandArgument? first = null;
+            CommandArgument? second = null;
 
             var app = new CommandLineApplication();
 
@@ -72,15 +72,15 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
 
             app.Execute("test", "one", "two");
 
-            Assert.Equal("one", first.Value);
-            Assert.Equal("two", second.Value);
+            Assert.Equal("one", first?.Value);
+            Assert.Equal("two", second?.Value);
         }
 
         [Fact]
         public void ExtraArgumentCausesException()
         {
-            CommandArgument first = null;
-            CommandArgument second = null;
+            CommandArgument? first = null;
+            CommandArgument? second = null;
 
             var app = new CommandLineApplication();
 
@@ -106,10 +106,10 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
                 c.AddName("s");
             });
 
-            var ex = Assert.Throws<InvalidOperationException>(() => app.Command("sub1", null));
+            var ex = Assert.Throws<InvalidOperationException>(() => app.Command("sub1", _ => {}));
             Assert.Equal(Strings.DuplicateSubcommandName("sub1"), ex.Message);
 
-            ex = Assert.Throws<InvalidOperationException>(() => app.Command("s", null));
+            ex = Assert.Throws<InvalidOperationException>(() => app.Command("s", _ => {}));
             Assert.Equal(Strings.DuplicateSubcommandName("s"), ex.Message);
         }
 
@@ -147,7 +147,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         [Fact]
         public void MultipleValuesArgumentConsumesAllArgumentValues()
         {
-            CommandArgument argument = null;
+            CommandArgument? argument = null;
 
             var app = new CommandLineApplication();
 
@@ -159,13 +159,13 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
 
             app.Execute("test", "one", "two", "three", "four", "five");
 
-            Assert.Equal(new[] { "one", "two", "three", "four", "five" }, argument.Values);
+            Assert.Equal(new[] { "one", "two", "three", "four", "five" }, argument?.Values);
         }
 
         [Fact]
         public void ArgumentsCanBeUsedOnParentCommands()
         {
-            CommandArgument projArg = null;
+            CommandArgument? projArg = null;
             var app = new CommandLineApplication();
             var slnArg = app.Argument("SLN_PATH", "Solution file");
 
@@ -177,15 +177,15 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             var exitCode = app.Execute("CommandLineUtils.sln", "sln", "Tests.csproj");
             Assert.Equal(0, exitCode);
             Assert.Equal("CommandLineUtils.sln", slnArg.Value);
-            Assert.Equal("Tests.csproj", projArg.Value);
+            Assert.Equal("Tests.csproj", projArg?.Value);
         }
 
         [Fact]
         public void MultipleValuesArgumentConsumesAllRemainingArgumentValues()
         {
-            CommandArgument first = null;
-            CommandArgument second = null;
-            CommandArgument third = null;
+            CommandArgument? first = null;
+            CommandArgument? second = null;
+            CommandArgument? third = null;
 
             var app = new CommandLineApplication();
 
@@ -199,9 +199,9 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
 
             app.Execute("test", "one", "two", "three", "four", "five");
 
-            Assert.Equal("one", first.Value);
-            Assert.Equal("two", second.Value);
-            Assert.Equal(new[] { "three", "four", "five" }, third.Values);
+            Assert.Equal("one", first?.Value);
+            Assert.Equal("two", second?.Value);
+            Assert.Equal(new[] { "three", "four", "five" }, third?.Values);
         }
 
         [Fact]
@@ -218,8 +218,8 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         [Fact]
         public void OptionSwitchMayBeProvided()
         {
-            CommandOption first = null;
-            CommandOption second = null;
+            CommandOption? first = null;
+            CommandOption? second = null;
 
             var app = new CommandLineApplication();
 
@@ -232,14 +232,14 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
 
             app.Execute("test", "--first", "one", "--second", "two");
 
-            Assert.Equal("one", first.Values[0]);
-            Assert.Equal("two", second.Values[0]);
+            Assert.Equal("one", first?.Values[0]);
+            Assert.Equal("two", second?.Values[0]);
         }
 
         [Fact]
         public void OptionValueMustBeProvided()
         {
-            CommandOption first = null;
+            CommandOption? first = null;
 
             var app = new CommandLineApplication();
 
@@ -251,14 +251,14 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
 
             var ex = Assert.ThrowsAny<CommandParsingException>(() => app.Execute("test", "--first"));
 
-            Assert.Contains($"Missing value for option '{first.LongName}'", ex.Message);
+            Assert.Contains($"Missing value for option '{first?.LongName}'", ex.Message);
         }
 
         [Fact]
         public void ValuesMayBeAttachedToSwitch()
         {
-            CommandOption first = null;
-            CommandOption second = null;
+            CommandOption? first = null;
+            CommandOption? second = null;
 
             var app = new CommandLineApplication();
 
@@ -271,15 +271,15 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
 
             app.Execute("test", "--first=one", "--second:two");
 
-            Assert.Equal("one", first.Values[0]);
-            Assert.Equal("two", second.Values[0]);
+            Assert.Equal("one", first?.Values[0]);
+            Assert.Equal("two", second?.Values[0]);
         }
 
         [Fact]
         public void ShortNamesMayBeDefined()
         {
-            CommandOption first = null;
-            CommandOption second = null;
+            CommandOption? first = null;
+            CommandOption? second = null;
 
             var app = new CommandLineApplication();
 
@@ -292,8 +292,8 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
 
             app.Execute("test", "-1=one", "-2", "two");
 
-            Assert.Equal("one", first.Values[0]);
-            Assert.Equal("two", second.Values[0]);
+            Assert.Equal("one", first?.Values[0]);
+            Assert.Equal("two", second?.Values[0]);
         }
 
         [Fact]
@@ -432,7 +432,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         public void ThrowsExceptionOnUnexpectedOptionBeforeValidSubcommandByDefault()
         {
             var unexpectedOption = "--unexpected";
-            CommandLineApplication subCmd = null;
+            CommandLineApplication? subCmd = null;
             var app = new CommandLineApplication();
 
             app.Command("k", c =>
@@ -449,7 +449,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         public void AllowNoThrowBehaviorOnUnexpectedOptionAfterSubcommand()
         {
             var unexpectedOption = "--unexpected";
-            CommandLineApplication subCmd = null;
+            CommandLineApplication? subCmd = null;
             var app = new CommandLineApplication();
 
             var testCmd = app.Command("k", c =>
@@ -461,7 +461,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             // (does not throw)
             app.Execute("k", "run", unexpectedOption);
             Assert.Empty(testCmd.RemainingArguments);
-            var arg = Assert.Single(subCmd.RemainingArguments);
+            var arg = Assert.Single(subCmd?.RemainingArguments);
             Assert.Equal(unexpectedOption, arg);
         }
 
@@ -470,7 +470,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         {
             var app = new CommandLineApplication();
             var optionA = app.Option("-a|--option-a", "", CommandOptionType.SingleValue, inherited: true);
-            string optionAValue = null;
+            string? optionAValue = null;
 
             var optionB = app.Option("-b", "", CommandOptionType.SingleValue, inherited: false);
 
@@ -512,7 +512,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         {
             var app = new CommandLineApplication();
             var top = app.Option("-a|--always", "Top-level", CommandOptionType.SingleValue, inherited: false);
-            CommandOption nested = null;
+            CommandOption? nested = null;
             app.Command("subcmd", c =>
             {
                 nested = c.Option("-a|--ask", "Nested", CommandOptionType.SingleValue);
@@ -520,22 +520,22 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
 
             app.Execute("-a", "top");
             Assert.Equal("top", top.Value());
-            Assert.Null(nested.Value());
+            Assert.Null(nested?.Value());
 
             top.Values.Clear();
 
             app.Execute("subcmd", "-a", "nested");
             Assert.Null(top.Value());
-            Assert.Equal("nested", nested.Value());
+            Assert.Equal("nested", nested?.Value());
         }
 
         [Fact]
         public void NestedInheritedOptions()
         {
-            string globalOptionValue = null, nest1OptionValue = null, nest2OptionValue = null;
+            string? globalOptionValue = null, nest1OptionValue = null, nest2OptionValue = null;
 
             var app = new CommandLineApplication();
-            CommandLineApplication subcmd2 = null;
+            CommandLineApplication? subcmd2 = null;
             var g = app.Option("-g|--global", "Global option", CommandOptionType.SingleValue, inherited: true);
             var subcmd1 = app.Command("lvl1", s1 =>
             {
@@ -562,9 +562,9 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             Assert.Contains(subcmd1.GetOptions(), o => o.LongName == "nest1");
             Assert.Contains(subcmd1.GetOptions(), o => o.LongName == "global");
 
-            Assert.Contains(subcmd2.GetOptions(), o => o.LongName == "nest2");
-            Assert.Contains(subcmd2.GetOptions(), o => o.LongName == "nest1");
-            Assert.Contains(subcmd2.GetOptions(), o => o.LongName == "global");
+            Assert.Contains(subcmd2?.GetOptions(), o => o.LongName == "nest2");
+            Assert.Contains(subcmd2?.GetOptions(), o => o.LongName == "nest1");
+            Assert.Contains(subcmd2?.GetOptions(), o => o.LongName == "global");
 
             Assert.ThrowsAny<CommandParsingException>(() => app.Execute("--nest2", "N2", "--nest1", "N1", "-g", "G"));
             Assert.ThrowsAny<CommandParsingException>(() => app.Execute("lvl1", "--nest2", "N2", "--nest1", "N1", "-g", "G"));
@@ -947,7 +947,7 @@ Examples:
         public void CommandNamesMatchingIsCaseInsensitive()
         {
             var app = new CommandLineApplication(throwOnUnexpectedArg: false);
-            var cmd = app.Command("CMD1", null);
+            var cmd = app.Command("CMD1", _ => {});
 
             Assert.Same(cmd, app.Parse("CMD1").SelectedCommand);
             Assert.Same(cmd, app.Parse("cmd1").SelectedCommand);

--- a/test/CommandLineUtils.Tests/CommandLineProcessorTests.cs
+++ b/test/CommandLineUtils.Tests/CommandLineProcessorTests.cs
@@ -124,7 +124,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         private class ShortNameType
         {
             [Option(ShortName = "au")]
-            public string Auth { get; }
+            public string? Auth { get; }
         }
 
         [Command]

--- a/test/CommandLineUtils.Tests/ConstructorInjectionConventionTests.cs
+++ b/test/CommandLineUtils.Tests/ConstructorInjectionConventionTests.cs
@@ -68,10 +68,10 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             public int GetArgCount() => _arguments.Count();
 
             [Option]
-            public string Opt { get; }
+            public string? Opt { get; }
 
             [Argument(0)]
-            public string Arg { get; }
+            public string? Arg { get; }
         }
 
         [Fact]
@@ -157,7 +157,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         private class TestAppWithAlternativeConstructor
         {
             public IConsole Console { get; }
-            public CommandLineApplication App { get; }
+            public CommandLineApplication? App { get; }
 
             public TestAppWithAlternativeConstructor(TestConsole console, CommandLineApplication app)
             {

--- a/test/CommandLineUtils.Tests/CustomValidationAttributeTest.cs
+++ b/test/CommandLineUtils.Tests/CustomValidationAttributeTest.cs
@@ -49,7 +49,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         private class RedBlueProgram
         {
             [Option, RedOrBlue]
-            public string Color { get; }
+            public string? Color { get; }
         }
 
         class RedOrBlueAttribute : ValidationAttribute

--- a/test/CommandLineUtils.Tests/DefaultHelpOptionTests.cs
+++ b/test/CommandLineUtils.Tests/DefaultHelpOptionTests.cs
@@ -16,8 +16,8 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         {
             var app = new CommandLineApplication<ProgramWithHelpOption>();
             app.Conventions.UseDefaultConventions();
-            Assert.Equal("H", app.OptionHelp.ShortName);
-            Assert.Null(app.OptionHelp.LongName);
+            Assert.Equal("H", app.OptionHelp?.ShortName);
+            Assert.Null(app.OptionHelp?.LongName);
         }
 
         [Fact]
@@ -36,9 +36,9 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             app.Option("-h", "test", CommandOptionType.NoValue);
             app.Conventions.UseDefaultHelpOption();
             Assert.NotNull(app.OptionHelp);
-            Assert.Null(app.OptionHelp.ShortName);
-            Assert.NotNull(app.OptionHelp.LongName);
-            Assert.NotNull(app.OptionHelp.SymbolName);
+            Assert.Null(app.OptionHelp?.ShortName);
+            Assert.NotNull(app.OptionHelp?.LongName);
+            Assert.NotNull(app.OptionHelp?.SymbolName);
         }
 
         [Fact]
@@ -53,9 +53,9 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
 
             Assert.Null(app.OptionHelp);
             Assert.NotNull(subcmd.OptionHelp);
-            Assert.Null(subcmd.OptionHelp.ShortName);
-            Assert.NotNull(subcmd.OptionHelp.LongName);
-            Assert.NotNull(subcmd.OptionHelp.SymbolName);
+            Assert.Null(subcmd.OptionHelp?.ShortName);
+            Assert.NotNull(subcmd.OptionHelp?.LongName);
+            Assert.NotNull(subcmd.OptionHelp?.SymbolName);
         }
 
         [Subcommand(typeof(Sub))]
@@ -71,11 +71,11 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             app.Conventions.UseDefaultConventions();
             var subcmd = Assert.Single(app.Commands);
             Assert.NotNull(app.OptionHelp);
-            Assert.False(app.OptionHelp.Inherited);
-            Assert.Equal("?", app.OptionHelp.SymbolName);
-            Assert.Equal("h", app.OptionHelp.ShortName);
-            Assert.Equal("help", app.OptionHelp.LongName);
-            Assert.Null(app.OptionHelp.ValueName);
+            Assert.False(app.OptionHelp?.Inherited);
+            Assert.Equal("?", app.OptionHelp?.SymbolName);
+            Assert.Equal("h", app.OptionHelp?.ShortName);
+            Assert.Equal("help", app.OptionHelp?.LongName);
+            Assert.Null(app.OptionHelp?.ValueName);
             Assert.NotSame(app.OptionHelp, subcmd.OptionHelp);
         }
 

--- a/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
+++ b/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
@@ -22,7 +22,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         private class EmptyShortName
         {
             [Option(ShortName = "")]
-            public string Option { get; }
+            public string? Option { get; }
         }
 
         [Fact]
@@ -53,8 +53,8 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         {
             var app = new CommandLineApplication<EmptyShortName>();
             app.Conventions.UseDefaultConventions();
-            app.Command("b", null);
-            app.Command("a", null);
+            app.Command("b", _ => { });
+            app.Command("a", _ => { });
             var helpText = GetHelpText(app);
 
             var indexOfA = helpText.IndexOf("  a", StringComparison.InvariantCulture);
@@ -68,8 +68,8 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             DefaultHelpTextGenerator.Singleton.SortCommandsByName = false;
             var app = new CommandLineApplication<EmptyShortName>();
             app.Conventions.UseDefaultConventions();
-            app.Command("b", null);
-            app.Command("a", null);
+            app.Command("b", _ => { });
+            app.Command("a", _ => { });
             var helpText = GetHelpText(app);
 
             var indexOfA = helpText.IndexOf("  a", StringComparison.InvariantCulture);

--- a/test/CommandLineUtils.Tests/ExecuteMethodConventionTests.cs
+++ b/test/CommandLineUtils.Tests/ExecuteMethodConventionTests.cs
@@ -88,7 +88,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         [Theory]
         [InlineData(null, 0)]
         [InlineData("subcommand", 1)]
-        public void OnExecuteIsExecutedOnSelectedSubcommand(string args, int expectedResult)
+        public void OnExecuteIsExecutedOnSelectedSubcommand(string? args, int expectedResult)
         {
             var app = new CommandLineApplication<MainExecute>();
             app.Conventions.UseSubcommandAttributes();
@@ -96,7 +96,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             app.Conventions.UseOnExecuteMethodFromModel();
 
             // this tests that the model is actually given values before it passed to command validation
-            var parseResult = app.Parse(args?.Split(' '));
+            var parseResult = app.Parse(args?.Split(' ') ?? Util.EmptyArray<string>());
 
             var result = parseResult.SelectedCommand.Invoke();
             Assert.Equal(expectedResult, result);

--- a/test/CommandLineUtils.Tests/FilePathExistsAttributeTests.cs
+++ b/test/CommandLineUtils.Tests/FilePathExistsAttributeTests.cs
@@ -23,14 +23,14 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         {
             [Argument(0)]
             [FileOrDirectoryExists]
-            public string File { get; }
+            public string? File { get; }
 
             private void OnExecute() { }
         }
 
         [Theory]
         [MemberData(nameof(BadFilePaths))]
-        public void ValidatesFilesMustExist(string filePath)
+        public void ValidatesFilesMustExist(string? filePath)
         {
             var app = new CommandLineApplication(
                 new TestConsole(_output),
@@ -40,7 +40,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
                 .Accepts().ExistingFileOrDirectory();
 
             var result = app
-                .Parse(filePath)
+                .Parse(filePath!)
                 .SelectedCommand
                 .GetValidationResult();
 
@@ -48,11 +48,11 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             Assert.Equal($"The file path '{filePath}' does not exist.", result.ErrorMessage);
 
             var console = new TestConsole(_output);
-            Assert.NotEqual(0, CommandLineApplication.Execute<App>(console, filePath));
+            Assert.NotEqual(0, CommandLineApplication.Execute<App>(console, filePath!));
         }
 
-        public static TheoryData<string> BadFilePaths
-            => new TheoryData<string>
+        public static TheoryData<string?> BadFilePaths
+            => new TheoryData<string?>
             {
                 "notfound.txt",
                 "\0",
@@ -127,7 +127,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         {
             [Argument(0)]
             [DirectoryExists]
-            public string Dir { get; }
+            public string? Dir { get; }
 
             private void OnExecute() { }
         }
@@ -136,7 +136,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         {
             [Argument(0)]
             [FileExists]
-            public string Path { get; }
+            public string? Path { get; }
 
             private void OnExecute() { }
         }

--- a/test/CommandLineUtils.Tests/FilePathNotExistsAttributeTests.cs
+++ b/test/CommandLineUtils.Tests/FilePathNotExistsAttributeTests.cs
@@ -23,7 +23,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         {
             [Argument(0)]
             [FileOrDirectoryNotExists]
-            public string File { get; }
+            public string? File { get; }
 
             private void OnExecute() { }
         }
@@ -44,7 +44,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
 
             app.Argument("Files", "Files")
                 .Accepts().NonExistingFileOrDirectory();
-                
+
             var result = app
                 .Parse(filePath)
                 .SelectedCommand
@@ -56,15 +56,6 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             var console = new TestConsole(_output);
             Assert.NotEqual(0, CommandLineApplication.Execute<App>(console, filePath));
         }
-
-        public static TheoryData<string> BadFilePaths
-            => new TheoryData<string>
-            {
-                "notfound.txt",
-                "\0",
-                null,
-                string.Empty,
-            };
 
         [Fact]
         public void ValidatesFilesRelativeToAppContext()
@@ -133,7 +124,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         {
             [Argument(0)]
             [DirectoryNotExists]
-            public string Dir { get; }
+            public string? Dir { get; }
 
             private void OnExecute() { }
         }
@@ -142,7 +133,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         {
             [Argument(0)]
             [FileNotExists]
-            public string Path { get; }
+            public string? Path { get; }
 
             private void OnExecute() { }
         }

--- a/test/CommandLineUtils.Tests/HelpOptionAttributeTests.cs
+++ b/test/CommandLineUtils.Tests/HelpOptionAttributeTests.cs
@@ -67,7 +67,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         private class HelpOptionOnNonBoolean
         {
             [HelpOption]
-            public string IsHelpOption { get; set; }
+            public string? IsHelpOption { get; set; }
         }
 
         [Fact]
@@ -82,7 +82,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         {
             [HelpOption]
             [Option]
-            public string IsHelpOption { get; set; }
+            public string? IsHelpOption { get; set; }
         }
 
         [Fact]
@@ -105,11 +105,11 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             var app = new CommandLineApplication<WithTypeHelpOption>();
             app.Conventions.UseHelpOptionAttribute();
             Assert.NotNull(app.OptionHelp);
-            Assert.Equal(CommandOptionType.NoValue, app.OptionHelp.OptionType);
-            Assert.Null(app.OptionHelp.SymbolName);
-            Assert.Equal("h", app.OptionHelp.ShortName);
-            Assert.Equal("help", app.OptionHelp.LongName);
-            Assert.Equal("My help info", app.OptionHelp.Description);
+            Assert.Equal(CommandOptionType.NoValue, app.OptionHelp?.OptionType);
+            Assert.Null(app.OptionHelp?.SymbolName);
+            Assert.Equal("h", app.OptionHelp?.ShortName);
+            Assert.Equal("help", app.OptionHelp?.LongName);
+            Assert.Equal("My help info", app.OptionHelp?.Description);
         }
 
         private class WithPropHelpOption
@@ -124,11 +124,11 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             var app = new CommandLineApplication<WithPropHelpOption>();
             app.Conventions.UseHelpOptionAttribute();
             Assert.NotNull(app.OptionHelp);
-            Assert.Equal(CommandOptionType.NoValue, app.OptionHelp.OptionType);
-            Assert.Null(app.OptionHelp.SymbolName);
-            Assert.Equal("h", app.OptionHelp.ShortName);
-            Assert.Equal("help", app.OptionHelp.LongName);
-            Assert.Equal("My help info", app.OptionHelp.Description);
+            Assert.Equal(CommandOptionType.NoValue, app.OptionHelp?.OptionType);
+            Assert.Null(app.OptionHelp?.SymbolName);
+            Assert.Equal("h", app.OptionHelp?.ShortName);
+            Assert.Equal("help", app.OptionHelp?.LongName);
+            Assert.Equal("My help info", app.OptionHelp?.Description);
         }
 
         [HelpOption]
@@ -158,7 +158,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             private class Sub
             {
                 [Argument(0, Name = "lvl-arg", Description = "subcommand argument")]
-                public string Arg { get; }
+                public string? Arg { get; }
             }
         }
 
@@ -173,7 +173,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             app.Execute("lvl2", "--help");
             var outData = sb.ToString();
 
-            Assert.True(app.OptionHelp.HasValue());
+            Assert.True(app.OptionHelp?.HasValue());
             Assert.Contains("Usage: lvl1 lvl2 [options] <lvl-arg>", outData);
         }
 
@@ -196,7 +196,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             {
                 getCommand.Description = "Gets a list of things.";
                 getCommand.HelpOption();
-                
+
                 getCommand.OnExecute(() =>
                 {
                     getCommand.ShowHelp();

--- a/test/CommandLineUtils.Tests/LegalFilePathAttributeTests.cs
+++ b/test/CommandLineUtils.Tests/LegalFilePathAttributeTests.cs
@@ -18,7 +18,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         private class App
         {
             [Argument(0), LegalFilePath]
-            public string FilePath { get; set; }
+            public string? FilePath { get; set; }
             private void OnExecute() { }
         }
 

--- a/test/CommandLineUtils.Tests/OptionAttributeTests.cs
+++ b/test/CommandLineUtils.Tests/OptionAttributeTests.cs
@@ -21,7 +21,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         private class AppWithUnknownOptionType
         {
             [Option]
-            public OptionAttributeTests Option { get; }
+            public OptionAttributeTests? Option { get; }
         }
 
         [Fact]
@@ -37,10 +37,10 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         private class ShortNameOverride
         {
             [Option(ShortName = "d1")]
-            public string Detail1 { get; }
+            public string? Detail1 { get; }
 
             [Option(ShortName = "d2")]
-            public string Detail2 { get; }
+            public string? Detail2 { get; }
         }
 
         [Fact]
@@ -60,10 +60,10 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         private class EmptyShortName
         {
             [Option(ShortName = "")]
-            public string Detail1 { get; }
+            public string? Detail1 { get; }
 
             [Option(ShortName = "")]
-            public string Detail2 { get; }
+            public string? Detail2 { get; }
         }
 
         [Fact]
@@ -177,7 +177,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             app4.Parse("-a3", "-a4");
             Assert.True(app4.Model.Arg3.HasValue);
             Assert.True(app4.Model.Arg4.hasValue);
-            Assert.True(app4.Model.Arg3.Value);
+            Assert.True(app4.Model.Arg3);
             Assert.Equal((true, null), app4.Model.Arg4);
         }
 

--- a/test/CommandLineUtils.Tests/ParentPropertyConventionTests.cs
+++ b/test/CommandLineUtils.Tests/ParentPropertyConventionTests.cs
@@ -10,12 +10,12 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         [Subcommand(typeof(AddCommand))]
         private class Program
         {
-            public object Subcommand { get; set; }
+            public object? Subcommand { get; set; }
         }
 
         private class AddCommand
         {
-            public object Parent { get; }
+            public object? Parent { get; }
         }
 
         [Fact]

--- a/test/CommandLineUtils.Tests/RemainingArgsPropertyConventionTests.cs
+++ b/test/CommandLineUtils.Tests/RemainingArgsPropertyConventionTests.cs
@@ -23,7 +23,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
 
         private class RemainingArguments_Array
         {
-            public string[] RemainingArguments { get; }
+            public string[]? RemainingArguments { get; }
         }
 
         [Fact]
@@ -36,7 +36,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
 
         private class RemainingArgs_Array
         {
-            public string[] RemainingArgs { get; }
+            public string[]? RemainingArgs { get; }
         }
 
 
@@ -50,7 +50,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
 
         private class Parent
         {
-            public object Subcommand { get; }
+            public object? Subcommand { get; }
         }
 
         [Fact]
@@ -65,7 +65,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
 
         private class RemainingArgs_List
         {
-            public List<string> RemainingArguments { get; }
+            public List<string>? RemainingArguments { get; }
         }
 
         [Fact]

--- a/test/CommandLineUtils.Tests/ResponseFileTests.cs
+++ b/test/CommandLineUtils.Tests/ResponseFileTests.cs
@@ -30,7 +30,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             return rsp;
         }
 
-        private List<string> ParseResponseFile(ResponseFileHandling options, params string[] responseFileLines)
+        private List<string?> ParseResponseFile(ResponseFileHandling options, params string[] responseFileLines)
         {
             var rsp = CreateResponseFile(responseFileLines);
             var app = new CommandLineApplication
@@ -261,7 +261,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         public void SubcommandsCanResponseFileOptions()
         {
             var app = new CommandLineApplication();
-            CommandArgument wordArgs = null;
+            CommandArgument? wordArgs = null;
             app.Command("save", c =>
             {
                 c.ResponseFileHandling = ResponseFileHandling.ParseArgsAsSpaceSeparated;
@@ -269,7 +269,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             });
             var rspFile = CreateResponseFile(" 'lorem ipsum' ", "dolor sit amet");
             app.Execute("save", "@" + rspFile);
-            Assert.Collection(wordArgs.Values,
+            Assert.Collection(wordArgs?.Values,
                 a => Assert.Equal("lorem ipsum", a),
                 a => Assert.Equal("dolor", a),
                 a => Assert.Equal("sit", a),

--- a/test/CommandLineUtils.Tests/StringDistanceTests.cs
+++ b/test/CommandLineUtils.Tests/StringDistanceTests.cs
@@ -107,9 +107,9 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         [Fact]
         public void MatchingWithNullReturnsNull()
         {
-            Assert.Null(StringDistance.GetBestMatchesSorted(null, "", new []{ ""}, 0));
-            Assert.Null(StringDistance.GetBestMatchesSorted((s, s1) => 1, null, new []{ ""}, 0));
-            Assert.Null(StringDistance.GetBestMatchesSorted((s, s1) => 1, "", null, 0));
+            Assert.Empty(StringDistance.GetBestMatchesSorted(null, "", new []{ ""}, 0));
+            Assert.Empty(StringDistance.GetBestMatchesSorted((s, s1) => 1, null, new []{ ""}, 0));
+            Assert.Empty(StringDistance.GetBestMatchesSorted((s, s1) => 1, "", null, 0));
         }
 
         [Theory]

--- a/test/CommandLineUtils.Tests/SubcommandAttributeTests.cs
+++ b/test/CommandLineUtils.Tests/SubcommandAttributeTests.cs
@@ -25,13 +25,13 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             typeof(RemoveCmd))]
         private class Program
         {
-            public object Subcommand { get; set; }
+            public object? Subcommand { get; set; }
         }
 
         [Command("add", "a", "addition")]
         private class AddCmd
         {
-            public object Parent { get; }
+            public object? Parent { get; }
         }
 
         [Command("rm")]
@@ -66,7 +66,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
 
             protected override int OnExecute(CommandLineApplication app) => 101;
 
-            public MasterApp Parent { get; }
+            public MasterApp? Parent { get; }
         }
 
         private class Level2Command : CommandBase
@@ -77,7 +77,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             protected override int OnExecute(CommandLineApplication app)
                 => Value.HasValue ? Value.Value : 102;
 
-            public Level1Command Parent { get; }
+            public Level1Command? Parent { get; }
         }
 
         abstract class CommandBase
@@ -85,7 +85,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             [HelpOption("--help")]
             protected bool IsHelp { get; }
 
-            public CommandBase Subcommand { get; set; }
+            public CommandBase? Subcommand { get; set; }
 
             protected abstract int OnExecute(CommandLineApplication app);
         }
@@ -173,11 +173,11 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         {
             var app = CommandLineParser.ParseArgs<MasterApp>("level1", "--mid", "level2", "--verbose", "--value", "6");
             Assert.IsType<Level1Command>(app.Subcommand);
-            var sub = Assert.IsType<Level2Command>(app.Subcommand.Subcommand);
+            var sub = Assert.IsType<Level2Command>(app.Subcommand?.Subcommand);
             Assert.NotNull(sub.Parent);
-            Assert.NotNull(sub.Parent.Parent);
-            Assert.True(sub.Parent.Mid);
-            Assert.True(sub.Parent.Parent.Verbose);
+            Assert.NotNull(sub.Parent?.Parent);
+            Assert.True(sub.Parent?.Mid);
+            Assert.True(sub.Parent?.Parent?.Verbose);
             Assert.Equal(6, sub.Value);
         }
 

--- a/test/CommandLineUtils.Tests/SubcommandPropertyConventionTests.cs
+++ b/test/CommandLineUtils.Tests/SubcommandPropertyConventionTests.cs
@@ -10,12 +10,12 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         [Subcommand(typeof(AddCommand))]
         private class Program
         {
-            public object Subcommand { get; set; }
+            public object? Subcommand { get; set; }
         }
 
         private class AddCommand
         {
-            public object Parent { get; }
+            public object? Parent { get; }
         }
 
         [Fact]

--- a/test/CommandLineUtils.Tests/ValidateMethodConventionTests.cs
+++ b/test/CommandLineUtils.Tests/ValidateMethodConventionTests.cs
@@ -80,9 +80,9 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
 
                 Assert.Equal(typeof(CommandLineApplication<SubcommandValidate>), context.ObjectInstance.GetType());
                 var subcommand = (CommandLineApplication<SubcommandValidate>) context.ObjectInstance;
-                var main = (CommandLineApplication<MainValidate>) subcommand.Parent;
+                var main = (CommandLineApplication<MainValidate>?) subcommand.Parent;
 
-                var middle = main.Model.Middle;
+                var middle = main?.Model.Middle;
                 if (middle.HasValue)
                 {
                     if (middle.Value < this.Start || middle.Value >= this.End)

--- a/test/CommandLineUtils.Tests/ValidationTests.cs
+++ b/test/CommandLineUtils.Tests/ValidationTests.cs
@@ -89,7 +89,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         private class RequiredOption
         {
             [Required, Option]
-            public string Param { get; set; }
+            public string? Param { get; set; }
 
             private void OnExecute() { }
         }
@@ -100,12 +100,15 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             Assert.Equal(0, CommandLineApplication.Execute<RequiredOption>("-p", "p"));
         }
 
+// Workaround https://github.com/dotnet/roslyn/issues/33199 https://github.com/xunit/xunit/issues/1897
+#nullable disable
         [Theory]
         [InlineData(null)]
         [InlineData(new object[] { new[] { "-p", "" } })]
         [InlineData(new object[] { new[] { "-p", " " } })]
         public void RequiredOption_Attribute_Fail(string[] args)
         {
+#nullable enable
             Assert.NotEqual(0, CommandLineApplication.Execute<RequiredOption>(new TestConsole(_output), args));
         }
 
@@ -114,12 +117,12 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         [InlineData(new string[0], false)]
         [InlineData(new[] { " " }, false)]
         [InlineData(new[] { "val", "" }, false)]
-        [InlineData(new string[] { null }, false)]
-        public void RequiredArgument_Fail(string[] args, bool allowEmptyStrings)
+        [InlineData(new string?[] { null }, false)]
+        public void RequiredArgument_Fail(string?[] args, bool allowEmptyStrings)
         {
             var app = new CommandLineApplication(new TestConsole(_output));
             app.Argument("Test", "Test arg", multipleValues: true).IsRequired(allowEmptyStrings);
-            Assert.NotEqual(0, app.Execute(args));
+            Assert.NotEqual(0, app.Execute(args!));
         }
 
         [Theory]
@@ -164,7 +167,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         private class ValidationErrorApp
         {
             [Required, Option]
-            public string Name { get; }
+            public string? Name { get; }
             private int OnValidationError()
             {
                 return 7;
@@ -175,7 +178,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         private class ValidationErrorSubcommand
         {
             [Argument(0), Required]
-            public string[] Args { get; }
+            public string[]? Args { get; }
 
             private int OnValidationError()
             {
@@ -198,7 +201,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         private class ThrowOnExecuteApp
         {
             [Option, Required]
-            public string Name { get; }
+            public string? Name { get; }
             private int OnExecute()
             {
                 throw new InvalidOperationException("This method should not be invoked");
@@ -309,7 +312,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         private class ProgramWithRequiredArg
         {
             [Argument(0), Required(ErrorMessage = "Arg is required")]
-            public string Version { get; }
+            public string? Version { get; }
 
             private void OnValidationError()
             {

--- a/test/CommandLineUtils.Tests/ValueParserProviderCustomTests.cs
+++ b/test/CommandLineUtils.Tests/ValueParserProviderCustomTests.cs
@@ -15,7 +15,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         {
             public Type TargetType { get; } = typeof(DateTimeOffset);
 
-            public object Parse(string argName, string value, CultureInfo culture)
+            public object? Parse(string? argName, string? value, CultureInfo culture)
             {
                 if (!DateTimeOffset.TryParse(value, culture, DateTimeStyles.None, out var result))
                 {
@@ -31,7 +31,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         {
             public Type TargetType { get; } = typeof(ValueTuple<int, double, string>?);
 
-            public object Parse(string argName, string value, CultureInfo culture)
+            public object? Parse(string? argName, string? value, CultureInfo culture)
             {
                 if (string.IsNullOrWhiteSpace(value))
                 {
@@ -73,7 +73,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
 
             public Type TargetType { get; } = typeof(double);
 
-            public object Parse(string argName, string value, CultureInfo culture)
+            public object? Parse(string? argName, string? value, CultureInfo culture)
             {
                 if (!double.TryParse(value, NumberStyles.Number, _iso80000NumberFormatInfo, out var result))
                 {
@@ -104,7 +104,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             ValueTuple<int, double, string>? expectedComplexValue = null;
 
             var app = new CommandLineApplication<CustomParserProgram>();
-            
+
             app.ValueParsers.Add(new ComplexTupleParser());
             app.ValueParsers.AddOrReplace(new MyDateTimeOffsetParser());
             app.ValueParsers.AddOrReplace(new MyDoubleParser());
@@ -216,7 +216,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         public void CustomParsersAreAvailableToSubCommands()
         {
             var expectedDate = new DateTimeOffset(2018, 02, 16, 21, 30, 33, 45, TimeSpan.FromHours(10));
-            
+
             var app = new CommandLineApplication<CustomParserProgramAttributes>();
             app.ValueParsers.AddOrReplace(new MyDateTimeOffsetParser());
             app.Conventions.UseDefaultConventions();
@@ -261,9 +261,11 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
 
         private class BadValueParser : IValueParser
         {
-            public Type TargetType { get; } = null;
+#nullable disable // Intentionally testing compatibility
+            public Type TargetType { get; }
+#nullable enable
 
-            public object Parse(string argName, string value, CultureInfo culture)
+            public object? Parse(string? argName, string? value, CultureInfo culture)
             {
                 throw new NotImplementedException();
             }
@@ -305,7 +307,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
                 () =>
                 {
                     var app = new CommandLineApplication<CustomParserProgram>();
-                    app.ValueParsers.Add(null);
+                    app.ValueParsers.Add(null!);
                 });
 
             Assert.Contains("parser", ex.Message);
@@ -318,7 +320,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
                 () =>
                 {
                     var app = new CommandLineApplication<CustomParserProgram>();
-                    app.ValueParsers.AddRange(null);
+                    app.ValueParsers.AddRange(null!);
                 });
 
             Assert.Contains("parsers", ex.Message);
@@ -331,7 +333,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
                 () =>
                 {
                     var app = new CommandLineApplication<CustomParserProgram>();
-                    app.ValueParsers.AddOrReplace(null);
+                    app.ValueParsers.AddOrReplace(null!);
                 });
 
             Assert.Contains("parser", ex.Message);

--- a/test/CommandLineUtils.Tests/ValueParserProviderTests.cs
+++ b/test/CommandLineUtils.Tests/ValueParserProviderTests.cs
@@ -64,22 +64,22 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             public ulong UInt64 { get; }
 
             [Option("--string-arr")]
-            public string[] StringArray { get; }
+            public string[]? StringArray { get; }
 
             [Option("--int32-arr")]
-            public int[] Int32Array { get; }
+            public int[]? Int32Array { get; }
 
             [Option("--flag")]
-            public bool[] Flags { get; }
+            public bool[]? Flags { get; }
 
             [Option("--string-ilist")]
-            public IList<string> StringIList { get; }
+            public IList<string>? StringIList { get; }
 
             [Option("--string-list")]
-            public List<string> StringList { get; }
+            public List<string>? StringList { get; }
 
             [Option("--string-set")]
-            public ISet<string> StringSet { get; }
+            public ISet<string>? StringSet { get; }
 
             [Option("--color")]
             public Color Color { get; }
@@ -100,7 +100,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             public (bool HasValue, Color Value) EnumValueTuple { get; }
 
             [Option("--uri")]
-            public Uri Uri { get; set; }
+            public Uri? Uri { get; set; }
 
             [Option("--datetime")]
             public DateTime DateTime { get; }
@@ -128,6 +128,8 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             }
         }
 
+// Workaround https://github.com/dotnet/roslyn/issues/33199 https://github.com/xunit/xunit/issues/1897
+#nullable disable
         public static IEnumerable<object[]> GetFloatingPointSymbolsData()
         {
             using (new InCulture(CultureInfo.InvariantCulture))
@@ -141,6 +143,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
                 };
             }
         }
+#nullable enable
 
         [Theory]
         [InlineData("255", byte.MaxValue)]
@@ -315,32 +318,32 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         public void ParsesInt32Array()
         {
             var parsed = CommandLineParser.ParseArgs<Program>("--int32-arr", "-1", "--int32-arr", "1");
-            Assert.Equal(-1, parsed.Int32Array[0]);
-            Assert.Equal(1, parsed.Int32Array[1]);
+            Assert.Equal(-1, parsed.Int32Array?[0]);
+            Assert.Equal(1, parsed.Int32Array?[1]);
         }
 
         [Fact]
         public void ParsesStringArray()
         {
             var parsed = CommandLineParser.ParseArgs<Program>("--string-arr", "first", "--string-arr", "second");
-            Assert.Equal("first", parsed.StringArray[0]);
-            Assert.Equal("second", parsed.StringArray[1]);
+            Assert.Equal("first", parsed.StringArray?[0]);
+            Assert.Equal("second", parsed.StringArray?[1]);
         }
 
         [Fact]
         public void ParsesStringIList()
         {
             var parsed = CommandLineParser.ParseArgs<Program>("--string-ilist", "first", "--string-ilist", "second");
-            Assert.Equal("first", parsed.StringIList[0]);
-            Assert.Equal("second", parsed.StringIList[1]);
+            Assert.Equal("first", parsed.StringIList?[0]);
+            Assert.Equal("second", parsed.StringIList?[1]);
         }
 
         [Fact]
         public void ParsesStringList()
         {
             var parsed = CommandLineParser.ParseArgs<Program>("--string-list", "first", "--string-list", "second");
-            Assert.Equal("first", parsed.StringList[0]);
-            Assert.Equal("second", parsed.StringList[1]);
+            Assert.Equal("first", parsed.StringList?[0]);
+            Assert.Equal("second", parsed.StringList?[1]);
         }
 
 
@@ -424,7 +427,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         public void ParsesUri(string uriString)
         {
             var parsed = CommandLineParser.ParseArgs<Program>("--uri", uriString);
-            Assert.Equal(uriString, parsed.Uri.ToString());
+            Assert.Equal(uriString, parsed.Uri?.ToString());
         }
 
         [Theory]
@@ -473,7 +476,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
 
             var parsed = CommandLineParser.ParseArgs<Program>(args.ToArray());
             Assert.NotNull(parsed.Flags);
-            Assert.Equal(repeat, parsed.Flags.Length);
+            Assert.Equal(repeat, parsed.Flags?.Length);
             Assert.All(parsed.Flags, value => Assert.True(value));
         }
 
@@ -501,7 +504,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             public bool BoolArg { get; }
 
             [Argument(2)]
-            public IList<string> TheRest { get; }
+            public IList<string>? TheRest { get; }
         }
 
         [Fact]
@@ -515,9 +518,9 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
 
             Assert.Equal(1, parsed.Int32Arg);
             Assert.True(parsed.BoolArg);
-            Assert.Equal(2, parsed.TheRest.Count);
-            Assert.Equal("a", parsed.TheRest[0]);
-            Assert.Equal("b", parsed.TheRest[1]);
+            Assert.Equal(2, parsed.TheRest?.Count);
+            Assert.Equal("a", parsed.TheRest?[0]);
+            Assert.Equal("b", parsed.TheRest?[1]);
         }
 
         [Fact]

--- a/test/CommandLineUtils.Tests/VersionOptionAttributeTests.cs
+++ b/test/CommandLineUtils.Tests/VersionOptionAttributeTests.cs
@@ -65,7 +65,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         private class VersionOptionOnNonBoolean
         {
             [VersionOption("1.2.0")]
-            public string IsVersionOption { get; set; }
+            public string? IsVersionOption { get; set; }
         }
 
         [Fact]
@@ -80,7 +80,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         {
             [VersionOption("1.2.0")]
             [Option]
-            public string IsVersionOption { get; set; }
+            public string? IsVersionOption { get; set; }
         }
 
         [Fact]
@@ -96,7 +96,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         {
             [VersionOption("1.2.0")]
             [HelpOption]
-            public string IsVersionOption { get; set; }
+            public string? IsVersionOption { get; set; }
         }
 
         [Fact]
@@ -120,11 +120,11 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             var app = new CommandLineApplication<WithTypeVersionOption>();
             app.Conventions.UseVersionOptionAttribute();
             Assert.NotNull(app.OptionVersion);
-            Assert.Equal(CommandOptionType.NoValue, app.OptionVersion.OptionType);
-            Assert.Null(app.OptionVersion.SymbolName);
-            Assert.Null(app.OptionVersion.ShortName);
-            Assert.Equal("version", app.OptionVersion.LongName);
-            Assert.Equal("My version info", app.OptionVersion.Description);
+            Assert.Equal(CommandOptionType.NoValue, app.OptionVersion?.OptionType);
+            Assert.Null(app.OptionVersion?.SymbolName);
+            Assert.Null(app.OptionVersion?.ShortName);
+            Assert.Equal("version", app.OptionVersion?.LongName);
+            Assert.Equal("My version info", app.OptionVersion?.Description);
         }
 
         private class WithPropVersionOption
@@ -139,11 +139,11 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             var app = new CommandLineApplication<WithPropVersionOption>();
             app.Conventions.UseVersionOptionAttribute();
             Assert.NotNull(app.OptionVersion);
-            Assert.Equal(CommandOptionType.NoValue, app.OptionVersion.OptionType);
-            Assert.Null(app.OptionVersion.SymbolName);
-            Assert.Null(app.OptionVersion.ShortName);
-            Assert.Equal("version", app.OptionVersion.LongName);
-            Assert.Equal("My version info", app.OptionVersion.Description);
+            Assert.Equal(CommandOptionType.NoValue, app.OptionVersion?.OptionType);
+            Assert.Null(app.OptionVersion?.SymbolName);
+            Assert.Null(app.OptionVersion?.ShortName);
+            Assert.Equal("version", app.OptionVersion?.LongName);
+            Assert.Equal("My version info", app.OptionVersion?.Description);
         }
 
         [VersionOption("-?|-V|--version", "1.0.0")]

--- a/test/CommandLineUtils.Tests/VersionOptionFromMemberAttributeTests.cs
+++ b/test/CommandLineUtils.Tests/VersionOptionFromMemberAttributeTests.cs
@@ -19,7 +19,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         {
             var app = new CommandLineApplication<Property>();
             app.Conventions.UseVersionOptionFromMemberAttribute();
-            Assert.Equal("2.0.0", app.ShortVersionGetter());
+            Assert.Equal("2.0.0", app.ShortVersionGetter?.Invoke());
             Assert.Equal(app.ShortVersionGetter, app.LongVersionGetter);
         }
 
@@ -34,7 +34,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         {
             var app = new CommandLineApplication<Method>();
             app.Conventions.UseVersionOptionFromMemberAttribute();
-            Assert.Equal("2.0.0", app.ShortVersionGetter());
+            Assert.Equal("2.0.0", app.ShortVersionGetter?.Invoke());
             Assert.Equal(app.ShortVersionGetter, app.LongVersionGetter);
         }
 
@@ -49,7 +49,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         {
             var app = new CommandLineApplication<StaticMethod>();
             app.Conventions.UseVersionOptionFromMemberAttribute();
-            Assert.Equal("2.0.0", app.ShortVersionGetter());
+            Assert.Equal("2.0.0", app.ShortVersionGetter?.Invoke());
             Assert.Equal(app.ShortVersionGetter, app.LongVersionGetter);
         }
 

--- a/test/Hosting.CommandLine.Tests/HostBuilderExtensionsTests.cs
+++ b/test/Hosting.CommandLine.Tests/HostBuilderExtensionsTests.cs
@@ -105,8 +105,9 @@ namespace McMaster.Extensions.Hosting.CommandLine.Tests
         }
 
         public class ValueHolder<T>
+            where T : class
         {
-            public T Value { get; set; }
+            public T? Value { get; set; }
         }
 
         [Command("Capture")]
@@ -114,7 +115,7 @@ namespace McMaster.Extensions.Hosting.CommandLine.Tests
         {
             public ValueHolder<string[]> ValueHolder { get; set; }
 
-            public string[] RemainingArguments
+            public string[]? RemainingArguments
             {
                 get => ValueHolder.Value;
                 set => ValueHolder.Value = value;

--- a/version.props
+++ b/version.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.3.4</VersionPrefix>
-    <VersionSuffix>build</VersionSuffix>
+    <VersionPrefix>2.4.0</VersionPrefix>
+    <VersionSuffix>alpha</VersionSuffix>
     <IncludePreReleaseLabelInPackageVersion Condition="'$(IsStableBuild)' != 'true'">true</IncludePreReleaseLabelInPackageVersion>
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">$(BUILD_NUMBER)</BuildNumber>
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">0</BuildNumber>


### PR DESCRIPTION
Resolves #240 

This updates the project to compile using C# 8.0 and takes advantage of the nullable reference types feature. Beyond adding nullability annotations, this uncovered a few places where null ref exceptions were possible, so a few minor behavior changes were required. 

This also motivated a refactor of CommandLineParser to use pattern matching instead of an enums.

Includes workarounds for  https://github.com/dotnet/roslyn/issues/33199  and https://github.com/xunit/xunit/issues/1897