### PR TITLE
Show enum values as argument in help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 [See unreleased changes][unreleased].
+* Fix [#92] by [@kbilsted] - Show enum names in help text for Options and Arguments stored as enum
 
 ## [v2.4.1]
 

--- a/src/CommandLineUtils/Attributes/ArgumentAttribute.cs
+++ b/src/CommandLineUtils/Attributes/ArgumentAttribute.cs
@@ -71,6 +71,7 @@ namespace McMaster.Extensions.CommandLineUtils
                 Name = Name ?? prop.Name,
                 Description = Description,
                 ShowInHelpText = ShowInHelpText,
+                UnderlyingType = prop.PropertyType,
             };
         }
     }

--- a/src/CommandLineUtils/Attributes/OptionAttribute.cs
+++ b/src/CommandLineUtils/Attributes/OptionAttribute.cs
@@ -81,6 +81,7 @@ namespace McMaster.Extensions.CommandLineUtils
                     LongName = longName,
                     ShortName = longName.Substring(0, 1),
                     ValueName = prop.Name.ToConstantCase(),
+                    UnderlyingType = prop.PropertyType,
                 };
             }
 

--- a/src/CommandLineUtils/CommandArgument.cs
+++ b/src/CommandLineUtils/CommandArgument.cs
@@ -60,6 +60,11 @@ namespace McMaster.Extensions.CommandLineUtils
         /// </summary>
         public ICollection<IArgumentValidator> Validators { get; } = new List<IArgumentValidator>();
 
