### PR TITLE
Removed redundant use of IDisposable and ManualResetEvent.

### DIFF
--- a/src/Hosting.CommandLine/Internal/CommandLineLifetime.cs
+++ b/src/Hosting.CommandLine/Internal/CommandLineLifetime.cs
@@ -14,13 +14,12 @@ namespace McMaster.Extensions.Hosting.CommandLine.Internal
     ///     Waits from completion of the <see cref="CommandLineApplication" /> and
     ///     initiates shutdown.
     /// </summary>
-    internal class CommandLineLifetime : IHostLifetime, IDisposable
+    internal class CommandLineLifetime : IHostLifetime
     {
         private readonly IApplicationLifetime _applicationLifetime;
         private readonly ICommandLineService _cliService;
         private readonly IConsole _console;
         private readonly IUnhandledExceptionHandler? _unhandledExceptionHandler;
-        private readonly ManualResetEvent _disposeComplete = new ManualResetEvent(false);
 
         /// <summary>
         ///     Creates a new instance.
@@ -85,7 +84,6 @@ namespace McMaster.Extensions.Hosting.CommandLine.Internal
             AppDomain.CurrentDomain.ProcessExit += (_, __) =>
             {
                 _applicationLifetime.StopApplication();
-                _disposeComplete.WaitOne();
             };
 
             // Capture CTRL+C and prevent it from immediately force killing the app.
@@ -96,12 +94,6 @@ namespace McMaster.Extensions.Hosting.CommandLine.Internal
             };
 
             return Task.CompletedTask;
-        }
-
-        public void Dispose()
-        {
-            _disposeComplete.Set();
-            _disposeComplete.Dispose();
         }
     }
 }


### PR DESCRIPTION
Fixed problem with usage of ManualResetEvent object.
[original issue](https://github.com/natemcmaster/CommandLineUtils/issues/261)
As i can see there is no any reason to implement IDisposable and use ManualResetEvent inside Dispose method. With this fix everything works as expected.
 