### PR TITLE
fix: disable deterministic NuGet packaging which causes failures for users in GMT >0 timezones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 [See unreleased changes][unreleased].
 
+## [v2.4.1]
+
+* Fix [#277] - workaround a bug in NuGet's 'deterministic packaging' feature which causes issues based on your timezone
+
 ## [v2.4.0]
 
 * Fix [#227] by [@ejball] - ArgumentEscaper should escape empty string

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -2,4 +2,14 @@
   <Target Name="UpdateCiSettings" Condition="'$(CI)' == 'true' AND '$(OS)' == 'Windows_NT' AND '$(IsPackable)' == 'true'">
     <Message Importance="High" Text="##vso[build.updatebuildnumber]$(PackageVersion)" />
   </Target>
+
+
+  <!-- Workaround https://github.com/NuGet/Home/issues/7001 -->
+  <Target Name="DisableNuGetDeterministicPackaging"
+          BeforeTargets="GenerateNuspec"
+          AfterTargets="CoreCompile">
+    <PropertyGroup>
+      <Deterministic>false</Deterministic>
+    </PropertyGroup>
+  </Target>
 </Project>

--- a/src/CommandLineUtils/releasenotes.props
+++ b/src/CommandLineUtils/releasenotes.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <PackageReleaseNotes Condition="'$(VersionPrefix)' == '2.4.0'">
+    <PackageReleaseNotes Condition="'$(VersionPrefix)' == '2.4.1'">
 Features and bug fixes by some awesome contributors:
 
 * @IanG: Attributes for files and directories that must not exist
@@ -16,6 +16,10 @@ Other things I fixed:
 * Add async methods that accept cancellation tokens
 * Handle CTRL+C by default
 * Support calling CommandLineApplication.Execute multiple times
+
+2.4.1 hot fix:
+* Workaround a bizarre NuGet bug which causes problems for users in Europe and Asia
+  (see https://github.com/NuGet/Home/issues/8603)
     </PackageReleaseNotes>
 
     <PackageReleaseNotes Condition="'$(VersionPrefix)' == '2.3.4'">

--- a/src/Hosting.CommandLine/releasenotes.props
+++ b/src/Hosting.CommandLine/releasenotes.props
@@ -1,10 +1,14 @@
 <Project>
   <PropertyGroup>
-    <PackageReleaseNotes Condition="'$(VersionPrefix)' == '2.4.0'">
+    <PackageReleaseNotes Condition="'$(VersionPrefix)' == '2.4.1'">
 Changes:
 * Support C# 8.0 and nullable reference types
 * RunCommandLineApplicationAsync is actually async now, not just sync disguised as an async API
 * Better CTRL+C support
+
+2.4.1 hot fix:
+* Workaround a bizarre NuGet bug which causes problems for users in Europe and Asia
+  (see https://github.com/NuGet/Home/issues/8603)
     </PackageReleaseNotes>
     <PackageReleaseNotes>$(PackageReleaseNotes)
 


### PR DESCRIPTION
Workaround NuGet/Home#7001 and https://github.com/NuGet/Home/issues/8603

Fixes #277 