+        /// <summary>
+        /// Defines the underlying type of the option for the help-text-generator
+        /// </summary>
+        public Type UnderlyingType { get; set; }
+
         internal void Reset()
         {
             Values.Clear();

--- a/src/CommandLineUtils/CommandArgument.cs
+++ b/src/CommandLineUtils/CommandArgument.cs
@@ -61,9 +61,9 @@ namespace McMaster.Extensions.CommandLineUtils
         public ICollection<IArgumentValidator> Validators { get; } = new List<IArgumentValidator>();
 
         /// <summary>
-        /// Defines the underlying type of the option for the help-text-generator
+        /// Defines the underlying type of the argument for the help-text-generator
         /// </summary>
-        public Type UnderlyingType { get; set; }
+        internal Type UnderlyingType { get; set; }
 
         internal void Reset()
         {

--- a/src/CommandLineUtils/CommandArgument{T}.cs
+++ b/src/CommandLineUtils/CommandArgument{T}.cs
@@ -28,6 +28,7 @@ namespace McMaster.Extensions.CommandLineUtils
         public CommandArgument(IValueParser<T> valueParser)
         {
             _valueParser = valueParser ?? throw new ArgumentNullException(nameof(valueParser));
+            UnderlyingType = typeof(T);
         }
 
         /// <summary>

--- a/src/CommandLineUtils/CommandOption.cs
+++ b/src/CommandLineUtils/CommandOption.cs
@@ -135,7 +135,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <summary>
         /// Defines the underlying type of the option for the help-text-generator
         /// </summary>
-        public Type UnderlyingType { get; set; }
+        internal Type UnderlyingType { get; set; }
 
         /// <summary>
         /// A collection of validators that execute before invoking <see cref="CommandLineApplication.OnExecute(Func{int})"/>.

--- a/src/CommandLineUtils/CommandOption.cs
+++ b/src/CommandLineUtils/CommandOption.cs
@@ -133,6 +133,11 @@ namespace McMaster.Extensions.CommandLineUtils
         public bool Inherited { get; set; }
 
         /// <summary>
+        /// Defines the underlying type of the option for the help-text-generator
+        /// </summary>
+        public Type UnderlyingType { get; set; }
+
+        /// <summary>
         /// A collection of validators that execute before invoking <see cref="CommandLineApplication.OnExecute(Func{int})"/>.
         /// When validation fails, <see cref="CommandLineApplication.ValidationErrorHandler"/> is invoked.
         /// </summary>

--- a/src/CommandLineUtils/CommandOption{T}.cs
+++ b/src/CommandLineUtils/CommandOption{T}.cs
@@ -30,6 +30,7 @@ namespace McMaster.Extensions.CommandLineUtils
             : base(template, optionType)
         {
             _valueParser = valueParser ?? throw new ArgumentNullException(nameof(valueParser));
+            UnderlyingType = typeof(T);
         }
 
         /// <summary>

--- a/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
+++ b/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
@@ -172,7 +172,7 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
 
                 foreach (var arg in visibleArguments)
                 {
-                    var enumNames = ExtractamesFromEnum(arg.GetType());
+                    var enumNames = ExtractNamesFromEnum(arg.GetType());
                     var description = enumNames.Any()
                         ? $"{arg.Description}\nAllowed values are: {string.Join(", ", enumNames)}"
                         : arg.Description;
@@ -207,7 +207,7 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
 
                 foreach (var opt in visibleOptions)
                 {
-                    var enumNames = ExtractamesFromEnum(opt.GetType());
+                    var enumNames = ExtractNamesFromEnum(opt.GetType());
                     var description = enumNames.Any()
                         ? $"{opt.Description}\nAllowed values are: {string.Join(", ", enumNames)}"
                         : opt.Description;
@@ -247,7 +247,7 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
 
                 foreach (var cmd in orderedCommands)
                 {
-                    var enumNames = ExtractamesFromEnum(cmd.GetType());
+                    var enumNames = ExtractNamesFromEnum(cmd.GetType());
                     var description = enumNames.Any()
                         ? $"{cmd.Description}\nAllowed values are: {string.Join(", ", enumNames)}"
                         : cmd.Description;

--- a/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
+++ b/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 
 namespace McMaster.Extensions.CommandLineUtils.HelpText
@@ -347,19 +348,14 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
 
         private string[] ExtractNamesFromEnum(Type type)
         {
-#if NETSTANDARD1_6 // no support for GetGenericArguments()
-            return new string[0];
-#else
-            if (!type.IsGenericType)
+            if(!type.GetTypeInfo().IsGenericType)
                 return new string[0];
 
-            var genericArguments = type.GetGenericArguments();
-            if (genericArguments.Length > 1 || !genericArguments[0].IsEnum)
+            var genericArguments = type.GetTypeInfo().GetGenericArguments();
+            if (genericArguments.Length > 1 || !genericArguments[0].GetTypeInfo().IsEnum)
                 return new string[0];
 
             return Enum.GetNames(genericArguments[0]);
-#endif
         }
-
     }
 }

--- a/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
+++ b/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
@@ -42,9 +42,9 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
         public bool SortCommandsByName { get; set; } = true;
 
         /// <summary>
-        /// If set it overrides, the console width is not from the running system.
+        /// Override the console width disregarding any value from the executing environment.
         /// </summary>
-        public int? OverriddenConsoleWidth { get; set; } = null;
+        public int? MaxLineLength { get; set; } = null;
 
         /// <inheritdoc />
         public virtual void Generate(CommandLineApplication application, TextWriter output)
@@ -338,8 +338,8 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
         {
             try
             {
-                if (OverriddenConsoleWidth.HasValue)
-                    return OverriddenConsoleWidth;
+                if (MaxLineLength.HasValue)
+                    return MaxLineLength;
 
                 return Console.BufferWidth;
             }

--- a/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
+++ b/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
@@ -345,7 +345,7 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
             }
         }
 
-        string[] ExtractamesFromEnum(Type type)
+        private string[] ExtractNamesFromEnum(Type type)
         {
 #if NETSTANDARD1_6 // no support for GetGenericArguments()
             return new string[0];

--- a/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
+++ b/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
@@ -172,7 +172,12 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
 
                 foreach (var arg in visibleArguments)
                 {
-                    var wrappedDescription = IndentWriter?.Write(arg.Description);
+                    var enumNames = ExtractamesFromEnum(arg.GetType());
+                    var description = enumNames.Any()
+                        ? $"{arg.Description}\nAllowed values are: {string.Join(", ", enumNames)}"
+                        : arg.Description;
+
+                    var wrappedDescription = IndentWriter?.Write(description);
                     var message = string.Format(outputFormat, arg.Name, wrappedDescription);
 
                     output.Write(message);
@@ -202,7 +207,12 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
 
                 foreach (var opt in visibleOptions)
                 {
-                    var wrappedDescription = IndentWriter?.Write(opt.Description);
+                    var enumNames = ExtractamesFromEnum(opt.GetType());
+                    var description = enumNames.Any()
+                        ? $"{opt.Description}\nAllowed values are: {string.Join(", ", enumNames)}"
+                        : opt.Description;
+
+                    var wrappedDescription = IndentWriter?.Write(description);
                     var message = string.Format(outputFormat, Format(opt), wrappedDescription);
 
                     output.Write(message);
@@ -210,6 +220,7 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
                 }
             }
         }
+
 
         /// <summary>
         /// Generate the lines that show information about subcommands
@@ -233,9 +244,15 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
                 var orderedCommands = SortCommandsByName
                     ? visibleCommands.OrderBy(c => c.Name).ToList()
                     : visibleCommands;
+
                 foreach (var cmd in orderedCommands)
                 {
-                    var wrappedDescription = IndentWriter?.Write(cmd.Description);
+                    var enumNames = ExtractamesFromEnum(cmd.GetType());
+                    var description = enumNames.Any()
+                        ? $"{cmd.Description}\nAllowed values are: {string.Join(", ", enumNames)}"
+                        : cmd.Description;
+
+                    var wrappedDescription = IndentWriter?.Write(description);
                     var message = string.Format(outputFormat, cmd.Name, wrappedDescription);
 
                     output.Write(message);
@@ -326,6 +343,22 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
                 // An IOException will be thrown trying to get the Console.BufferWidth.
                 return null;
             }
+        }
+
+        string[] ExtractamesFromEnum(Type type)
+        {
+#if NETSTANDARD1_6 // no support for GetGenericArguments()
+            return new string[0];
+#else
+            if (!type.IsGenericType)
+                return new string[0];
+
+            var genericArguments = type.GetGenericArguments();
+            if (genericArguments.Length > 1 || !genericArguments[0].IsEnum)
+                return new string[0];
+
+            return Enum.GetNames(genericArguments[0]);
+#endif
         }
 
     }

--- a/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
+++ b/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
@@ -34,12 +34,17 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
         /// <summary>
         /// Initializes a new instance of <see cref="DefaultHelpTextGenerator"/>.
         /// </summary>
-        protected DefaultHelpTextGenerator() { }
+        public DefaultHelpTextGenerator() { }
 
         /// <summary>
         /// Determines if commands are ordered by name in generated help text
         /// </summary>
         public bool SortCommandsByName { get; set; } = true;
+
+        /// <summary>
+        /// If set it overrides, the console width is not from the running system.
+        /// </summary>
+        public int? OverriddenConsoleWidth { get; set; } = null;
 
         /// <inheritdoc />
         public virtual void Generate(CommandLineApplication application, TextWriter output)
@@ -336,11 +341,14 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
         {
             try
             {
+                if (OverriddenConsoleWidth.HasValue)
+                    return OverriddenConsoleWidth;
+
                 return Console.BufferWidth;
             }
             catch (IOException)
             {
-                // If there isn't a console - for instance in test enviornments
+                // If there isn't a console - for instance in test environments
                 // An IOException will be thrown trying to get the Console.BufferWidth.
                 return null;
             }

--- a/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
+++ b/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
@@ -178,7 +178,7 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
 
                 foreach (var arg in visibleArguments)
                 {
-                    var enumNames = ExtractNamesFromEnum(arg.GetType());
+                    var enumNames = ExtractNamesFromEnum(arg.UnderlyingType);
                     var description = enumNames.Any()
                         ? $"{arg.Description}\nAllowed values are: {string.Join(", ", enumNames)}"
                         : arg.Description;
@@ -213,7 +213,7 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
 
                 foreach (var opt in visibleOptions)
                 {
-                    var enumNames = ExtractNamesFromEnum(opt.GetType());
+                    var enumNames = ExtractNamesFromEnum(opt.UnderlyingType);
                     var description = enumNames.Any()
                         ? $"{opt.Description}\nAllowed values are: {string.Join(", ", enumNames)}"
                         : opt.Description;
@@ -253,7 +253,7 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
 
                 foreach (var cmd in orderedCommands)
                 {
-                    var enumNames = ExtractNamesFromEnum(cmd.GetType());
+                    var enumNames = ExtractNamesFromEnumGeneric(cmd.GetType());
                     var description = enumNames.Any()
                         ? $"{cmd.Description}\nAllowed values are: {string.Join(", ", enumNames)}"
                         : cmd.Description;
@@ -354,16 +354,26 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
             }
         }
 
-        private string[] ExtractNamesFromEnum(Type type)
+        private string[] ExtractNamesFromEnumGeneric(Type type)
         {
             if(!type.GetTypeInfo().IsGenericType)
                 return new string[0];
 
             var genericArguments = type.GetTypeInfo().GetGenericArguments();
-            if (genericArguments.Length > 1 || !genericArguments[0].GetTypeInfo().IsEnum)
+            if (genericArguments.Length > 1)
                 return new string[0];
 
-            return Enum.GetNames(genericArguments[0]);
+            return ExtractNamesFromEnum(genericArguments[0]);
+        }
+
+        private string[] ExtractNamesFromEnum(Type type)
+        {
+            if(type==null)
+                return new string[0];
+            if (!type.GetTypeInfo().IsEnum)
+                return new string[0];
+
+            return Enum.GetNames(type);
         }
     }
 }

--- a/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
+++ b/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
@@ -253,10 +253,7 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
 
                 foreach (var cmd in orderedCommands)
                 {
-                    var enumNames = ExtractNamesFromEnumGeneric(cmd.GetType());
-                    var description = enumNames.Any()
-                        ? $"{cmd.Description}\nAllowed values are: {string.Join(", ", enumNames)}"
-                        : cmd.Description;
+                    var description = cmd.Description;
 
                     var wrappedDescription = IndentWriter?.Write(description);
                     var message = string.Format(outputFormat, cmd.Name, wrappedDescription);
@@ -354,22 +351,11 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
             }
         }
 
-        private string[] ExtractNamesFromEnumGeneric(Type type)
-        {
-            if(!type.GetTypeInfo().IsGenericType)
-                return new string[0];
-
-            var genericArguments = type.GetTypeInfo().GetGenericArguments();
-            if (genericArguments.Length > 1)
-                return new string[0];
-
-            return ExtractNamesFromEnum(genericArguments[0]);
-        }
-
         private string[] ExtractNamesFromEnum(Type type)
         {
-            if(type==null)
+            if(type == null)
                 return new string[0];
+
             if (!type.GetTypeInfo().IsEnum)
                 return new string[0];
 

--- a/src/CommandLineUtils/PublicAPI.Shipped.txt
+++ b/src/CommandLineUtils/PublicAPI.Shipped.txt
@@ -57,6 +57,8 @@ McMaster.Extensions.CommandLineUtils.CommandArgument.Name.get -> string
 McMaster.Extensions.CommandLineUtils.CommandArgument.Name.set -> void
 McMaster.Extensions.CommandLineUtils.CommandArgument.ShowInHelpText.get -> bool
 McMaster.Extensions.CommandLineUtils.CommandArgument.ShowInHelpText.set -> void
+McMaster.Extensions.CommandLineUtils.CommandArgument.UnderlyingType.get -> System.Type
+McMaster.Extensions.CommandLineUtils.CommandArgument.UnderlyingType.set -> void
 McMaster.Extensions.CommandLineUtils.CommandArgument.Validators.get -> System.Collections.Generic.ICollection<McMaster.Extensions.CommandLineUtils.Validation.IArgumentValidator>
 McMaster.Extensions.CommandLineUtils.CommandArgument.Value.get -> string
 McMaster.Extensions.CommandLineUtils.CommandArgument.Values.get -> System.Collections.Generic.List<string>
@@ -204,6 +206,8 @@ McMaster.Extensions.CommandLineUtils.CommandOption.SymbolName.get -> string
 McMaster.Extensions.CommandLineUtils.CommandOption.SymbolName.set -> void
 McMaster.Extensions.CommandLineUtils.CommandOption.Template.get -> string
 McMaster.Extensions.CommandLineUtils.CommandOption.Template.set -> void
+McMaster.Extensions.CommandLineUtils.CommandOption.UnderlyingType.get -> System.Type
+McMaster.Extensions.CommandLineUtils.CommandOption.UnderlyingType.set -> void
 McMaster.Extensions.CommandLineUtils.CommandOption.TryParse(string value) -> bool
 McMaster.Extensions.CommandLineUtils.CommandOption.Validators.get -> System.Collections.Generic.ICollection<McMaster.Extensions.CommandLineUtils.Validation.IOptionValidator>
 McMaster.Extensions.CommandLineUtils.CommandOption.Value() -> string

--- a/src/CommandLineUtils/PublicAPI.Shipped.txt
+++ b/src/CommandLineUtils/PublicAPI.Shipped.txt
@@ -298,6 +298,8 @@ McMaster.Extensions.CommandLineUtils.HelpOptionAttribute.HelpOptionAttribute() -
 McMaster.Extensions.CommandLineUtils.HelpOptionAttribute.HelpOptionAttribute(string template) -> void
 McMaster.Extensions.CommandLineUtils.HelpText.DefaultHelpTextGenerator
 McMaster.Extensions.CommandLineUtils.HelpText.DefaultHelpTextGenerator.DefaultHelpTextGenerator() -> void
+McMaster.Extensions.CommandLineUtils.HelpText.DefaultHelpTextGenerator.OverriddenConsoleWidth.get -> int?
+McMaster.Extensions.CommandLineUtils.HelpText.DefaultHelpTextGenerator.OverriddenConsoleWidth.set -> void
 McMaster.Extensions.CommandLineUtils.HelpText.DefaultHelpTextGenerator.SortCommandsByName.get -> bool
 McMaster.Extensions.CommandLineUtils.HelpText.DefaultHelpTextGenerator.SortCommandsByName.set -> void
 McMaster.Extensions.CommandLineUtils.HelpText.IHelpTextGenerator

--- a/src/CommandLineUtils/PublicAPI.Shipped.txt
+++ b/src/CommandLineUtils/PublicAPI.Shipped.txt
@@ -57,8 +57,6 @@ McMaster.Extensions.CommandLineUtils.CommandArgument.Name.get -> string
 McMaster.Extensions.CommandLineUtils.CommandArgument.Name.set -> void
 McMaster.Extensions.CommandLineUtils.CommandArgument.ShowInHelpText.get -> bool
 McMaster.Extensions.CommandLineUtils.CommandArgument.ShowInHelpText.set -> void
-McMaster.Extensions.CommandLineUtils.CommandArgument.UnderlyingType.get -> System.Type
-McMaster.Extensions.CommandLineUtils.CommandArgument.UnderlyingType.set -> void
 McMaster.Extensions.CommandLineUtils.CommandArgument.Validators.get -> System.Collections.Generic.ICollection<McMaster.Extensions.CommandLineUtils.Validation.IArgumentValidator>
 McMaster.Extensions.CommandLineUtils.CommandArgument.Value.get -> string
 McMaster.Extensions.CommandLineUtils.CommandArgument.Values.get -> System.Collections.Generic.List<string>
@@ -206,8 +204,6 @@ McMaster.Extensions.CommandLineUtils.CommandOption.SymbolName.get -> string
 McMaster.Extensions.CommandLineUtils.CommandOption.SymbolName.set -> void
 McMaster.Extensions.CommandLineUtils.CommandOption.Template.get -> string
 McMaster.Extensions.CommandLineUtils.CommandOption.Template.set -> void
-McMaster.Extensions.CommandLineUtils.CommandOption.UnderlyingType.get -> System.Type
-McMaster.Extensions.CommandLineUtils.CommandOption.UnderlyingType.set -> void
 McMaster.Extensions.CommandLineUtils.CommandOption.TryParse(string value) -> bool
 McMaster.Extensions.CommandLineUtils.CommandOption.Validators.get -> System.Collections.Generic.ICollection<McMaster.Extensions.CommandLineUtils.Validation.IOptionValidator>
 McMaster.Extensions.CommandLineUtils.CommandOption.Value() -> string

--- a/src/CommandLineUtils/PublicAPI.Shipped.txt
+++ b/src/CommandLineUtils/PublicAPI.Shipped.txt
@@ -298,8 +298,8 @@ McMaster.Extensions.CommandLineUtils.HelpOptionAttribute.HelpOptionAttribute() -
 McMaster.Extensions.CommandLineUtils.HelpOptionAttribute.HelpOptionAttribute(string template) -> void
 McMaster.Extensions.CommandLineUtils.HelpText.DefaultHelpTextGenerator
 McMaster.Extensions.CommandLineUtils.HelpText.DefaultHelpTextGenerator.DefaultHelpTextGenerator() -> void
-McMaster.Extensions.CommandLineUtils.HelpText.DefaultHelpTextGenerator.OverriddenConsoleWidth.get -> int?
-McMaster.Extensions.CommandLineUtils.HelpText.DefaultHelpTextGenerator.OverriddenConsoleWidth.set -> void
+McMaster.Extensions.CommandLineUtils.HelpText.DefaultHelpTextGenerator.MaxLineLength.get -> int?
+McMaster.Extensions.CommandLineUtils.HelpText.DefaultHelpTextGenerator.MaxLineLength.set -> void
 McMaster.Extensions.CommandLineUtils.HelpText.DefaultHelpTextGenerator.SortCommandsByName.get -> bool
 McMaster.Extensions.CommandLineUtils.HelpText.DefaultHelpTextGenerator.SortCommandsByName.set -> void
 McMaster.Extensions.CommandLineUtils.HelpText.IHelpTextGenerator

--- a/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
+++ b/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
@@ -98,10 +98,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             app.Option<SomeEnum>("--enumOpt <E>", "enum option desc", CommandOptionType.SingleValue);
             app.Argument("SomeArgument1", "arg desc");
             app.Argument<SomeEnum>("SomeArgument2", "arg desc");
-
-            StringWriter sw = new StringWriter();
-            app.Out = sw;
-            app.ShowHelp(false);
+            var helpText = GetHelpText(app);
 
             Assert.Equal(@"Usage:  [options] <SomeArgument1> <SomeArgument2>
 
@@ -118,7 +115,7 @@ Options:
                  Allowed values are: None, Normal, Extreme
 
 ",
-            sw.ToString(),
+            helpText,
             ignoreLineEndingDifferences: true);
         }
     }

--- a/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
+++ b/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
@@ -130,5 +130,50 @@ Options:
             helpText,
             ignoreLineEndingDifferences: true);
         }
+
+
+        [Fact]
+        public void ShowHelpFromAttributes()
+        {
+            var app = new CommandLineApplication<MyApp>(){Name = "test"};
+            app.Conventions.UseDefaultConventions();
+            var helpText = GetHelpText(app);
+
+            Assert.Equal(@"Usage: test [options] <SomeStringArgument> <SomeEnumArgument>
+
+Arguments:
+  SomeStringArgument                string arg desc
+  SomeEnumArgument                  enum arg desc
+                                    Allowed values are: None, Normal, Extreme
+
+Options:
+  -strOpt|--str-opt <STR_OPT>       str option desc
+  -intOpt|--int-opt <INT_OPT>       int option desc
+  -enumOpt|--verbosity <VERBOSITY>  enum option desc
+                                    Allowed values are: None, Normal, Extreme
+  -?|-h|--help                      Show help information
+
+",
+                helpText,
+                ignoreLineEndingDifferences: true);
+        }
+
+        public class MyApp
+        {
+            [Option(ShortName = "strOpt", Description = "str option desc")]
+            public string strOpt{ get; set; }
+
+            [Option(ShortName = "intOpt", Description = "int option desc")]
+            public int intOpt { get; set; }
+
+            [Option(ShortName = "enumOpt", Description = "enum option desc")]
+            public SomeEnum Verbosity { get; set; }
+
+            [Argument(0, Description = "string arg desc")]
+            public string SomeStringArgument { get; set; }
+
+            [Argument(1, Description = "enum arg desc")]
+            public SomeEnum SomeEnumArgument { get; set; }
+        }
     }
 }

--- a/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
+++ b/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
@@ -117,7 +117,9 @@ Options:
   --enumOpt <E>  enum option desc
                  Allowed values are: None, Normal, Extreme
 
-", sw.ToString());
+",
+            sw.ToString(),
+            ignoreLineEndingDifferences: true);
         }
     }
 }

--- a/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
+++ b/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
@@ -92,7 +92,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         {
             var generator = new DefaultHelpTextGenerator
             {
-                OverriddenConsoleWidth = 80
+                MaxLineLength = 80
             };
 
             return GetHelpText(app, generator);

--- a/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
+++ b/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
@@ -85,5 +85,39 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             _output.WriteLine(helpText);
             return helpText;
         }
+        
+        enum SomeEnum { None, Normal, Extreme }
+
+        [Fact]
+        public void ShowHelp()
+        {
+            var app = new CommandLineApplication();
+            app.HelpOption();
+            app.Option("--strOpt <E>", "int option desc", CommandOptionType.SingleValue);
+            app.Option<int>("--intOpt <E>", "int option desc", CommandOptionType.SingleValue);
+            app.Option<SomeEnum>("--enumOpt <E>", "enum option desc", CommandOptionType.SingleValue);
+            app.Argument("SomeArgument1", "arg desc");
+            app.Argument<SomeEnum>("SomeArgument2", "arg desc");
+
+            StringWriter sw = new StringWriter();
+            app.Out = sw;
+            app.ShowHelp(false);
+
+            Assert.Equal(@"Usage:  [options] <SomeArgument1> <SomeArgument2>
+
+Arguments:
+  SomeArgument1  arg desc
+  SomeArgument2  arg desc
+                 Allowed values are: None, Normal, Extreme
+
+Options:
+  -?|-h|--help   Show help information
+  --strOpt <E>   int option desc
+  --intOpt <E>   int option desc
+  --enumOpt <E>  enum option desc
+                 Allowed values are: None, Normal, Extreme
+
+", sw.ToString());
+        }
     }
 }

--- a/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
+++ b/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
@@ -98,33 +98,33 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             return GetHelpText(app, generator);
         }
 
-        enum SomeEnum { None, Normal, Extreme }
+        public enum SomeEnum { None, Normal, Extreme }
 
         [Fact]
         public void ShowHelp()
         {
             var app = new CommandLineApplication();
             app.HelpOption();
-            app.Option("--strOpt <E>", "int option desc", CommandOptionType.SingleValue);
+            app.Option("--strOpt <E>", "str option desc", CommandOptionType.SingleValue);
             app.Option<int>("--intOpt <E>", "int option desc", CommandOptionType.SingleValue);
             app.Option<SomeEnum>("--enumOpt <E>", "enum option desc", CommandOptionType.SingleValue);
-            app.Argument("SomeArgument1", "arg desc");
-            app.Argument<SomeEnum>("SomeArgument2", "arg desc");
+            app.Argument("SomeStringArgument", "string arg desc");
+            app.Argument<SomeEnum>("SomeEnumArgument", "enum arg desc");
             var helpText = GetHelpText(app);
 
-            Assert.Equal(@"Usage:  [options] <SomeArgument1> <SomeArgument2>
+            Assert.Equal(@"Usage:  [options] <SomeStringArgument> <SomeEnumArgument>
 
 Arguments:
-  SomeArgument1  arg desc
-  SomeArgument2  arg desc
-                 Allowed values are: None, Normal, Extreme
+  SomeStringArgument  string arg desc
+  SomeEnumArgument    enum arg desc
+                      Allowed values are: None, Normal, Extreme
 
 Options:
-  -?|-h|--help   Show help information
-  --strOpt <E>   int option desc
-  --intOpt <E>   int option desc
-  --enumOpt <E>  enum option desc
-                 Allowed values are: None, Normal, Extreme
+  -?|-h|--help        Show help information
+  --strOpt <E>        str option desc
+  --intOpt <E>        int option desc
+  --enumOpt <E>       enum option desc
+                      Allowed values are: None, Normal, Extreme
 
 ",
             helpText,

--- a/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
+++ b/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
@@ -65,27 +65,39 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         [Fact]
         public void DoesNotOrderCommandsByName()
         {
-            DefaultHelpTextGenerator.Singleton.SortCommandsByName = false;
             var app = new CommandLineApplication<EmptyShortName>();
             app.Conventions.UseDefaultConventions();
             app.Command("b", _ => { });
             app.Command("a", _ => { });
-            var helpText = GetHelpText(app);
+            var generator = new DefaultHelpTextGenerator() {SortCommandsByName = false};
+            var helpText = GetHelpText(app, generator);
 
             var indexOfA = helpText.IndexOf("  a", StringComparison.InvariantCulture);
             var indexOfB = helpText.IndexOf("  b", StringComparison.InvariantCulture);
             Assert.True(indexOfA > indexOfB);
         }
 
-        private string GetHelpText(CommandLineApplication app)
+        private string GetHelpText(CommandLineApplication app, DefaultHelpTextGenerator generator)
         {
             var sb = new StringBuilder();
-            DefaultHelpTextGenerator.Singleton.Generate(app, new StringWriter(sb));
+            generator.Generate(app, new StringWriter(sb));
             var helpText = sb.ToString();
+
             _output.WriteLine(helpText);
+
             return helpText;
         }
-        
+
+        private string GetHelpText(CommandLineApplication app)
+        {
+            var generator = new DefaultHelpTextGenerator
+            {
+                OverriddenConsoleWidth = 80
+            };
+
+            return GetHelpText(app, generator);
+        }
+
         enum SomeEnum { None, Normal, Extreme }
 
         [Fact]


### PR DESCRIPTION
When options or arguments are parsed into an enum, the help text will now include the values contained in the enum.

fixes #92
