### PR TITLE
Improve code readability by improving the signal to noise ratio. 

### DIFF
--- a/docs/samples/dependency-injection/custom/Program.cs
+++ b/docs/samples/dependency-injection/custom/Program.cs
@@ -4,7 +4,6 @@ using McMaster.Extensions.CommandLineUtils;
 
 namespace CustomServices
 {
-#region Program
     [Command(Name = "di", Description = "Dependency Injection sample project")]
     [HelpOption]
     class Program
@@ -35,16 +34,12 @@ namespace CustomServices
             _myService.Invoke();
         }
     }
-#endregion
 
-#region IMyService
     interface IMyService
     {
         void Invoke();
     }
-#endregion
 
-#region MyServiceImplementation
     class MyServiceImplementation : IMyService
     {
         private readonly IConsole _console;
@@ -59,5 +54,4 @@ namespace CustomServices
             _console.WriteLine("Hello dependency injection!");
         }
     }
-#endregion
 }

--- a/docs/samples/dependency-injection/generic-host/Program.cs
+++ b/docs/samples/dependency-injection/generic-host/Program.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.Logging;
 
 namespace CustomServices
 {
-#region Program
     [Command(Name = "di", Description = "Dependency Injection sample project")]
     class Program
     {
@@ -50,16 +49,12 @@ namespace CustomServices
             _greeter.Greet(Name, Language);
         }
     }
-#endregion
 
-#region IGreeter
     interface IGreeter
     {
         void Greet(string name, string language);
     }
-#endregion
 
-#region Greeter
     class Greeter : IGreeter
     {
         private readonly IConsole _console;
@@ -86,5 +81,4 @@ namespace CustomServices
             _console.WriteLine(greeting, name);
         }
     }
-#endregion
 }

--- a/docs/samples/dependency-injection/generic-host/Program.cs
+++ b/docs/samples/dependency-injection/generic-host/Program.cs
@@ -13,7 +13,6 @@ namespace CustomServices
     [Command(Name = "di", Description = "Dependency Injection sample project")]
     class Program
     {
-
         [Argument(0, Description = "your name")]
         private string Name { get; } = "dependency injection";
 

--- a/docs/samples/subcommands/nested-types/Program.cs
+++ b/docs/samples/subcommands/nested-types/Program.cs
@@ -7,9 +7,7 @@ using McMaster.Extensions.CommandLineUtils;
 
 namespace SubcommandSample
 {
-    /// <summary>
-    /// In this example, each command a nested class type.
-    /// </summary>
+    /// <summary> In this example, each command a nested class type. </summary>
     [Command(Name = "fake-docker", Description = "A self-sufficient runtime for containers"),
      Subcommand(typeof(Containers), typeof(Images))]
     class Docker

--- a/src/CommandLineUtils/Abstractions/CommandLineContext.cs
+++ b/src/CommandLineUtils/Abstractions/CommandLineContext.cs
@@ -6,33 +6,23 @@ using System.IO;
 
 namespace McMaster.Extensions.CommandLineUtils.Abstractions
 {
-    /// <summary>
-    /// Contains information about the execution context of the command-line application.
-    /// </summary>
+    /// <summary> Contains information about the execution context of the command-line application. </summary>
     public abstract class CommandLineContext
     {
         private string[] _args = new string[0];
         private string _workDir = Directory.GetCurrentDirectory();
         private IConsole _console = PhysicalConsole.Singleton;
 
-        /// <summary>
-        /// The arguments as provided in Program.Main.
-        /// </summary>
-        /// <remarks>
-        /// Cannot be null.
-        /// </remarks>
+        /// <summary> The arguments as provided in Program.Main. </summary>
+        /// <remarks> Cannot be null. </remarks>
         public string[] Arguments
         {
             get => _args;
             protected set => _args = value ?? throw new ArgumentNullException(nameof(value));
         }
 
-        /// <summary>
-        /// The current working directory. Defaults to <see cref="Directory.GetCurrentDirectory" />
-        /// </summary>
-        /// <remarks>
-        /// Cannot be null, and must be an absolute file path.
-        /// </remarks>
+        /// <summary> The current working directory. Defaults to <see cref="Directory.GetCurrentDirectory" /> </summary>
+        /// <remarks> Cannot be null, and must be an absolute file path. </remarks>
         public string WorkingDirectory
         {
             get => _workDir;
@@ -52,12 +42,8 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
             }
         }
 
-        /// <summary>
-        /// The console.
-        /// </summary>
-        /// <remarks>
-        /// Cannot be null.
-        /// </remarks>
+        /// <summary> The console. </summary>
+        /// <remarks> Cannot be null. </remarks>
         public IConsole Console
         {
             get => _console;

--- a/src/CommandLineUtils/Abstractions/CommandLineContext.cs
+++ b/src/CommandLineUtils/Abstractions/CommandLineContext.cs
@@ -42,7 +42,6 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
             }
         }
 
-        /// <summary> The console. </summary>
         /// <remarks> Cannot be null. </remarks>
         public IConsole Console
         {

--- a/src/CommandLineUtils/Abstractions/IModelAccessor.cs
+++ b/src/CommandLineUtils/Abstractions/IModelAccessor.cs
@@ -5,20 +5,14 @@ using System;
 
 namespace McMaster.Extensions.CommandLineUtils.Abstractions
 {
-    /// <summary>
-    /// Provides access to a command line application model.
-    /// </summary>
+    /// <summary> Provides access to a command line application model. </summary>
     public interface IModelAccessor
     {
-        /// <summary>
-        /// Gets the type of the model.
-        /// </summary>
+        /// <summary> Gets the type of the model. </summary>
         /// <returns>The type.</returns>
         Type GetModelType();
 
-        /// <summary>
-        /// Gets the model.
-        /// </summary>
+        /// <summary> Gets the model. </summary>
         /// <returns>The model.</returns>
         object GetModel();
     }

--- a/src/CommandLineUtils/Abstractions/IModelAccessor.cs
+++ b/src/CommandLineUtils/Abstractions/IModelAccessor.cs
@@ -12,7 +12,6 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
         /// <returns>The type.</returns>
         Type GetModelType();
 
-        /// <summary> Gets the model. </summary>
         /// <returns>The model.</returns>
         object GetModel();
     }

--- a/src/CommandLineUtils/Abstractions/IValueParser.cs
+++ b/src/CommandLineUtils/Abstractions/IValueParser.cs
@@ -6,19 +6,13 @@ using System.Globalization;
 
 namespace McMaster.Extensions.CommandLineUtils.Abstractions
 {
-    /// <summary>
-    /// A parser that can convert string into an object.
-    /// </summary>
+    /// <summary> A parser that can convert string into an object. </summary>
     public interface IValueParser
     {
-        /// <summary>
-        /// Gets the Type that this value parser is defined for.
-        /// </summary>
+        /// <summary> Gets the Type that this value parser is defined for. </summary>
         Type TargetType { get; }
 
-        /// <summary>
-        /// Parses the raw string value.
-        /// </summary>
+        /// <summary> Parses the raw string value. </summary>
         /// <param name="argName">The name of the argument this value will be bound to.</param>
         /// <param name="value">The raw string value to parse.</param>
         /// <param name="culture">The culture that should be used to parse values.</param>

--- a/src/CommandLineUtils/Abstractions/IValueParser{T}.cs
+++ b/src/CommandLineUtils/Abstractions/IValueParser{T}.cs
@@ -5,14 +5,10 @@ using System.Globalization;
 
 namespace McMaster.Extensions.CommandLineUtils.Abstractions
 {
-    /// <summary>
-    /// A parser that can convert string into <typeparamref name="T" />.
-    /// </summary>
+    /// <summary> A parser that can convert string into <typeparamref name="T" />. </summary>
     public interface IValueParser<T> : IValueParser
     {
-        /// <summary>
-        /// Parses the raw string value.
-        /// </summary>
+        /// <summary> Parses the raw string value. </summary>
         /// <param name="argName">The name of the argument this value will be bound to.</param>
         /// <param name="value">The raw string value to parse.</param>
         /// <param name="culture">The culture that should be used to parse values.</param>

--- a/src/CommandLineUtils/Abstractions/ParseResult.cs
+++ b/src/CommandLineUtils/Abstractions/ParseResult.cs
@@ -6,14 +6,10 @@ using System.ComponentModel;
 
 namespace McMaster.Extensions.CommandLineUtils.Abstractions
 {
-    /// <summary>
-    /// The result of parsing command line arguments.
-    /// </summary>
+    /// <summary> The result of parsing command line arguments. </summary>
     public class ParseResult
     {
-        /// <summary>
-        /// Initializes <see cref="ParseResult"/>.
-        /// </summary>
+        /// <summary> Initializes <see cref="ParseResult"/>. </summary>
         /// <param name="selectedCommand">The command selected for execution.</param>
         public ParseResult(CommandLineApplication selectedCommand)
         {
@@ -32,9 +28,7 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
         }
 #pragma warning restore CS8618 // Non-nullable field is uninitialized.
 
-        /// <summary>
-        /// The application or subcommand that matches the command line arguments.
-        /// </summary>
+        /// <summary> The application or subcommand that matches the command line arguments. </summary>
         public CommandLineApplication SelectedCommand { get; set; }
     }
 }

--- a/src/CommandLineUtils/Abstractions/ValueParserProvider.cs
+++ b/src/CommandLineUtils/Abstractions/ValueParserProvider.cs
@@ -9,9 +9,7 @@ using System.Reflection;
 
 namespace McMaster.Extensions.CommandLineUtils.Abstractions
 {
-    /// <summary>
-    /// A store of value parsers that are used to convert argument values from strings to types.
-    /// </summary>
+    /// <summary> A store of value parsers that are used to convert argument values from strings to types. </summary>
     public class ValueParserProvider
     {
         private readonly Dictionary<Type, IValueParser> _parsers = new Dictionary<Type, IValueParser>(10);
@@ -39,12 +37,8 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
                 });
         }
 
-        /// <summary>
-        /// Gets or sets the CultureInfo which is used to convert argument values to types.
-        /// </summary>
-        /// <remarks>
-        /// The default value is <see cref="CultureInfo.CurrentCulture"/>.
-        /// </remarks>
+        /// <summary> Gets or sets the CultureInfo which is used to convert argument values to types. </summary>
+        /// <remarks> The default value is <see cref="CultureInfo.CurrentCulture"/>. </remarks>
         public CultureInfo ParseCulture { get; set; } = CultureInfo.CurrentCulture;
 
         private static readonly MethodInfo s_GetParserGeneric
@@ -52,25 +46,15 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
                 .GetMethods(BindingFlags.Instance | BindingFlags.Public)
                 .Single(m => m.Name == nameof(GetParser) && m.IsGenericMethod);
 
-        /// <summary>
-        /// Returns a parser registered for the given type.
-        /// </summary>
-        /// <param name="type"></param>
-        /// <returns></returns>
+        /// <summary> Returns a parser registered for the given type. </summary>
         public IValueParser GetParser(Type type)
         {
             var method = s_GetParserGeneric.MakeGenericMethod(type);
             return (IValueParser)method.Invoke(this, Util.EmptyArray<object>());
         }
 
-        /// <summary>
-        /// Returns a parser for the generic type T.
-        /// </summary>
-        /// <remarks>
-        /// If parser is not registered, null is returned.
-        /// </remarks>
-        /// <typeparam name="T"></typeparam>
-        /// <returns></returns>
+        /// <summary> Returns a parser for the generic type T. </summary>
+        /// <remarks> If parser is not registered, null is returned. </remarks>
         public IValueParser<T>? GetParser<T>()
         {
             var parser = GetParserImpl<T>();
@@ -135,9 +119,7 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
             return null;
         }
 
-        /// <summary>
-        /// Add a new value parser to the provider.
-        /// </summary>
+        /// <summary> Add a new value parser to the provider. </summary>
         /// <param name="parser">An instance of the parser that is used to convert an argument from a string.</param>
         /// <exception cref="ArgumentException">
         /// A value parser with the same <see cref="IValueParser.TargetType"/> is already registered.
@@ -148,9 +130,7 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
             SafeAdd(parser);
         }
 
-        /// <summary>
-        /// Add collection of a new value parsers to the provider.
-        /// </summary>
+        /// <summary> Add collection of a new value parsers to the provider. </summary>
         /// <param name="parsers">The collection whose parsers should be added.</param>
         /// <exception cref="ArgumentException">
         /// A value parser with the same <see cref="IValueParser.TargetType"/> is already registered.

--- a/src/CommandLineUtils/Attributes/AllowedValuesAttribute.cs
+++ b/src/CommandLineUtils/Attributes/AllowedValuesAttribute.cs
@@ -19,20 +19,13 @@ namespace McMaster.Extensions.CommandLineUtils
     {
         private readonly string[] _allowedValues;
 
-        /// <summary>
-        /// Initializes an instance of <see cref="AllowedValuesAttribute"/>.
-        /// </summary>
-        /// <param name="allowedValues"></param>
+        /// <summary> Initializes an instance of <see cref="AllowedValuesAttribute"/>. </summary>
         public AllowedValuesAttribute(params string[] allowedValues)
             : this(StringComparison.CurrentCulture, allowedValues)
         {
         }
 
-        /// <summary>
-        /// Initializes an instance of <see cref="AllowedValuesAttribute"/>.
-        /// </summary>
-        /// <param name="comparer"></param>
-        /// <param name="allowedValues"></param>
+        /// <summary> Initializes an instance of <see cref="AllowedValuesAttribute"/>. </summary>
         public AllowedValuesAttribute(StringComparison comparer, params string[] allowedValues)
             : base(GetDefaultError(allowedValues))
         {
@@ -43,14 +36,10 @@ namespace McMaster.Extensions.CommandLineUtils
         private static string GetDefaultError(string[] allowedValues)
             => "Invalid value '{0}'. Allowed values are: " + string.Join(", ", allowedValues);
 
-        /// <summary>
-        /// The comparison method used.
-        /// </summary>
+        /// <summary> The comparison method used. </summary>
         public StringComparison Comparer { get; set; }
 
-        /// <summary>
-        /// Comparison between values and allowed values should ignore case.
-        /// </summary>
+        /// <summary> Comparison between values and allowed values should ignore case. </summary>
         public bool IgnoreCase
         {
             get

--- a/src/CommandLineUtils/Attributes/ArgumentAttribute.cs
+++ b/src/CommandLineUtils/Attributes/ArgumentAttribute.cs
@@ -15,22 +15,16 @@ namespace McMaster.Extensions.CommandLineUtils
     public sealed class ArgumentAttribute : Attribute
     {
         /// <summary> Initializes a new <see cref="ArgumentAttribute" />. </summary>
-        /// <param name="order">The order</param>
         public ArgumentAttribute(int order)
             : this(order, null)
         { }
 
         /// <summary> Initializes a new <see cref="ArgumentAttribute" />. </summary>
-        /// <param name="order">The order</param>
-        /// <param name="name">The name</param>
         public ArgumentAttribute(int order, string? name)
             : this(order, name, null)
         { }
 
         /// <summary> Initializes a new <see cref="ArgumentAttribute" />. </summary>
-        /// <param name="order">The order</param>
-        /// <param name="name">The name</param>
-        /// <param name="description">The description</param>
         public ArgumentAttribute(int order, string? name, string? description)
         {
             Order = order;

--- a/src/CommandLineUtils/Attributes/ArgumentAttribute.cs
+++ b/src/CommandLineUtils/Attributes/ArgumentAttribute.cs
@@ -14,26 +14,20 @@ namespace McMaster.Extensions.CommandLineUtils
     [AttributeUsage(AttributeTargets.Property)]
     public sealed class ArgumentAttribute : Attribute
     {
-        /// <summary>
-        /// Initializes a new <see cref="ArgumentAttribute" />.
-        /// </summary>
+        /// <summary> Initializes a new <see cref="ArgumentAttribute" />. </summary>
         /// <param name="order">The order</param>
         public ArgumentAttribute(int order)
             : this(order, null)
         { }
 
-        /// <summary>
-        /// Initializes a new <see cref="ArgumentAttribute" />.
-        /// </summary>
+        /// <summary> Initializes a new <see cref="ArgumentAttribute" />. </summary>
         /// <param name="order">The order</param>
         /// <param name="name">The name</param>
         public ArgumentAttribute(int order, string? name)
             : this(order, name, null)
         { }
 
-        /// <summary>
-        /// Initializes a new <see cref="ArgumentAttribute" />.
-        /// </summary>
+        /// <summary> Initializes a new <see cref="ArgumentAttribute" />. </summary>
         /// <param name="order">The order</param>
         /// <param name="name">The name</param>
         /// <param name="description">The description</param>
@@ -44,24 +38,16 @@ namespace McMaster.Extensions.CommandLineUtils
             Description = description;
         }
 
-        /// <summary>
-        /// The order in which the argument is expected, relative to other arguments.
-        /// </summary>
+        /// <summary> The order in which the argument is expected, relative to other arguments. </summary>
         public int Order { get; set; }
 
-        /// <summary>
-        /// The name of the argument. <seealso cref="CommandArgument.Name"/>.
-        /// </summary>
+        /// <summary> The name of the argument. <seealso cref="CommandArgument.Name"/>. </summary>
         public string? Name { get; set; }
 
-        /// <summary>
-        /// Determines if the argument appears in the generated help-text.  <seealso cref="CommandArgument.ShowInHelpText"/>.
-        /// </summary>
+        /// <summary> Determines if the argument appears in the generated help-text.  <seealso cref="CommandArgument.ShowInHelpText"/>. </summary>
         public bool ShowInHelpText { get; set; } = true;
 
-        /// <summary>
-        /// A description of the argument.  <seealso cref="CommandArgument.Description"/>.
-        /// </summary>
+        /// <summary> A description of the argument.  <seealso cref="CommandArgument.Description"/>. </summary>
         public string? Description { get; set; }
 
         internal CommandArgument Configure(PropertyInfo prop)

--- a/src/CommandLineUtils/Attributes/CommandAttribute.cs
+++ b/src/CommandLineUtils/Attributes/CommandAttribute.cs
@@ -8,32 +8,24 @@ using System.Linq;
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    /// <summary>
-    /// Represents a command line application using attributes to define options and arguments.
-    /// </summary>
+    /// <summary> Represents a command line application using attributes to define options and arguments. </summary>
     [AttributeUsage(AttributeTargets.Class)]
     public sealed class CommandAttribute : Attribute
     {
         private string[] _names = Util.EmptyArray<string>();
 
-        /// <summary>
-        /// Initializes a new <see cref="CommandAttribute"/>.
-        /// </summary>
+        /// <summary> Initializes a new <see cref="CommandAttribute"/>. </summary>
         public CommandAttribute()
         { }
 
-        /// <summary>
-        /// Initializes a new <see cref="CommandAttribute"/>.
-        /// </summary>
+        /// <summary> Initializes a new <see cref="CommandAttribute"/>. </summary>
         /// <param name="name">The name of the command.</param>
         public CommandAttribute(string name)
         {
             Name = name;
         }
 
-        /// <summary>
-        /// Initializes a new <see cref="CommandAttribute"/>.
-        /// </summary>
+        /// <summary> Initializes a new <see cref="CommandAttribute"/>. </summary>
         /// <param name="names">The names of the command. The first name given is the primary name</param>
         public CommandAttribute(params string[] names)
         {
@@ -60,54 +52,34 @@ namespace McMaster.Extensions.CommandLineUtils
             }
         }
 
-        /// <summary>
-        /// THe names of the command. The first is the primary name. All other names are aliases.
-        /// </summary>
+        /// <summary> THe names of the command. The first is the primary name. All other names are aliases. </summary>
         public IEnumerable<string> Names => _names;
 
-        /// <summary>
-        /// The full name of the command line application to show in help text. <seealso cref="CommandLineApplication.FullName" />
-        /// </summary>
+        /// <summary> The full name of the command line application to show in help text. <seealso cref="CommandLineApplication.FullName" /> </summary>
         public string? FullName { get; set; }
 
-        /// <summary>
-        /// A description of the command. <seealso cref="CommandLineApplication.Description"/>
-        /// </summary>
+        /// <summary> A description of the command. <seealso cref="CommandLineApplication.Description"/> </summary>
         public string? Description { get; set; }
 
-        /// <summary>
-        /// Determines if this command appears in generated help text. <seealso cref="CommandLineApplication.ShowInHelpText"/>
-        /// </summary>
+        /// <summary> Determines if this command appears in generated help text. <seealso cref="CommandLineApplication.ShowInHelpText"/> </summary>
         public bool ShowInHelpText { get; set; } = true;
 
-        /// <summary>
-        /// Additional text that appears at the bottom of generated help text. <seealso cref="CommandLineApplication.ExtendedHelpText"/>
-        /// </summary>
+        /// <summary> Additional text that appears at the bottom of generated help text. <seealso cref="CommandLineApplication.ExtendedHelpText"/> </summary>
         public string? ExtendedHelpText { get; set; }
 
-        /// <summary>
-        /// Throw when unexpected arguments are encountered. <seealso cref="CommandLineApplication.ThrowOnUnexpectedArgument"/>
-        /// </summary>
+        /// <summary> Throw when unexpected arguments are encountered. <seealso cref="CommandLineApplication.ThrowOnUnexpectedArgument"/> </summary>
         public bool ThrowOnUnexpectedArgument { get; set; } = true;
 
-        /// <summary>
-        /// Allow '--' to be used to stop parsing arguments. <seealso cref="CommandLineApplication.AllowArgumentSeparator"/>
-        /// </summary>
+        /// <summary> Allow '--' to be used to stop parsing arguments. <seealso cref="CommandLineApplication.AllowArgumentSeparator"/> </summary>
         public bool AllowArgumentSeparator { get; set; }
 
-        /// <summary>
-        /// Treat arguments beginning as '@' as a response file. <seealso cref="CommandLineApplication.ResponseFileHandling"/>
-        /// </summary>
+        /// <summary> Treat arguments beginning as '@' as a response file. <seealso cref="CommandLineApplication.ResponseFileHandling"/> </summary>
         public ResponseFileHandling ResponseFileHandling { get; set; } = ResponseFileHandling.Disabled;
 
-        /// <summary>
-        /// The way arguments and options are matched.
-        /// </summary>
+        /// <summary> The way arguments and options are matched. </summary>
         public StringComparison OptionsComparison { get; set; } = StringComparison.Ordinal;
 
-        /// <summary>
-        /// Specifies the culture used to convert values into types.
-        /// </summary>
+        /// <summary> Specifies the culture used to convert values into types. </summary>
         public CultureInfo ParseCulture { get; set; } = CultureInfo.CurrentCulture;
 
         /// <summary>
@@ -133,9 +105,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// This defaults to true unless an option with a short name of two or more characters is added.
         /// </para>
         /// </summary>
-        /// <remarks>
-        /// <seealso href="https://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html"/>
-        /// </remarks>
+        /// <remarks> <seealso href="https://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html"/> </remarks>
         public bool ClusterOptions
         {
             get => _clusterOptions ?? true;

--- a/src/CommandLineUtils/Attributes/DirectoryExistsAttribute.cs
+++ b/src/CommandLineUtils/Attributes/DirectoryExistsAttribute.cs
@@ -7,15 +7,11 @@ using McMaster.Extensions.CommandLineUtils.Validation;
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    /// <summary>
-    /// Specifies that the data must be an already existing directory, not a file.
-    /// </summary>
+    /// <summary> Specifies that the data must be an already existing directory, not a file. </summary>
     [AttributeUsage(AttributeTargets.Property)]
     public sealed class DirectoryExistsAttribute : FilePathExistsAttributeBase
     {
-        /// <summary>
-        /// Initializes an instance of <see cref="FileExistsAttribute"/>.
-        /// </summary>
+        /// <summary> Initializes an instance of <see cref="FileExistsAttribute"/>. </summary>
         public DirectoryExistsAttribute()
             : base(FilePathType.Directory)
         {

--- a/src/CommandLineUtils/Attributes/DirectoryNotExistsAttribute.cs
+++ b/src/CommandLineUtils/Attributes/DirectoryNotExistsAttribute.cs
@@ -7,15 +7,11 @@ using McMaster.Extensions.CommandLineUtils.Validation;
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    /// <summary>
-    /// Specifies that the data must not be an already existing directory, not a file.
-    /// </summary>
+    /// <summary> Specifies that the data must not be an already existing directory, not a file. </summary>
     [AttributeUsage(AttributeTargets.Property)]
     public sealed class DirectoryNotExistsAttribute : FilePathNotExistsAttributeBase
     {
-        /// <summary>
-        /// Initializes an instance of <see cref="DirectoryNotExistsAttribute"/>.
-        /// </summary>
+        /// <summary> Initializes an instance of <see cref="DirectoryNotExistsAttribute"/>. </summary>
         public DirectoryNotExistsAttribute()
             : base(FilePathType.Directory)
         {

--- a/src/CommandLineUtils/Attributes/FileExistsAttribute.cs
+++ b/src/CommandLineUtils/Attributes/FileExistsAttribute.cs
@@ -7,15 +7,11 @@ using McMaster.Extensions.CommandLineUtils.Validation;
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    /// <summary>
-    /// Specifies that the data must be an already existing file, not a directory.
-    /// </summary>
+    /// <summary> Specifies that the data must be an already existing file, not a directory. </summary>
     [AttributeUsage(AttributeTargets.Property)]
     public sealed class FileExistsAttribute : FilePathExistsAttributeBase
     {
-        /// <summary>
-        /// Initializes an instance of <see cref="FileExistsAttribute"/>.
-        /// </summary>
+        /// <summary> Initializes an instance of <see cref="FileExistsAttribute"/>. </summary>
         public FileExistsAttribute()
             : base(FilePathType.File)
         {

--- a/src/CommandLineUtils/Attributes/FileNotExistsAttribute.cs
+++ b/src/CommandLineUtils/Attributes/FileNotExistsAttribute.cs
@@ -7,15 +7,11 @@ using McMaster.Extensions.CommandLineUtils.Validation;
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    /// <summary>
-    /// Specifies that the data must not be an already existing file, not a directory.
-    /// </summary>
+    /// <summary> Specifies that the data must not be an already existing file, not a directory. </summary>
     [AttributeUsage(AttributeTargets.Property)]
     public sealed class FileNotExistsAttribute : FilePathNotExistsAttributeBase
     {
-        /// <summary>
-        /// Initializes an instance of <see cref="FileNotExistsAttribute"/>.
-        /// </summary>
+        /// <summary> Initializes an instance of <see cref="FileNotExistsAttribute"/>. </summary>
         public FileNotExistsAttribute()
             : base(FilePathType.File)
         {

--- a/src/CommandLineUtils/Attributes/FileOrDirectoryExistsAttribute.cs
+++ b/src/CommandLineUtils/Attributes/FileOrDirectoryExistsAttribute.cs
@@ -7,15 +7,11 @@ using McMaster.Extensions.CommandLineUtils.Validation;
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    /// <summary>
-    /// Specifies that the data must be an already existing file or directory.
-    /// </summary>
+    /// <summary> Specifies that the data must be an already existing file or directory. </summary>
     [AttributeUsage(AttributeTargets.Property)]
     public sealed class FileOrDirectoryExistsAttribute : FilePathExistsAttributeBase
     {
-        /// <summary>
-        /// Initializes an instance of <see cref="FileOrDirectoryExistsAttribute"/>.
-        /// </summary>
+        /// <summary> Initializes an instance of <see cref="FileOrDirectoryExistsAttribute"/>. </summary>
         public FileOrDirectoryExistsAttribute()
             : base(FilePathType.Any)
         {

--- a/src/CommandLineUtils/Attributes/FileOrDirectoryNotExistsAttribute.cs
+++ b/src/CommandLineUtils/Attributes/FileOrDirectoryNotExistsAttribute.cs
@@ -7,15 +7,11 @@ using McMaster.Extensions.CommandLineUtils.Validation;
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    /// <summary>
-    /// Specifies that the data must not be an already existing file or directory.
-    /// </summary>
+    /// <summary> Specifies that the data must not be an already existing file or directory. </summary>
     [AttributeUsage(AttributeTargets.Property)]
     public sealed class FileOrDirectoryNotExistsAttribute : FilePathNotExistsAttributeBase
     {
-        /// <summary>
-        /// Initializes an instance of <see cref="FileOrDirectoryNotExistsAttribute"/>.
-        /// </summary>
+        /// <summary> Initializes an instance of <see cref="FileOrDirectoryNotExistsAttribute"/>. </summary>
         public FileOrDirectoryNotExistsAttribute()
             : base(FilePathType.Any)
         {

--- a/src/CommandLineUtils/Attributes/FilePathExistsAttributeBase.cs
+++ b/src/CommandLineUtils/Attributes/FilePathExistsAttributeBase.cs
@@ -8,17 +8,13 @@ using McMaster.Extensions.CommandLineUtils.Abstractions;
 
 namespace McMaster.Extensions.CommandLineUtils.Validation
 {
-    /// <summary>
-    /// Base type for attributes that check for existing files or directories.
-    /// </summary>
+    /// <summary> Base type for attributes that check for existing files or directories. </summary>
     [AttributeUsage(AttributeTargets.Property)]
     public abstract class FilePathExistsAttributeBase : ValidationAttribute
     {
         private readonly FilePathType _filePathType;
 
-        /// <summary>
-        /// Initializes an instance of <see cref="FilePathExistsAttributeBase"/>.
-        /// </summary>
+        /// <summary> Initializes an instance of <see cref="FilePathExistsAttributeBase"/>. </summary>
         /// <param name="filePathType">Acceptable file path types</param>
         internal FilePathExistsAttributeBase(FilePathType filePathType)
             : base(GetDefaultErrorMessage(filePathType))

--- a/src/CommandLineUtils/Attributes/FilePathNotExistsAttributeBase.cs
+++ b/src/CommandLineUtils/Attributes/FilePathNotExistsAttributeBase.cs
@@ -8,17 +8,13 @@ using McMaster.Extensions.CommandLineUtils.Abstractions;
 
 namespace McMaster.Extensions.CommandLineUtils.Validation
 {
-    /// <summary>
-    /// Base type for attributes that check for files or directories not existing.
-    /// </summary>
+    /// <summary> Base type for attributes that check for files or directories not existing. </summary>
     [AttributeUsage(AttributeTargets.Property)]
     public abstract class FilePathNotExistsAttributeBase : ValidationAttribute
     {
         private readonly FilePathType _filePathType;
 
-        /// <summary>
-        /// Initializes an instance of <see cref="FilePathNotExistsAttributeBase"/>.
-        /// </summary>
+        /// <summary> Initializes an instance of <see cref="FilePathNotExistsAttributeBase"/>. </summary>
         /// <param name="filePathType">Acceptable file path types</param>
         internal FilePathNotExistsAttributeBase(FilePathType filePathType)
             : base(GetDefaultErrorMessage(filePathType))

--- a/src/CommandLineUtils/Attributes/HelpOptionAttribute.cs
+++ b/src/CommandLineUtils/Attributes/HelpOptionAttribute.cs
@@ -5,23 +5,17 @@ using System;
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    /// <summary>
-    /// The option used to determine if help text should be displayed. This should only be used once per command line app.
-    /// </summary>
+    /// <summary> The option used to determine if help text should be displayed. This should only be used once per command line app. </summary>
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Class)]
     public sealed class HelpOptionAttribute : OptionAttributeBase
     {
-        /// <summary>
-        /// Initializes a new <see cref="HelpOptionAttribute"/> with the template <c>-?|-h|--help</c>.
-        /// </summary>
+        /// <summary> Initializes a new <see cref="HelpOptionAttribute"/> with the template <c>-?|-h|--help</c>. </summary>
         public HelpOptionAttribute()
             : this(Strings.DefaultHelpTemplate)
         {
         }
 
-        /// <summary>
-        /// Initializes a new <see cref="HelpOptionAttribute"/>.
-        /// </summary>
+        /// <summary> Initializes a new <see cref="HelpOptionAttribute"/>. </summary>
         /// <param name="template">The string template. <see cref="CommandOption.Template"/>.</param>
         public HelpOptionAttribute(string template)
         {
@@ -29,9 +23,7 @@ namespace McMaster.Extensions.CommandLineUtils
             Description = Strings.DefaultHelpOptionDescription;
         }
 
-        /// <summary>
-        /// The option template. This is parsed into the short and long name.
-        /// </summary>
+        /// <summary> The option template. This is parsed into the short and long name. </summary>
         public new string Template { get; set; }
 
         internal CommandOption Configure(CommandLineApplication app)

--- a/src/CommandLineUtils/Attributes/LegalFilePathAttribute.cs
+++ b/src/CommandLineUtils/Attributes/LegalFilePathAttribute.cs
@@ -7,19 +7,14 @@ using System.IO;
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    /// <summary>
-    /// Specifies that a value must be a legal file path.
-    /// </summary>
+    /// <summary> Specifies that a value must be a legal file path. </summary>
     [AttributeUsage(AttributeTargets.Property)]
     public sealed class LegalFilePathAttribute : ValidationAttribute
     {
-        /// <summary>
-        /// Initializes an instance of <see cref="LegalFilePathAttribute"/>.
-        /// </summary>
+        /// <summary> Initializes an instance of <see cref="LegalFilePathAttribute"/>. </summary>
         public LegalFilePathAttribute()
             : base("'{0}' is an invalid file path.")
         {
-
         }
 
         /// <inheritdoc />

--- a/src/CommandLineUtils/Attributes/OptionAttribute.cs
+++ b/src/CommandLineUtils/Attributes/OptionAttribute.cs
@@ -27,20 +27,17 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Initializes a new <see cref="OptionAttribute"/>. </summary>
-        /// <param name="optionType">The optionType</param>
         public OptionAttribute(CommandOptionType optionType)
             : this(null, null, optionType)
         { }
 
         /// <summary> Initializes a new <see cref="OptionAttribute"/>. </summary>
-        /// <param name="template">The template</param>
         /// <param name="optionType">The option type</param>
         public OptionAttribute(string template, CommandOptionType optionType)
             : this(template, null, optionType)
         { }
 
         /// <summary> Initializes a new <see cref="OptionAttribute"/>. </summary>
-        /// <param name="template">The template</param>
         /// <param name="description">The option description</param>
         /// <param name="optionType">The option type</param>
         public OptionAttribute(string? template, string? description, CommandOptionType optionType)

--- a/src/CommandLineUtils/Attributes/OptionAttribute.cs
+++ b/src/CommandLineUtils/Attributes/OptionAttribute.cs
@@ -32,14 +32,11 @@ namespace McMaster.Extensions.CommandLineUtils
         { }
 
         /// <summary> Initializes a new <see cref="OptionAttribute"/>. </summary>
-        /// <param name="optionType">The option type</param>
         public OptionAttribute(string template, CommandOptionType optionType)
             : this(template, null, optionType)
         { }
 
         /// <summary> Initializes a new <see cref="OptionAttribute"/>. </summary>
-        /// <param name="description">The option description</param>
-        /// <param name="optionType">The option type</param>
         public OptionAttribute(string? template, string? description, CommandOptionType optionType)
         {
             Template = template;

--- a/src/CommandLineUtils/Attributes/OptionAttribute.cs
+++ b/src/CommandLineUtils/Attributes/OptionAttribute.cs
@@ -14,42 +14,32 @@ namespace McMaster.Extensions.CommandLineUtils
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
     public sealed class OptionAttribute : OptionAttributeBase
     {
-        /// <summary>
-        /// Initializes a new <see cref="OptionAttribute"/>.
-        /// </summary>
+        /// <summary> Initializes a new <see cref="OptionAttribute"/>. </summary>
         public OptionAttribute()
         {
         }
 
-        /// <summary>
-        /// Initializes a new <see cref="OptionAttribute"/>.
-        /// </summary>
+        /// <summary> Initializes a new <see cref="OptionAttribute"/>. </summary>
         /// <param name="template">The string template. <see cref="CommandOption.Template"/>.</param>
         public OptionAttribute(string template)
         {
             Template = template;
         }
 
-        /// <summary>
-        /// Initializes a new <see cref="OptionAttribute"/>.
-        /// </summary>
+        /// <summary> Initializes a new <see cref="OptionAttribute"/>. </summary>
         /// <param name="optionType">The optionType</param>
         public OptionAttribute(CommandOptionType optionType)
             : this(null, null, optionType)
         { }
 
-        /// <summary>
-        /// Initializes a new <see cref="OptionAttribute"/>.
-        /// </summary>
+        /// <summary> Initializes a new <see cref="OptionAttribute"/>. </summary>
         /// <param name="template">The template</param>
         /// <param name="optionType">The option type</param>
         public OptionAttribute(string template, CommandOptionType optionType)
             : this(template, null, optionType)
         { }
 
-        /// <summary>
-        /// Initializes a new <see cref="OptionAttribute"/>.
-        /// </summary>
+        /// <summary> Initializes a new <see cref="OptionAttribute"/>. </summary>
         /// <param name="template">The template</param>
         /// <param name="description">The option description</param>
         /// <param name="optionType">The option type</param>
@@ -60,9 +50,7 @@ namespace McMaster.Extensions.CommandLineUtils
             OptionType = optionType;
         }
 
-        /// <summary>
-        /// Defines the type of the option. When not set, this will be inferred from the CLR type of the property. <seealso cref="CommandOption.OptionType"/>
-        /// </summary>
+        /// <summary> Defines the type of the option. When not set, this will be inferred from the CLR type of the property. <seealso cref="CommandOption.OptionType"/> </summary>
         public CommandOptionType? OptionType { get; set; }
 
         internal CommandOption Configure(CommandLineApplication app, PropertyInfo prop)

--- a/src/CommandLineUtils/Attributes/OptionAttributeBase.cs
+++ b/src/CommandLineUtils/Attributes/OptionAttributeBase.cs
@@ -5,24 +5,16 @@ using System;
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    /// <summary>
-    /// Common option properties.
-    /// </summary>
+    /// <summary> Common option properties. </summary>
     public abstract class OptionAttributeBase : Attribute
     {
-        /// <summary>
-        /// The option template. This is parsed into the short and long name.
-        /// </summary>
+        /// <summary> The option template. This is parsed into the short and long name. </summary>
         public string? Template { get; set; }
 
-        /// <summary>
-        /// The short command line flag used to identify this option. On command line, this is preceeded by a single '-{ShortName}'.
-        /// </summary>
+        /// <summary> The short command line flag used to identify this option. On command line, this is preceeded by a single '-{ShortName}'. </summary>
         public string? ShortName { get; set; }
 
-        /// <summary>
-        /// The long command line flag used to identify this option. On command line, this is preceeded by a double dash: '--{LongName}'.
-        /// </summary>
+        /// <summary> The long command line flag used to identify this option. On command line, this is preceeded by a double dash: '--{LongName}'. </summary>
         public string? LongName { get; set; }
 
         /// <summary>
@@ -31,19 +23,13 @@ namespace McMaster.Extensions.CommandLineUtils
         /// </summary>
         public string? SymbolName { get; set; }
 
-        /// <summary>
-        /// The name of value(s) shown in help text when OptionType is not <see cref="CommandOptionType.NoValue"/>.
-        /// </summary>
+        /// <summary> The name of value(s) shown in help text when OptionType is not <see cref="CommandOptionType.NoValue"/>. </summary>
         public string? ValueName { get; set; }
 
-        /// <summary>
-        /// A description of this option to show in generated help text. <seealso cref="CommandOption.Description"/>.
-        /// </summary>
+        /// <summary> A description of this option to show in generated help text. <seealso cref="CommandOption.Description"/>. </summary>
         public string? Description { get; set; }
 
-        /// <summary>
-        /// Determines if this option should be shown in generated help text. <seealso cref="CommandOption.ShowInHelpText"/>.
-        /// </summary>
+        /// <summary> Determines if this option should be shown in generated help text. <seealso cref="CommandOption.ShowInHelpText"/>. </summary>
         public bool ShowInHelpText { get; set; } = true;
 
         /// <summary>

--- a/src/CommandLineUtils/Attributes/OptionAttributeBase.cs
+++ b/src/CommandLineUtils/Attributes/OptionAttributeBase.cs
@@ -5,7 +5,6 @@ using System;
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    /// <summary> Common option properties. </summary>
     public abstract class OptionAttributeBase : Attribute
     {
         /// <summary> The option template. This is parsed into the short and long name. </summary>

--- a/src/CommandLineUtils/Attributes/SubcommandAttribute.cs
+++ b/src/CommandLineUtils/Attributes/SubcommandAttribute.cs
@@ -8,15 +8,11 @@ using System.ComponentModel;
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    /// <summary>
-    /// Represents a subcommand.
-    /// </summary>
+    /// <summary> Represents a subcommand. </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
     public sealed class SubcommandAttribute : Attribute
     {
-        /// <summary>
-        /// This constructor is obsolete. The recommended replacement is <see cref="SubcommandAttribute(Type[])"/>.
-        /// </summary>
+        /// <summary> This constructor is obsolete. The recommended replacement is <see cref="SubcommandAttribute(Type[])"/>. </summary>
         /// <param name="name">The name of the subcommand</param>
         /// <param name="commandType">The type of the subcommand.</param>
         [Obsolete("[Subcommand(string, Type)] is obsolete and will be removed in a future version. " +
@@ -30,9 +26,7 @@ namespace McMaster.Extensions.CommandLineUtils
             Name = name;
         }
 
-        /// <summary>
-        /// Initializes a new instance of <see cref="McMaster.Extensions.CommandLineUtils.SubcommandAttribute" />.
-        /// </summary>
+        /// <summary> Initializes a new instance of <see cref="McMaster.Extensions.CommandLineUtils.SubcommandAttribute" />. </summary>
         /// <param name="subcommands">The subcommand types.</param>
         public SubcommandAttribute(params Type[] subcommands)
         {
@@ -49,9 +43,7 @@ namespace McMaster.Extensions.CommandLineUtils
             Types = subcommands;
         }
 
-        /// <summary>
-        /// The types of the subcommands.
-        /// </summary>
+        /// <summary> The types of the subcommands. </summary>
         public Type[] Types { get; private set; }
 
         /// <summary>

--- a/src/CommandLineUtils/Attributes/SubcommandAttribute.cs
+++ b/src/CommandLineUtils/Attributes/SubcommandAttribute.cs
@@ -8,7 +8,6 @@ using System.ComponentModel;
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    /// <summary> Represents a subcommand. </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
     public sealed class SubcommandAttribute : Attribute
     {
@@ -27,7 +26,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Initializes a new instance of <see cref="McMaster.Extensions.CommandLineUtils.SubcommandAttribute" />. </summary>
-        /// <param name="subcommands">The subcommand types.</param>
         public SubcommandAttribute(params Type[] subcommands)
         {
             if (subcommands == null)

--- a/src/CommandLineUtils/Attributes/SuppressDefaultHelpOptionAttribute.cs
+++ b/src/CommandLineUtils/Attributes/SuppressDefaultHelpOptionAttribute.cs
@@ -6,9 +6,7 @@ using McMaster.Extensions.CommandLineUtils.Conventions;
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    /// <summary>
-    /// Suppress <see cref="DefaultHelpOptionConvention"/>.
-    /// </summary>
+    /// <summary> Suppress <see cref="DefaultHelpOptionConvention"/>. </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Assembly, Inherited = true)]
     public sealed class SuppressDefaultHelpOptionAttribute : Attribute
     {

--- a/src/CommandLineUtils/Attributes/VersionOptionAttribute.cs
+++ b/src/CommandLineUtils/Attributes/VersionOptionAttribute.cs
@@ -5,24 +5,18 @@ using System;
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    /// <summary>
-    /// The option used to determine if version text should be displayed.
-    /// </summary>
+    /// <summary> The option used to determine if version text should be displayed. </summary>
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Class)]
     public sealed class VersionOptionAttribute : OptionAttributeBase
     {
-        /// <summary>
-        /// Initializes a new <see cref="VersionOptionAttribute"/> with the template <c>--version</c>.
-        /// </summary>
+        /// <summary> Initializes a new <see cref="VersionOptionAttribute"/> with the template <c>--version</c>. </summary>
         /// <param name="version">The version</param>
         public VersionOptionAttribute(string version)
             : this(Strings.DefaultVersionTemplate, version)
         {
         }
 
-        /// <summary>
-        /// Initializes a new <see cref="VersionOptionAttribute"/>.
-        /// </summary>
+        /// <summary> Initializes a new <see cref="VersionOptionAttribute"/>. </summary>
         /// <param name="template">The string template. <seealso cref="CommandOption.Template"/>.</param>
         /// <param name="version">The version</param>
         public VersionOptionAttribute(string template, string version)
@@ -32,14 +26,10 @@ namespace McMaster.Extensions.CommandLineUtils
             Description = Strings.DefaultVersionOptionDescription;
         }
 
-        /// <summary>
-        /// The version information to be shown. <see cref="CommandLineApplication.ShortVersionGetter"/>.
-        /// </summary>
+        /// <summary> The version information to be shown. <see cref="CommandLineApplication.ShortVersionGetter"/>. </summary>
         public string Version { get; set; }
 
-        /// <summary>
-        /// The option template. This is parsed into the short and long name.
-        /// </summary>
+        /// <summary> The option template. This is parsed into the short and long name. </summary>
         public new string Template { get; set; }
 
         internal CommandOption Configure(CommandLineApplication app)

--- a/src/CommandLineUtils/Attributes/VersionOptionAttribute.cs
+++ b/src/CommandLineUtils/Attributes/VersionOptionAttribute.cs
@@ -10,7 +10,6 @@ namespace McMaster.Extensions.CommandLineUtils
     public sealed class VersionOptionAttribute : OptionAttributeBase
     {
         /// <summary> Initializes a new <see cref="VersionOptionAttribute"/> with the template <c>--version</c>. </summary>
-        /// <param name="version">The version</param>
         public VersionOptionAttribute(string version)
             : this(Strings.DefaultVersionTemplate, version)
         {
@@ -18,7 +17,6 @@ namespace McMaster.Extensions.CommandLineUtils
 
         /// <summary> Initializes a new <see cref="VersionOptionAttribute"/>. </summary>
         /// <param name="template">The string template. <seealso cref="CommandOption.Template"/>.</param>
-        /// <param name="version">The version</param>
         public VersionOptionAttribute(string template, string version)
         {
             Version = version;

--- a/src/CommandLineUtils/Attributes/VersionOptionFromMemberAttribute.cs
+++ b/src/CommandLineUtils/Attributes/VersionOptionFromMemberAttribute.cs
@@ -13,30 +13,22 @@ namespace McMaster.Extensions.CommandLineUtils
     [AttributeUsage(AttributeTargets.Class)]
     public sealed class VersionOptionFromMemberAttribute : OptionAttributeBase
     {
-        /// <summary>
-        /// Initializes an instance of <see cref="VersionOptionFromMemberAttribute"/> with <c>--version</c> as the template.
-        /// </summary>
+        /// <summary> Initializes an instance of <see cref="VersionOptionFromMemberAttribute"/> with <c>--version</c> as the template. </summary>
         public VersionOptionFromMemberAttribute()
             : this(Strings.DefaultVersionTemplate)
         { }
 
-        /// <summary>
-        /// Initializes an instance of <see cref="VersionOptionFromMemberAttribute"/> with <c>--version</c> as the template.
-        /// </summary>
+        /// <summary> Initializes an instance of <see cref="VersionOptionFromMemberAttribute"/> with <c>--version</c> as the template. </summary>
         /// <param name="template">The version template.</param>
         public VersionOptionFromMemberAttribute(string template)
         {
             Template = template;
         }
 
-        /// <summary>
-        /// The name of the property or method that returns short version information.
-        /// </summary>
+        /// <summary> The name of the property or method that returns short version information. </summary>
         public string? MemberName { get; set; }
 
-        /// <summary>
-        /// The option template. This is parsed into the short and long name.
-        /// </summary>
+        /// <summary> The option template. This is parsed into the short and long name. </summary>
         public new string Template { get; set; }
 
         internal CommandOption Configure(CommandLineApplication app, Type type, Func<object> targetInstanceFactory)

--- a/src/CommandLineUtils/CommandArgument.cs
+++ b/src/CommandLineUtils/CommandArgument.cs
@@ -16,42 +16,28 @@ namespace McMaster.Extensions.CommandLineUtils
     /// </summary>
     public class CommandArgument
     {
-        /// <summary>
-        /// Initializes a new instance of <see cref="CommandArgument"/>.
-        /// </summary>
+        /// <summary> Initializes a new instance of <see cref="CommandArgument"/>. </summary>
         public CommandArgument()
         {
             Values = new List<string?>();
         }
 
-        /// <summary>
-        /// The name of the argument.
-        /// </summary>
+        /// <summary> The name of the argument. </summary>
         public string? Name { get; set; }
 
-        /// <summary>
-        /// Determines if the argument appears in the generated help-text.
-        /// </summary>
+        /// <summary> Determines if the argument appears in the generated help-text. </summary>
         public bool ShowInHelpText { get; set; } = true;
 
-        /// <summary>
-        /// A description of the argument.
-        /// </summary>
+        /// <summary> A description of the argument. </summary>
         public string? Description { get; set; }
 
-        /// <summary>
-        /// All values specified, if any.
-        /// </summary>
+        /// <summary> All values specified, if any. </summary>
         public List<string?> Values { get; private set; }
 
-        /// <summary>
-        /// Allow multiple values.
-        /// </summary>
+        /// <summary> Allow multiple values. </summary>
         public bool MultipleValues { get; set; }
 
-        /// <summary>
-        /// The first value from <see cref="Values"/>, if any.
-        /// </summary>
+        /// <summary> The first value from <see cref="Values"/>, if any. </summary>
         public string? Value => Values.FirstOrDefault();
 
         /// <summary>
@@ -60,9 +46,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// </summary>
         public ICollection<IArgumentValidator> Validators { get; } = new List<IArgumentValidator>();
 
-        /// <summary>
-        /// Defines the underlying type of the argument for the help-text-generator
-        /// </summary>
+        /// <summary> Defines the underlying type of the argument for the help-text-generator </summary>
         internal Type UnderlyingType { get; set; }
 
         internal void Reset()

--- a/src/CommandLineUtils/CommandArgument{T}.cs
+++ b/src/CommandLineUtils/CommandArgument{T}.cs
@@ -22,14 +22,12 @@ namespace McMaster.Extensions.CommandLineUtils
         private readonly IValueParser<T> _valueParser;
 
         /// <summary> Initializes a new instance of <see cref="CommandArgument{T}" /> </summary>
-        /// <param name="valueParser">The value parser.</param>
         public CommandArgument(IValueParser<T> valueParser)
         {
             _valueParser = valueParser ?? throw new ArgumentNullException(nameof(valueParser));
             UnderlyingType = typeof(T);
         }
 
-        /// <summary> The parsed value. </summary>
         public T ParsedValue => _parsedValues.FirstOrDefault();
 
         /// <summary> All parsed values; </summary>

--- a/src/CommandLineUtils/CommandArgument{T}.cs
+++ b/src/CommandLineUtils/CommandArgument{T}.cs
@@ -21,9 +21,7 @@ namespace McMaster.Extensions.CommandLineUtils
         private readonly List<T> _parsedValues = new List<T>();
         private readonly IValueParser<T> _valueParser;
 
-        /// <summary>
-        /// Initializes a new instance of <see cref="CommandArgument{T}" />
-        /// </summary>
+        /// <summary> Initializes a new instance of <see cref="CommandArgument{T}" /> </summary>
         /// <param name="valueParser">The value parser.</param>
         public CommandArgument(IValueParser<T> valueParser)
         {
@@ -31,14 +29,10 @@ namespace McMaster.Extensions.CommandLineUtils
             UnderlyingType = typeof(T);
         }
 
-        /// <summary>
-        /// The parsed value.
-        /// </summary>
+        /// <summary> The parsed value. </summary>
         public T ParsedValue => _parsedValues.FirstOrDefault();
 
-        /// <summary>
-        /// All parsed values;
-        /// </summary>
+        /// <summary> All parsed values; </summary>
         public IReadOnlyList<T> ParsedValues => _parsedValues;
 
         void IInternalCommandParamOfT.Parse(CultureInfo culture)

--- a/src/CommandLineUtils/CommandLineApplication.Execute.cs
+++ b/src/CommandLineUtils/CommandLineApplication.Execute.cs
@@ -23,7 +23,6 @@ namespace McMaster.Extensions.CommandLineUtils
         /// See <seealso cref="OptionAttribute" />, <seealso cref="ArgumentAttribute" />,
         /// <seealso cref="HelpOptionAttribute"/>, and <seealso cref="VersionOptionAttribute"/>.
         /// </summary>
-        /// <param name="context">The execution context.</param>
         /// <typeparam name="TApp">A type that should be bound to the arguments.</typeparam>
         /// <exception cref="InvalidOperationException">Thrown when attributes are incorrectly configured.</exception>
         /// <returns>The process exit code</returns>
@@ -38,7 +37,6 @@ namespace McMaster.Extensions.CommandLineUtils
         /// See <seealso cref="OptionAttribute" />, <seealso cref="ArgumentAttribute" />,
         /// <seealso cref="HelpOptionAttribute"/>, and <seealso cref="VersionOptionAttribute"/>.
         /// </summary>
-        /// <param name="context">The execution context.</param>
         /// <typeparam name="TApp">A type that should be bound to the arguments.</typeparam>
         /// <exception cref="InvalidOperationException">Thrown when attributes are incorrectly configured.</exception>
         /// <returns>The process exit code</returns>

--- a/src/CommandLineUtils/CommandLineApplication.Execute.cs
+++ b/src/CommandLineUtils/CommandLineApplication.Execute.cs
@@ -39,7 +39,6 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <seealso cref="HelpOptionAttribute"/>, and <seealso cref="VersionOptionAttribute"/>.
         /// </summary>
         /// <param name="context">The execution context.</param>
-        /// <param name="cancellationToken"></param>
         /// <typeparam name="TApp">A type that should be bound to the arguments.</typeparam>
         /// <exception cref="InvalidOperationException">Thrown when attributes are incorrectly configured.</exception>
         /// <returns>The process exit code</returns>
@@ -144,7 +143,6 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <seealso cref="HelpOptionAttribute"/>, and <seealso cref="VersionOptionAttribute"/>.
         /// </summary>
         /// <param name="args">The arguments</param>
-        /// <param name="cancellationToken"></param>
         /// <typeparam name="TApp">A type that should be bound to the arguments.</typeparam>
         /// <exception cref="InvalidOperationException">Thrown when attributes are incorrectly configured.</exception>
         /// <returns>The process exit code</returns>

--- a/src/CommandLineUtils/CommandLineApplication.Execute.cs
+++ b/src/CommandLineUtils/CommandLineApplication.Execute.cs
@@ -94,7 +94,6 @@ namespace McMaster.Extensions.CommandLineUtils
         /// See <seealso cref="OptionAttribute" />, <seealso cref="ArgumentAttribute" />,
         /// <seealso cref="HelpOptionAttribute"/>, and <seealso cref="VersionOptionAttribute"/>.
         /// </summary>
-        /// <param name="args">The arguments</param>
         /// <typeparam name="TApp">A type that should be bound to the arguments.</typeparam>
         /// <exception cref="InvalidOperationException">Thrown when attributes are incorrectly configured.</exception>
         /// <returns>The process exit code</returns>
@@ -109,7 +108,6 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <seealso cref="HelpOptionAttribute"/>, and <seealso cref="VersionOptionAttribute"/>.
         /// </summary>
         /// <param name="console">The console to use</param>
-        /// <param name="args">The arguments</param>
         /// <typeparam name="TApp">A type that should be bound to the arguments.</typeparam>
         /// <exception cref="InvalidOperationException">Thrown when attributes are incorrectly configured.</exception>
         /// <returns>The process exit code</returns>
@@ -127,7 +125,6 @@ namespace McMaster.Extensions.CommandLineUtils
         /// See <seealso cref="OptionAttribute" />, <seealso cref="ArgumentAttribute" />,
         /// <seealso cref="HelpOptionAttribute"/>, and <seealso cref="VersionOptionAttribute"/>.
         /// </summary>
-        /// <param name="args">The arguments</param>
         /// <typeparam name="TApp">A type that should be bound to the arguments.</typeparam>
         /// <exception cref="InvalidOperationException">Thrown when attributes are incorrectly configured.</exception>
         /// <returns>The process exit code</returns>
@@ -142,7 +139,6 @@ namespace McMaster.Extensions.CommandLineUtils
         /// See <seealso cref="OptionAttribute" />, <seealso cref="ArgumentAttribute" />,
         /// <seealso cref="HelpOptionAttribute"/>, and <seealso cref="VersionOptionAttribute"/>.
         /// </summary>
-        /// <param name="args">The arguments</param>
         /// <typeparam name="TApp">A type that should be bound to the arguments.</typeparam>
         /// <exception cref="InvalidOperationException">Thrown when attributes are incorrectly configured.</exception>
         /// <returns>The process exit code</returns>
@@ -162,7 +158,6 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <seealso cref="HelpOptionAttribute"/>, and <seealso cref="VersionOptionAttribute"/>.
         /// </summary>
         /// <param name="console">The console to use</param>
-        /// <param name="args">The arguments</param>
         /// <typeparam name="TApp">A type that should be bound to the arguments.</typeparam>
         /// <exception cref="InvalidOperationException">Thrown when attributes are incorrectly configured.</exception>
         /// <returns>The process exit code</returns>

--- a/src/CommandLineUtils/CommandLineApplication.Validation.cs
+++ b/src/CommandLineUtils/CommandLineApplication.Validation.cs
@@ -28,9 +28,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// </summary>
         public ICollection<ICommandValidator> Validators { get; } = new List<ICommandValidator>();
 
-        /// <summary>
-        /// Validates arguments and options.
-        /// </summary>
+        /// <summary> Validates arguments and options. </summary>
         /// <returns>The first validation result that is not <see cref="ValidationResult.Success"/> if there is an error.</returns>
         public ValidationResult GetValidationResult()
         {

--- a/src/CommandLineUtils/CommandLineApplication.cs
+++ b/src/CommandLineUtils/CommandLineApplication.cs
@@ -256,7 +256,6 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <summary> The short-form of the version to display in generated help text. </summary>
         public Func<string?>? ShortVersionGetter { get; set; }
 
-        /// <summary> Subcommands. </summary>
         public List<CommandLineApplication> Commands { get; private set; }
 
         /// <summary> Determines if '--' can be used to separate known arguments and options from additional content passed to <see cref="RemainingArguments"/>. </summary>

--- a/src/CommandLineUtils/CommandLineApplication.cs
+++ b/src/CommandLineUtils/CommandLineApplication.cs
@@ -375,7 +375,6 @@ namespace McMaster.Extensions.CommandLineUtils
             _names.Add(name);
         }
 
-        /// <summary> Add a subcommand </summary>
         public void AddSubcommand(CommandLineApplication subcommand)
         {
             if (subcommand == null)
@@ -413,7 +412,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
-        /// <summary> Adds a subcommand. </summary>
         /// <param name="name">The word used to invoke the subcommand.</param>
         public CommandLineApplication Command(string name, Action<CommandLineApplication> configuration,
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
@@ -612,7 +610,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Parses an array of strings, matching them against <see cref="Options"/>, <see cref="Arguments"/>, and <see cref="Commands"/>. </summary>
-        /// <param name="args">Command line arguments.</param>
         /// <returns>The result of parsing.</returns>
         public ParseResult Parse(params string[] args)
         {
@@ -641,7 +638,6 @@ namespace McMaster.Extensions.CommandLineUtils
         public bool MakeSuggestionsInErrorMessage { get; set; } = true;
 
         /// <summary> Handle the result of parsing command line arguments. </summary>
-        /// <param name="parseResult">The parse result.</param>
         protected virtual void HandleParseResult(ParseResult parseResult)
         {
             Parent?.HandleParseResult(parseResult);
@@ -837,10 +833,8 @@ namespace McMaster.Extensions.CommandLineUtils
             }
         }
 
-        /// <summary> Show full help. </summary>
         public void ShowHelp() => ShowHelp(usePager: UsePagerForHelpText);
 
-        /// <summary> Show full help. </summary>
         /// <param name="usePager">Use a console pager to display help text, if possible.</param>
         public void ShowHelp(bool usePager)
         {

--- a/src/CommandLineUtils/CommandLineApplication.cs
+++ b/src/CommandLineUtils/CommandLineApplication.cs
@@ -58,9 +58,7 @@ namespace McMaster.Extensions.CommandLineUtils
         private readonly List<IConvention> _conventions = new List<IConvention>();
 
 #pragma warning disable RS0027 // Public API with optional parameter(s) should have the most parameters amongst its public overloads.
-        /// <summary>
-        /// Initializes a new instance of <see cref="CommandLineApplication"/>.
-        /// </summary>
+        /// <summary> Initializes a new instance of <see cref="CommandLineApplication"/>. </summary>
         /// <param name="throwOnUnexpectedArg">Initial value for <see cref="ThrowOnUnexpectedArgument"/>.</param>
         public CommandLineApplication(bool throwOnUnexpectedArg = true)
 #pragma warning restore RS0027 // Public API with optional parameter(s) should have the most parameters amongst its public overloads.
@@ -68,17 +66,13 @@ namespace McMaster.Extensions.CommandLineUtils
         {
         }
 
-        /// <summary>
-        /// Initializes a new instance of <see cref="CommandLineApplication"/>.
-        /// </summary>
+        /// <summary> Initializes a new instance of <see cref="CommandLineApplication"/>. </summary>
         /// <param name="console">The console implementation to use.</param>
         public CommandLineApplication(IConsole console)
             : this(null, DefaultHelpTextGenerator.Singleton, new DefaultCommandLineContext(console), throwOnUnexpectedArg: true)
         { }
 
-        /// <summary>
-        /// Initializes a new instance of <see cref="CommandLineApplication"/>.
-        /// </summary>
+        /// <summary> Initializes a new instance of <see cref="CommandLineApplication"/>. </summary>
         /// <param name="console">The console implementation to use.</param>
         /// <param name="workingDirectory">The current working directory.</param>
         /// <param name="throwOnUnexpectedArg">Initial value for <see cref="ThrowOnUnexpectedArgument"/>.</param>
@@ -86,9 +80,7 @@ namespace McMaster.Extensions.CommandLineUtils
             : this(null, DefaultHelpTextGenerator.Singleton, new DefaultCommandLineContext(console, workingDirectory), throwOnUnexpectedArg)
         { }
 
-        /// <summary>
-        /// Initializes a new instance of <see cref="CommandLineApplication"/>.
-        /// </summary>
+        /// <summary> Initializes a new instance of <see cref="CommandLineApplication"/>. </summary>
         /// <param name="helpTextGenerator">The help text generator to use.</param>
         /// <param name="console">The console implementation to use.</param>
         /// <param name="workingDirectory">The current working directory.</param>
@@ -142,23 +134,17 @@ namespace McMaster.Extensions.CommandLineUtils
             }
         }
 
-        /// <summary>
-        /// Defaults to null. A link to the parent command if this is instance is a subcommand.
-        /// </summary>
+        /// <summary> Defaults to null. A link to the parent command if this is instance is a subcommand. </summary>
         public CommandLineApplication? Parent { get; set; }
 
-        /// <summary>
-        /// The help text generator to use.
-        /// </summary>
+        /// <summary> The help text generator to use. </summary>
         public IHelpTextGenerator HelpTextGenerator
         {
             get => _helpTextGenerator;
             set => _helpTextGenerator = value ?? throw new ArgumentNullException(nameof(value));
         }
 
-        /// <summary>
-        /// The short name of the command. When this is a subcommand, it is the name of the word used to invoke the subcommand.
-        /// </summary>
+        /// <summary> The short name of the command. When this is a subcommand, it is the name of the word used to invoke the subcommand. </summary>
         public string? Name
         {
             get => _primaryCommandName;
@@ -169,39 +155,25 @@ namespace McMaster.Extensions.CommandLineUtils
             }
         }
 
-        /// <summary>
-        /// The full name of the command to show in the help text.
-        /// </summary>
+        /// <summary> The full name of the command to show in the help text. </summary>
         public string? FullName { get; set; }
 
-        /// <summary>
-        /// A description of the command.
-        /// </summary>
+        /// <summary> A description of the command. </summary>
         public string? Description { get; set; }
 
-        /// <summary>
-        /// Determines if this command appears in generated help text.
-        /// </summary>
+        /// <summary> Determines if this command appears in generated help text. </summary>
         public bool ShowInHelpText { get; set; } = true;
 
-        /// <summary>
-        /// Additional text that appears at the bottom of generated help text.
-        /// </summary>
+        /// <summary> Additional text that appears at the bottom of generated help text. </summary>
         public string? ExtendedHelpText { get; set; }
 
-        /// <summary>
-        /// Available command-line options on this command. Use <see cref="GetOptions"/> to get all available options, which may include inherited options.
-        /// </summary>
+        /// <summary> Available command-line options on this command. Use <see cref="GetOptions"/> to get all available options, which may include inherited options. </summary>
         public List<CommandOption> Options { get; private set; }
 
-        /// <summary>
-        /// Whether a Pager should be used to display help text.
-        /// </summary>
+        /// <summary> Whether a Pager should be used to display help text. </summary>
         public bool UsePagerForHelpText { get; set; }
 
-        /// <summary>
-        /// All names by which the command can be referenced. This includes <see cref="Name"/> and an aliases added in <see cref="AddName"/>.
-        /// </summary>
+        /// <summary> All names by which the command can be referenced. This includes <see cref="Name"/> and an aliases added in <see cref="AddName"/>. </summary>
         public IEnumerable<string> Names
         {
             get
@@ -218,9 +190,7 @@ namespace McMaster.Extensions.CommandLineUtils
             }
         }
 
-        /// <summary>
-        /// The option used to determine if help text should be displayed. This is set by calling <see cref="HelpOption(string)"/>.
-        /// </summary>
+        /// <summary> The option used to determine if help text should be displayed. This is set by calling <see cref="HelpOption(string)"/>. </summary>
         public CommandOption? OptionHelp
         {
             get
@@ -239,19 +209,13 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
 
-        /// <summary>
-        /// The options used to determine if the command version should be displayed. This is set by calling <see cref="VersionOption(string, Func{string}, Func{string})"/>.
-        /// </summary>
+        /// <summary> The options used to determine if the command version should be displayed. This is set by calling <see cref="VersionOption(string, Func{string}, Func{string})"/>. </summary>
         public CommandOption? OptionVersion { get; internal set; }
 
-        /// <summary>
-        /// Required command-line arguments.
-        /// </summary>
+        /// <summary> Required command-line arguments. </summary>
         public List<CommandArgument> Arguments { get; private set; }
 
-        /// <summary>
-        /// When initialized with <see cref="ThrowOnUnexpectedArgument"/> to <c>false</c>, this will contain any unrecognized arguments.
-        /// </summary>
+        /// <summary> When initialized with <see cref="ThrowOnUnexpectedArgument"/> to <c>false</c>, this will contain any unrecognized arguments. </summary>
         public List<string> RemainingArguments { get; private set; }
 
         /// <summary>
@@ -261,9 +225,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// </summary>
         public bool ThrowOnUnexpectedArgument { get; set; }
 
-        /// <summary>
-        /// True when <see cref="OptionHelp"/> or <see cref="OptionVersion"/> was matched.
-        /// </summary>
+        /// <summary> True when <see cref="OptionHelp"/> or <see cref="OptionVersion"/> was matched. </summary>
         public bool IsShowingInformation { get; protected set; }
 
         /// <summary>
@@ -288,24 +250,16 @@ namespace McMaster.Extensions.CommandLineUtils
             set => _handler = _ => Task.FromResult(value());
         }
 
-        /// <summary>
-        /// The long-form of the version to display in generated help text.
-        /// </summary>
+        /// <summary> The long-form of the version to display in generated help text. </summary>
         public Func<string?>? LongVersionGetter { get; set; }
 
-        /// <summary>
-        /// The short-form of the version to display in generated help text.
-        /// </summary>
+        /// <summary> The short-form of the version to display in generated help text. </summary>
         public Func<string?>? ShortVersionGetter { get; set; }
 
-        /// <summary>
-        /// Subcommands.
-        /// </summary>
+        /// <summary> Subcommands. </summary>
         public List<CommandLineApplication> Commands { get; private set; }
 
-        /// <summary>
-        /// Determines if '--' can be used to separate known arguments and options from additional content passed to <see cref="RemainingArguments"/>.
-        /// </summary>
+        /// <summary> Determines if '--' can be used to separate known arguments and options from additional content passed to <see cref="RemainingArguments"/>. </summary>
         public bool AllowArgumentSeparator { get; set; }
 
         /// <summary>
@@ -322,9 +276,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// </summary>
         public ResponseFileHandling ResponseFileHandling { get; set; }
 
-        /// <summary>
-        /// The way arguments and options are matched.
-        /// </summary>
+        /// <summary> The way arguments and options are matched. </summary>
         public StringComparison OptionsComparison { get; set; }
 
         /// <summary>
@@ -350,9 +302,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// This defaults to true unless an option with a short name of two or more characters is added.
         /// </para>
         /// </summary>
-        /// <remarks>
-        /// <seealso href="https://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html"/>
-        /// </remarks>
+        /// <remarks> <seealso href="https://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html"/> </remarks>
         public bool ClusterOptions
         {
             // unless explicitly set, use the value of cluster options from the parent command
@@ -372,9 +322,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// parsers can be added so that domain specific types can converted. In-built value parsers can also be replaced
         /// for precise control of all type conversion.
         /// </para>
-        /// <remarks>
-        /// Value parsers are currently only used by the Attribute API.
-        /// </remarks>
+        /// <remarks> Value parsers are currently only used by the Attribute API. </remarks>
         /// </summary>
         public ValueParserProvider ValueParsers { get; private set; }
 
@@ -388,19 +336,13 @@ namespace McMaster.Extensions.CommandLineUtils
         /// </summary>
         public string WorkingDirectory => _context.WorkingDirectory;
 
-        /// <summary>
-        /// The writer used to display generated help text.
-        /// </summary>
+        /// <summary> The writer used to display generated help text. </summary>
         public TextWriter Out { get; set; }
 
-        /// <summary>
-        /// The writer used to display generated error messages.
-        /// </summary>
+        /// <summary> The writer used to display generated error messages. </summary>
         public TextWriter Error { get; set; }
 
-        /// <summary>
-        /// Gets all command line options available to this command, including any inherited options.
-        /// </summary>
+        /// <summary> Gets all command line options available to this command, including any inherited options. </summary>
         /// <returns>Command line options.</returns>
         public IEnumerable<CommandOption> GetOptions()
         {
@@ -434,10 +376,7 @@ namespace McMaster.Extensions.CommandLineUtils
             _names.Add(name);
         }
 
-        /// <summary>
-        /// Add a subcommand
-        /// </summary>
-        /// <param name="subcommand"></param>
+        /// <summary> Add a subcommand </summary>
         public void AddSubcommand(CommandLineApplication subcommand)
         {
             if (subcommand == null)
@@ -475,13 +414,8 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
-        /// <summary>
-        /// Adds a subcommand.
-        /// </summary>
+        /// <summary> Adds a subcommand. </summary>
         /// <param name="name">The word used to invoke the subcommand.</param>
-        /// <param name="configuration"></param>
-        /// <param name="throwOnUnexpectedArg"></param>
-        /// <returns></returns>
         public CommandLineApplication Command(string name, Action<CommandLineApplication> configuration,
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
             bool throwOnUnexpectedArg = true)
@@ -496,14 +430,9 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
-        /// <summary>
-        /// Adds a subcommand with model of type <typeparamref name="TModel" />.
-        /// </summary>
+        /// <summary> Adds a subcommand with model of type <typeparamref name="TModel" />. </summary>
         /// <param name="name">The word used to invoke the subcommand.</param>
-        /// <param name="configuration"></param>
-        /// <param name="throwOnUnexpectedArg"></param>
         /// <typeparam name="TModel">The model type of the subcommand.</typeparam>
-        /// <returns></returns>
         public CommandLineApplication<TModel> Command<TModel>(string name, Action<CommandLineApplication<TModel>> configuration,
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
             bool throwOnUnexpectedArg = true)
@@ -518,47 +447,19 @@ namespace McMaster.Extensions.CommandLineUtils
             return command;
         }
 
-        /// <summary>
-        /// Adds a command-line option.
-        /// </summary>
-        /// <param name="template"></param>
-        /// <param name="description"></param>
-        /// <param name="optionType"></param>
-        /// <returns></returns>
+        /// <summary> Adds a command-line option. </summary>
         public CommandOption Option(string template, string description, CommandOptionType optionType)
             => Option(template, description, optionType, _ => { }, inherited: false);
 
-        /// <summary>
-        /// Adds a command-line option.
-        /// </summary>
-        /// <param name="template"></param>
-        /// <param name="description"></param>
-        /// <param name="optionType"></param>
-        /// <param name="inherited"></param>
-        /// <returns></returns>
+        /// <summary> Adds a command-line option. </summary>
         public CommandOption Option(string template, string description, CommandOptionType optionType, bool inherited)
             => Option(template, description, optionType, _ => { }, inherited);
 
-        /// <summary>
-        /// Adds a command-line option.
-        /// </summary>
-        /// <param name="template"></param>
-        /// <param name="description"></param>
-        /// <param name="optionType"></param>
-        /// <param name="configuration"></param>
-        /// <returns></returns>
+        /// <summary> Adds a command-line option. </summary>
         public CommandOption Option(string template, string description, CommandOptionType optionType, Action<CommandOption> configuration)
             => Option(template, description, optionType, configuration, inherited: false);
 
-        /// <summary>
-        /// Adds a command line option.
-        /// </summary>
-        /// <param name="template"></param>
-        /// <param name="description"></param>
-        /// <param name="optionType"></param>
-        /// <param name="configuration"></param>
-        /// <param name="inherited"></param>
-        /// <returns></returns>
+        /// <summary> Adds a command line option. </summary>
         public CommandOption Option(string template, string description, CommandOptionType optionType, Action<CommandOption> configuration, bool inherited)
         {
             var option = new CommandOption(template, optionType)
@@ -571,14 +472,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return option;
         }
 
-        /// <summary>
-        /// Adds a command line option with values that should be parsable into <typeparamref name="T" />.
-        /// </summary>
-        /// <param name="template"></param>
-        /// <param name="description"></param>
-        /// <param name="optionType"></param>
-        /// <param name="configuration"></param>
-        /// <param name="inherited"></param>
+        /// <summary> Adds a command line option with values that should be parsable into <typeparamref name="T" />. </summary>
         /// <typeparam name="T">The type of the values on the option</typeparam>
         /// <returns>The option</returns>
         public CommandOption<T> Option<T>(string template, string description, CommandOptionType optionType, Action<CommandOption> configuration, bool inherited)
@@ -601,26 +495,13 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
-        /// <summary>
-        /// Adds a command line argument
-        /// </summary>
-        /// <param name="name"></param>
-        /// <param name="description"></param>
-        /// <param name="multipleValues"></param>
-        /// <returns></returns>
+        /// <summary> Adds a command line argument </summary>
         public CommandArgument Argument(string name, string description, bool multipleValues = false)
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
             => Argument(name, description, _ => { }, multipleValues);
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
-        /// <summary>
-        /// Adds a command line argument.
-        /// </summary>
-        /// <param name="name"></param>
-        /// <param name="description"></param>
-        /// <param name="configuration"></param>
-        /// <param name="multipleValues"></param>
-        /// <returns></returns>
+        /// <summary> Adds a command line argument. </summary>
         public CommandArgument Argument(string name, string description, Action<CommandArgument> configuration, bool multipleValues = false)
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
         {
@@ -636,15 +517,8 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
-        /// <summary>
-        /// Adds a command line argument with values that should be parsable into <typeparamref name="T" />.
-        /// </summary>
-        /// <param name="name"></param>
-        /// <param name="description"></param>
-        /// <param name="configuration"></param>
-        /// <param name="multipleValues"></param>
+        /// <summary> Adds a command line argument with values that should be parsable into <typeparamref name="T" />. </summary>
         /// <typeparam name="T">The type of the values on the option</typeparam>
-        /// <returns></returns>
         public CommandArgument<T> Argument<T>(string name, string description, Action<CommandArgument> configuration, bool multipleValues = false)
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
         {
@@ -676,10 +550,7 @@ namespace McMaster.Extensions.CommandLineUtils
             Arguments.Add(argument);
         }
 
-        /// <summary>
-        /// Defines a callback for when this command is invoked.
-        /// </summary>
-        /// <param name="invoke"></param>
+        /// <summary> Defines a callback for when this command is invoked. </summary>
         public void OnExecute(Func<int> invoke)
         {
             _handler = _ => Task.FromResult(invoke());
@@ -695,17 +566,13 @@ namespace McMaster.Extensions.CommandLineUtils
         /// Defines an asynchronous callback.
         /// </para>
         /// </summary>
-        /// <param name="invoke"></param>
         [Obsolete("This method is obsolete and will be removed in a future version. " +
                   "The recommended replacement is .OnExecuteAsync(). " +
                   "See https://github.com/natemcmaster/CommandLineUtils/issues/275 for details.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void OnExecute(Func<Task<int>> invoke) => OnExecuteAsync(_ => invoke());
 
-        /// <summary>
-        /// Defines an asynchronous callback.
-        /// </summary>
-        /// <param name="invoke"></param>
+        /// <summary> Defines an asynchronous callback. </summary>
         public void OnExecuteAsync(Func<CancellationToken, Task<int>> invoke)
         {
             _handler = invoke;
@@ -732,9 +599,7 @@ namespace McMaster.Extensions.CommandLineUtils
             RemainingArguments.Clear();
         }
 
-        /// <summary>
-        /// Adds an action to be invoked when all command line arguments have been parsed and validated.
-        /// </summary>
+        /// <summary> Adds an action to be invoked when all command line arguments have been parsed and validated. </summary>
         /// <param name="action">The action to be invoked</param>
         public void OnParsingComplete(Action<ParseResult> action)
         {
@@ -747,9 +612,7 @@ namespace McMaster.Extensions.CommandLineUtils
             _onParsingComplete.Add(action);
         }
 
-        /// <summary>
-        /// Parses an array of strings, matching them against <see cref="Options"/>, <see cref="Arguments"/>, and <see cref="Commands"/>.
-        /// </summary>
+        /// <summary> Parses an array of strings, matching them against <see cref="Options"/>, <see cref="Arguments"/>, and <see cref="Commands"/>. </summary>
         /// <param name="args">Command line arguments.</param>
         /// <returns>The result of parsing.</returns>
         public ParseResult Parse(params string[] args)
@@ -778,9 +641,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// </summary>
         public bool MakeSuggestionsInErrorMessage { get; set; } = true;
 
-        /// <summary>
-        /// Handle the result of parsing command line arguments.
-        /// </summary>
+        /// <summary> Handle the result of parsing command line arguments. </summary>
         /// <param name="parseResult">The parse result.</param>
         protected virtual void HandleParseResult(ParseResult parseResult)
         {
@@ -833,7 +694,6 @@ namespace McMaster.Extensions.CommandLineUtils
         /// If the parse result matches this command, <see cref="Invoke"/> will be invoked.
         /// </para>
         /// </summary>
-        /// <param name="args"></param>
         /// <returns>The return code from <see cref="Invoke"/>.</returns>
         public int Execute(params string[] args)
         {
@@ -856,8 +716,6 @@ namespace McMaster.Extensions.CommandLineUtils
         /// If the parse result matches this command, <see cref="Invoke"/> will be invoked.
         /// </para>
         /// </summary>
-        /// <param name="args"></param>
-        /// <param name="cancellationToken"></param>
         /// <returns>The return code from <see cref="Invoke"/>.</returns>
         public async Task<int> ExecuteAsync(string[] args, CancellationToken cancellationToken = default)
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
@@ -918,20 +776,11 @@ namespace McMaster.Extensions.CommandLineUtils
             }
         }
 
-        /// <summary>
-        /// Helper method that adds a help option.
-        /// </summary>
-        /// <param name="template"></param>
-        /// <returns></returns>
+        /// <summary> Helper method that adds a help option. </summary>
         public CommandOption HelpOption(string template)
             => HelpOption(template, false);
 
-        /// <summary>
-        /// Helper method that adds a help option.
-        /// </summary>
-        /// <param name="template"></param>
-        /// <param name="inherited"></param>
-        /// <returns></returns>
+        /// <summary> Helper method that adds a help option. </summary>
         public CommandOption HelpOption(string template, bool inherited)
         {
             // Help option is special because we stop parsing once we see it
@@ -942,13 +791,7 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
-        /// <summary>
-        /// Helper method that adds a version option from known versions strings.
-        /// </summary>
-        /// <param name="template"></param>
-        /// <param name="shortFormVersion"></param>
-        /// <param name="longFormVersion"></param>
-        /// <returns></returns>
+        /// <summary> Helper method that adds a version option from known versions strings. </summary>
         public CommandOption VersionOption(string template,
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
             string? shortFormVersion,
@@ -965,13 +808,7 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
-        /// <summary>
-        /// Helper method that adds a version option.
-        /// </summary>
-        /// <param name="template"></param>
-        /// <param name="shortFormVersionGetter"></param>
-        /// <param name="longFormVersionGetter"></param>
-        /// <returns></returns>
+        /// <summary> Helper method that adds a version option. </summary>
         public CommandOption VersionOption(string template,
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
             Func<string?>? shortFormVersionGetter,
@@ -986,9 +823,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return OptionVersion;
         }
 
-        /// <summary>
-        /// Show short hint that reminds users to use help option.
-        /// </summary>
+        /// <summary> Show short hint that reminds users to use help option. </summary>
         public virtual void ShowHint()
         {
             if (OptionHelp != null)
@@ -1003,14 +838,10 @@ namespace McMaster.Extensions.CommandLineUtils
             }
         }
 
-        /// <summary>
-        /// Show full help.
-        /// </summary>
+        /// <summary> Show full help. </summary>
         public void ShowHelp() => ShowHelp(usePager: UsePagerForHelpText);
 
-        /// <summary>
-        /// Show full help.
-        /// </summary>
+        /// <summary> Show full help. </summary>
         /// <param name="usePager">Use a console pager to display help text, if possible.</param>
         public void ShowHelp(bool usePager)
         {
@@ -1068,9 +899,7 @@ namespace McMaster.Extensions.CommandLineUtils
             target.ShowHelp();
         }
 
-        /// <summary>
-        /// Produces help text describing command usage.
-        /// </summary>
+        /// <summary> Produces help text describing command usage. </summary>
         /// <returns>The help text.</returns>
         public virtual string GetHelpText()
         {
@@ -1084,8 +913,6 @@ namespace McMaster.Extensions.CommandLineUtils
         /// This method has been marked as obsolete and will be removed in a future version.
         /// The recommended replacement is <see cref="GetHelpText()" />
         /// </summary>
-        /// <param name="commandName"></param>
-        /// <returns></returns>
         [Obsolete("This method has been marked as obsolete and will be removed in a future version. " +
             "The recommended replacement is GetHelpText()")]
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -1111,9 +938,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return target.GetHelpText();
         }
 
-        /// <summary>
-        /// Displays version information that includes <see cref="FullName"/> and <see cref="LongVersionGetter"/>.
-        /// </summary>
+        /// <summary> Displays version information that includes <see cref="FullName"/> and <see cref="LongVersionGetter"/>. </summary>
         public void ShowVersion()
         {
             CommandLineApplication? cmd = this;
@@ -1126,9 +951,7 @@ namespace McMaster.Extensions.CommandLineUtils
             Out.Write(GetVersionText());
         }
 
-        /// <summary>
-        /// Produces text describing version of the command.
-        /// </summary>
+        /// <summary> Produces text describing version of the command. </summary>
         /// <returns>The version text.</returns>
         public virtual string GetVersionText()
         {
@@ -1146,10 +969,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return sb.ToString();
         }
 
-        /// <summary>
-        /// Gets <see cref="FullName"/> and <see cref="ShortVersionGetter"/>.
-        /// </summary>
-        /// <returns></returns>
+        /// <summary> Gets <see cref="FullName"/> and <see cref="ShortVersionGetter"/>. </summary>
         public virtual string GetFullNameAndVersion()
         {
             var items = new List<string?>
@@ -1161,9 +981,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return string.Join(" ", items.Where(i => !string.IsNullOrEmpty(i)));
         }
 
-        /// <summary>
-        /// Traverses up <see cref="Parent"/> and displays the result of <see cref="GetFullNameAndVersion"/>.
-        /// </summary>
+        /// <summary> Traverses up <see cref="Parent"/> and displays the result of <see cref="GetFullNameAndVersion"/>. </summary>
         public void ShowRootCommandFullNameAndVersion()
         {
             var rootCmd = this;
@@ -1211,9 +1029,7 @@ namespace McMaster.Extensions.CommandLineUtils
 
         private IConventionBuilder? _builder;
 
-        /// <summary>
-        /// Gets a builder that can be used to apply conventions to
-        /// </summary>
+        /// <summary> Gets a builder that can be used to apply conventions to </summary>
         public IConventionBuilder Conventions
         {
             get

--- a/src/CommandLineUtils/CommandLineApplicationExtensions.cs
+++ b/src/CommandLineUtils/CommandLineApplicationExtensions.cs
@@ -11,88 +11,39 @@ using System.Threading.Tasks;
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    /// <summary>
-    /// Helper methods for <see cref="CommandLineApplication"/>.
-    /// </summary>
+    /// <summary> Helper methods for <see cref="CommandLineApplication"/>. </summary>
     public static class CommandLineApplicationExtensions
     {
-        /// <summary>
-        /// Adds a command line argument with values that should be parsable into <typeparamref name="T" />.
-        /// </summary>
-        /// <param name="app"></param>
-        /// <param name="name"></param>
-        /// <param name="description"></param>
-        /// <param name="multipleValues"></param>
-        /// <returns></returns>
+        /// <summary> Adds a command line argument with values that should be parsable into <typeparamref name="T" />. </summary>
         public static CommandArgument<T> Argument<T>(this CommandLineApplication app, string name, string description, bool multipleValues = false)
             => app.Argument<T>(name, description, _ => { }, multipleValues);
 
-        /// <summary>
-        /// Adds a command-line option with values that should be parsable into <typeparamref name="T" />.
-        /// </summary>
-        /// <param name="app"></param>
-        /// <param name="template"></param>
-        /// <param name="description"></param>
-        /// <param name="optionType"></param>
-        /// <returns></returns>
+        /// <summary> Adds a command-line option with values that should be parsable into <typeparamref name="T" />. </summary>
         public static CommandOption<T> Option<T>(this CommandLineApplication app, string template, string description, CommandOptionType optionType)
             => app.Option<T>(template, description, optionType, _ => { }, inherited: false);
 
-        /// <summary>
-        /// Adds a command-line option with values that should be parsable into <typeparamref name="T" />.
-        /// </summary>
-        /// <param name="app"></param>
-        /// <param name="template"></param>
-        /// <param name="description"></param>
-        /// <param name="optionType"></param>
-        /// <param name="inherited"></param>
-        /// <returns></returns>
+        /// <summary> Adds a command-line option with values that should be parsable into <typeparamref name="T" />. </summary>
         public static CommandOption<T> Option<T>(this CommandLineApplication app, string template, string description, CommandOptionType optionType, bool inherited)
             => app.Option<T>(template, description, optionType, _ => { }, inherited);
 
-        /// <summary>
-        /// Adds a command-line option with values that should be parsable into <typeparamref name="T" />.
-        /// </summary>
-        /// <param name="app"></param>
-        /// <param name="template"></param>
-        /// <param name="description"></param>
-        /// <param name="optionType"></param>
-        /// <param name="configuration"></param>
-        /// <returns></returns>
+        /// <summary> Adds a command-line option with values that should be parsable into <typeparamref name="T" />. </summary>
         public static CommandOption<T> Option<T>(this CommandLineApplication app, string template, string description, CommandOptionType optionType, Action<CommandOption> configuration)
             => app.Option<T>(template, description, optionType, configuration, inherited: false);
 
-        /// <summary>
-        /// Adds the help option with the template <c>-?|-h|--help</c>.
-        /// </summary>
-        /// <param name="app"></param>
-        /// <returns></returns>
+        /// <summary> Adds the help option with the template <c>-?|-h|--help</c>. </summary>
         public static CommandOption HelpOption(this CommandLineApplication app)
             => app.HelpOption(Strings.DefaultHelpTemplate);
 
-        /// <summary>
-        /// Adds the help option with the template <c>-?|-h|--help</c>.
-        /// </summary>
-        /// <param name="app"></param>
-        /// <param name="inherited"></param>
-        /// <returns></returns>
+        /// <summary> Adds the help option with the template <c>-?|-h|--help</c>. </summary>
         public static CommandOption HelpOption(this CommandLineApplication app, bool inherited)
             => app.HelpOption(Strings.DefaultHelpTemplate, inherited);
 
-        /// <summary>
-        /// Adds the verbose option with the template <c>-v|--verbose</c>.
-        /// </summary>
-        /// <param name="app"></param>
-        /// <returns></returns>
+        /// <summary> Adds the verbose option with the template <c>-v|--verbose</c>. </summary>
         public static CommandOption VerboseOption(this CommandLineApplication app)
             => VerboseOption(app, "-v|--verbose");
 
-        /// <summary>
-        /// Adds the verbose option with the template <c>-v|--verbose</c>.
-        /// </summary>
-        /// <param name="app"></param>
+        /// <summary> Adds the verbose option with the template <c>-v|--verbose</c>. </summary>
         /// <param name="template" />
-        /// <returns></returns>
         public static CommandOption VerboseOption(this CommandLineApplication app, string template)
             => app.Option(template, "Show verbose output", CommandOptionType.NoValue, inherited: true);
 
@@ -106,7 +57,6 @@ namespace McMaster.Extensions.CommandLineUtils
         /// Sets an async handler with a return code of <c>0</c>.
         /// </para>
         /// </summary>
-        /// <param name="app"></param>
         /// <param name="action">An asynchronous action to invoke when the ocmmand is selected..</param>
         [Obsolete("This method is obsolete and will be removed in a future version. " +
                   "The recommended replacement is .OnExecuteAsync(). " +
@@ -121,10 +71,7 @@ namespace McMaster.Extensions.CommandLineUtils
                        });
         }
 
-        /// <summary>
-        /// Sets an async handler with a return code of <c>0</c>.
-        /// </summary>
-        /// <param name="app"></param>
+        /// <summary> Sets an async handler with a return code of <c>0</c>. </summary>
         /// <param name="action">An asynchronous action to invoke when the ocmmand is selected..</param>
         public static void OnExecuteAsync(this CommandLineApplication app, Func<CancellationToken, Task> action)
             => app.OnExecuteAsync(async ct =>
@@ -133,10 +80,7 @@ namespace McMaster.Extensions.CommandLineUtils
                 return 0;
             });
 
-        /// <summary>
-        /// Sets <see cref="CommandLineApplication.Invoke"/> with a return code of <c>0</c>.
-        /// </summary>
-        /// <param name="app"></param>
+        /// <summary> Sets <see cref="CommandLineApplication.Invoke"/> with a return code of <c>0</c>. </summary>
         /// <param name="action">An action to invoke when the command is selected.</param>
         public static void OnExecute(this CommandLineApplication app, Action action)
             => app.OnExecute(() =>
@@ -145,19 +89,11 @@ namespace McMaster.Extensions.CommandLineUtils
                     return 0;
                 });
 
-        /// <summary>
-        /// Sets an action to invoke, but only when there is a validation error.
-        /// </summary>
-        /// <param name="app"></param>
-        /// <param name="action"></param>
+        /// <summary> Sets an action to invoke, but only when there is a validation error. </summary>
         public static void OnValidationError(this CommandLineApplication app, Func<ValidationResult, int> action)
             => app.ValidationErrorHandler = action;
 
-        /// <summary>
-        /// Sets an action to invoke, but only when there is a validation error.
-        /// </summary>
-        /// <param name="app"></param>
-        /// <param name="action"></param>
+        /// <summary> Sets an action to invoke, but only when there is a validation error. </summary>
         public static void OnValidationError(this CommandLineApplication app, Action<ValidationResult> action)
         {
             app.OnValidationError(r =>
@@ -175,8 +111,6 @@ namespace McMaster.Extensions.CommandLineUtils
         /// if no <see cref="AssemblyInformationalVersionAttribute"/> is applied.
         /// </para>
         /// </summary>
-        /// <param name="app"></param>
-        /// <param name="assembly"></param>
         /// <exception cref="ArgumentNullException">Either <paramref name="app"/> or <paramref name="assembly"/> is <c>null</c>.</exception>
         public static CommandOption VersionOptionFromAssemblyAttributes(this CommandLineApplication app, Assembly assembly)
             => VersionOptionFromAssemblyAttributes(app, Strings.DefaultVersionTemplate, assembly);
@@ -189,9 +123,6 @@ namespace McMaster.Extensions.CommandLineUtils
         /// if no <see cref="AssemblyInformationalVersionAttribute"/> is applied.
         /// </para>
         /// </summary>
-        /// <param name="app"></param>
-        /// <param name="template"></param>
-        /// <param name="assembly"></param>
         /// <exception cref="ArgumentNullException">Either <paramref name="app"/> or <paramref name="assembly"/> is <c>null</c>.</exception>
         public static CommandOption VersionOptionFromAssemblyAttributes(CommandLineApplication app, string template, Assembly assembly)
             => app.VersionOption(template, GetInformationalVersion(assembly));

--- a/src/CommandLineUtils/CommandLineApplication{T}.cs
+++ b/src/CommandLineUtils/CommandLineApplication{T}.cs
@@ -20,9 +20,7 @@ namespace McMaster.Extensions.CommandLineUtils
 
 #nullable disable
 #pragma warning disable RS0027 // Public API with optional parameter(s) should have the most parameters amongst its public overloads.
-        /// <summary>
-        /// Initializes a new instance of <see cref="CommandLineApplication"/>.
-        /// </summary>
+        /// <summary> Initializes a new instance of <see cref="CommandLineApplication"/>. </summary>
         /// <param name="throwOnUnexpectedArg">Initial value for <see cref="CommandLineApplication.ThrowOnUnexpectedArgument"/>.</param>
         public CommandLineApplication(bool throwOnUnexpectedArg = true)
 #pragma warning restore RS0027 // Public API with optional parameter(s) should have the most parameters amongst its public overloads.
@@ -31,9 +29,7 @@ namespace McMaster.Extensions.CommandLineUtils
             Initialize();
         }
 
-        /// <summary>
-        /// Initializes a new instance of <see cref="CommandLineApplication"/>.
-        /// </summary>
+        /// <summary> Initializes a new instance of <see cref="CommandLineApplication"/>. </summary>
         /// <param name="console">The console implementation to use.</param>
         public CommandLineApplication(IConsole console)
             : base(console)
@@ -41,9 +37,7 @@ namespace McMaster.Extensions.CommandLineUtils
             Initialize();
         }
 
-        /// <summary>
-        /// Initializes a new instance of <see cref="CommandLineApplication"/>.
-        /// </summary>
+        /// <summary> Initializes a new instance of <see cref="CommandLineApplication"/>. </summary>
         /// <param name="console">The console implementation to use.</param>
         /// <param name="workingDirectory">The current working directory.</param>
         /// <param name="throwOnUnexpectedArg">Initial value for <see cref="CommandLineApplication.ThrowOnUnexpectedArgument"/>.</param>
@@ -53,9 +47,7 @@ namespace McMaster.Extensions.CommandLineUtils
             Initialize();
         }
 
-        /// <summary>
-        /// Initializes a new instance of <see cref="CommandLineApplication"/>.
-        /// </summary>
+        /// <summary> Initializes a new instance of <see cref="CommandLineApplication"/>. </summary>
         /// <param name="helpTextGenerator">The help text generator to use.</param>
         /// <param name="console">The console implementation to use.</param>
         /// <param name="workingDirectory">The current working directory.</param>
@@ -90,24 +82,18 @@ namespace McMaster.Extensions.CommandLineUtils
             }
         }
 
-        /// <summary>
-        /// An instance of the model associated with the command line application.
-        /// </summary>
+        /// <summary> An instance of the model associated with the command line application. </summary>
         public TModel Model => _lazy.Value;
 
         Type IModelAccessor.GetModelType() => typeof(TModel);
 
         object IModelAccessor.GetModel() => Model;
 
-        /// <summary>
-        ///  Create an instance of <typeparamref name="TModel" />.
-        /// </summary>
+        /// <summary> Create an instance of <typeparamref name="TModel" />. </summary>
         /// <returns>An instance of the context.</returns>
         protected virtual TModel CreateModel() => ModelFactory();
 
-        /// <summary>
-        /// Defines the function that produces an instance of <typeparamref name="TModel" />.
-        /// </summary>
+        /// <summary> Defines the function that produces an instance of <typeparamref name="TModel" />. </summary>
         public Func<TModel> ModelFactory
         {
             get => _modelFactory;

--- a/src/CommandLineUtils/CommandOption.cs
+++ b/src/CommandLineUtils/CommandOption.cs
@@ -19,7 +19,6 @@ namespace McMaster.Extensions.CommandLineUtils
     {
         /// <summary> Initializes a new <see cref="CommandOption"/>. </summary>
         /// <param name="template">The template string. This is parsed into <see cref="ShortName"/> and <see cref="LongName"/>.</param>
-        /// <param name="optionType">The option type.</param>
         public CommandOption(string template, CommandOptionType optionType)
         {
 #pragma warning disable 618

--- a/src/CommandLineUtils/CommandOption.cs
+++ b/src/CommandLineUtils/CommandOption.cs
@@ -17,9 +17,7 @@ namespace McMaster.Extensions.CommandLineUtils
     /// </summary>
     public class CommandOption
     {
-        /// <summary>
-        /// Initializes a new <see cref="CommandOption"/>.
-        /// </summary>
+        /// <summary> Initializes a new <see cref="CommandOption"/>. </summary>
         /// <param name="template">The template string. This is parsed into <see cref="ShortName"/> and <see cref="LongName"/>.</param>
         /// <param name="optionType">The option type.</param>
         public CommandOption(string template, CommandOptionType optionType)
@@ -85,14 +83,10 @@ namespace McMaster.Extensions.CommandLineUtils
         [EditorBrowsable(EditorBrowsableState.Never)]
         public string? Template { get; set; }
 
-        /// <summary>
-        /// The short command line flag used to identify this option. On command line, this is preceeded by a single '-{ShortName}'.
-        /// </summary>
+        /// <summary> The short command line flag used to identify this option. On command line, this is preceeded by a single '-{ShortName}'. </summary>
         public string? ShortName { get; set; }
 
-        /// <summary>
-        /// The long command line flag used to identify this option. On command line, this is preceeded by a double dash: '--{LongName}'.
-        /// </summary>
+        /// <summary> The long command line flag used to identify this option. On command line, this is preceeded by a double dash: '--{LongName}'. </summary>
         public string? LongName { get; set; }
 
         /// <summary>
@@ -101,29 +95,19 @@ namespace McMaster.Extensions.CommandLineUtils
         /// </summary>
         public string? SymbolName { get; set; }
 
-        /// <summary>
-        /// The name of value(s) shown in help text when <see cref="OptionType"/> is not <see cref="CommandOptionType.NoValue"/>.
-        /// </summary>
+        /// <summary> The name of value(s) shown in help text when <see cref="OptionType"/> is not <see cref="CommandOptionType.NoValue"/>. </summary>
         public string? ValueName { get; set; }
 
-        /// <summary>
-        /// A description of this option to show in generated help text.
-        /// </summary>
+        /// <summary> A description of this option to show in generated help text. </summary>
         public string? Description { get; set; }
 
-        /// <summary>
-        /// Any values found during parsing, if any.
-        /// </summary>
+        /// <summary> Any values found during parsing, if any. </summary>
         public List<string?> Values { get; } = new List<string?>();
 
-        /// <summary>
-        /// Defines the type of the option.
-        /// </summary>
+        /// <summary> Defines the type of the option. </summary>
         public CommandOptionType OptionType { get; private set; }
 
-        /// <summary>
-        /// Determines if this option should be shown in generated help text.
-        /// </summary>
+        /// <summary> Determines if this option should be shown in generated help text. </summary>
         public bool ShowInHelpText { get; set; } = true;
 
         /// <summary>
@@ -132,9 +116,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// </summary>
         public bool Inherited { get; set; }
 
-        /// <summary>
-        /// Defines the underlying type of the option for the help-text-generator
-        /// </summary>
+        /// <summary> Defines the underlying type of the option for the help-text-generator </summary>
         internal Type UnderlyingType { get; set; }
 
         /// <summary>
@@ -143,11 +125,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// </summary>
         public ICollection<IOptionValidator> Validators { get; } = new List<IOptionValidator>();
 
-        /// <summary>
-        /// Attempt to parse the value that follows after the flag.
-        /// </summary>
-        /// <param name="value"></param>
-        /// <returns></returns>
+        /// <summary> Attempt to parse the value that follows after the flag. </summary>
         public bool TryParse(string? value)
         {
             switch (OptionType)
@@ -179,27 +157,19 @@ namespace McMaster.Extensions.CommandLineUtils
             return true;
         }
 
-        /// <summary>
-        /// True when <see cref="Values"/> is not empty.
-        /// </summary>
-        /// <returns></returns>
+        /// <summary> True when <see cref="Values"/> is not empty. </summary>
         public bool HasValue()
         {
             return Values.Any();
         }
 
-        /// <summary>
-        /// Returns the first element of <see cref="Values"/>, if any.
-        /// </summary>
-        /// <returns></returns>
+        /// <summary> Returns the first element of <see cref="Values"/>, if any. </summary>
         public string? Value()
         {
             return HasValue() ? Values[0] : null;
         }
 
-        /// <summary>
-        /// Generates the template string in the format "-{Symbol}|-{Short}|--{Long} &lt;{Value}&gt;" for display in help text.
-        /// </summary>
+        /// <summary> Generates the template string in the format "-{Symbol}|-{Short}|--{Long} &lt;{Value}&gt;" for display in help text. </summary>
         /// <returns>The template string</returns>
         internal string ToTemplateString()
         {

--- a/src/CommandLineUtils/CommandOptionType.cs
+++ b/src/CommandLineUtils/CommandOptionType.cs
@@ -4,9 +4,7 @@
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    /// <summary>
-    /// Defines the kinds of inputs <see cref="CommandOption"/> accepts.
-    /// </summary>
+    /// <summary> Defines the kinds of inputs <see cref="CommandOption"/> accepts. </summary>
     public enum CommandOptionType
     {
         /// <summary>

--- a/src/CommandLineUtils/CommandOption{T}.cs
+++ b/src/CommandLineUtils/CommandOption{T}.cs
@@ -20,9 +20,7 @@ namespace McMaster.Extensions.CommandLineUtils
         private readonly List<T> _parsedValues = new List<T>();
         private readonly IValueParser<T> _valueParser;
 
-        /// <summary>
-        /// Intializes a new instance of <see cref="CommandOption{T}" />
-        /// </summary>
+        /// <summary> Intializes a new instance of <see cref="CommandOption{T}" /> </summary>
         /// <param name="valueParser">The parser use to convert values into type of T.</param>
         /// <param name="template">The option tempalte.</param>
         /// <param name="optionType">The optiont type</param>
@@ -33,14 +31,10 @@ namespace McMaster.Extensions.CommandLineUtils
             UnderlyingType = typeof(T);
         }
 
-        /// <summary>
-        /// The parsed value.
-        /// </summary>
+        /// <summary> The parsed value. </summary>
         public T ParsedValue => _parsedValues.FirstOrDefault();
 
-        /// <summary>
-        /// All parsed values;
-        /// </summary>
+        /// <summary> All parsed values; </summary>
         public IReadOnlyList<T> ParsedValues => _parsedValues;
 
         void IInternalCommandParamOfT.Parse(CultureInfo culture)

--- a/src/CommandLineUtils/CommandOption{T}.cs
+++ b/src/CommandLineUtils/CommandOption{T}.cs
@@ -22,8 +22,6 @@ namespace McMaster.Extensions.CommandLineUtils
 
         /// <summary> Intializes a new instance of <see cref="CommandOption{T}" /> </summary>
         /// <param name="valueParser">The parser use to convert values into type of T.</param>
-        /// <param name="template">The option tempalte.</param>
-        /// <param name="optionType">The optiont type</param>
         public CommandOption(IValueParser<T> valueParser, string template, CommandOptionType optionType)
             : base(template, optionType)
         {
@@ -31,7 +29,6 @@ namespace McMaster.Extensions.CommandLineUtils
             UnderlyingType = typeof(T);
         }
 
-        /// <summary> The parsed value. </summary>
         public T ParsedValue => _parsedValues.FirstOrDefault();
 
         /// <summary> All parsed values; </summary>

--- a/src/CommandLineUtils/CommandParsingException.cs
+++ b/src/CommandLineUtils/CommandParsingException.cs
@@ -6,14 +6,10 @@ using System;
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    /// <summary>
-    /// The exception that is thrown when command line arguments could not be parsed.
-    /// </summary>
+    /// <summary> The exception that is thrown when command line arguments could not be parsed. </summary>
     public class CommandParsingException : Exception
     {
-        /// <summary>
-        /// Initializes an instance of <see cref="CommandParsingException"/>.
-        /// </summary>
+        /// <summary> Initializes an instance of <see cref="CommandParsingException"/>. </summary>
         /// <param name="command">The command.</param>
         /// <param name="message">The message.</param>
         public CommandParsingException(CommandLineApplication command, string message)
@@ -22,9 +18,7 @@ namespace McMaster.Extensions.CommandLineUtils
             Command = command;
         }
 
-        /// <summary>
-        /// Initializes an instance of <see cref="CommandParsingException"/>.
-        /// </summary>
+        /// <summary> Initializes an instance of <see cref="CommandParsingException"/>. </summary>
         /// <param name="command">The command.</param>
         /// <param name="message">The message.</param>
         /// <param name="innerException">The inner exception</param>
@@ -34,9 +28,7 @@ namespace McMaster.Extensions.CommandLineUtils
             Command = command;
         }
 
-        /// <summary>
-        /// The command that is throwing the exception.
-        /// </summary>
+        /// <summary> The command that is throwing the exception. </summary>
         public CommandLineApplication Command { get; }
     }
 }

--- a/src/CommandLineUtils/CommandParsingException.cs
+++ b/src/CommandLineUtils/CommandParsingException.cs
@@ -10,8 +10,6 @@ namespace McMaster.Extensions.CommandLineUtils
     public class CommandParsingException : Exception
     {
         /// <summary> Initializes an instance of <see cref="CommandParsingException"/>. </summary>
-        /// <param name="command">The command.</param>
-        /// <param name="message">The message.</param>
         public CommandParsingException(CommandLineApplication command, string message)
             : base(message)
         {
@@ -19,8 +17,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Initializes an instance of <see cref="CommandParsingException"/>. </summary>
-        /// <param name="command">The command.</param>
-        /// <param name="message">The message.</param>
         /// <param name="innerException">The inner exception</param>
         public CommandParsingException(CommandLineApplication command, string message, Exception innerException)
             : base(message, innerException)

--- a/src/CommandLineUtils/CommandParsingException.cs
+++ b/src/CommandLineUtils/CommandParsingException.cs
@@ -17,7 +17,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Initializes an instance of <see cref="CommandParsingException"/>. </summary>
-        /// <param name="innerException">The inner exception</param>
         public CommandParsingException(CommandLineApplication command, string message, Exception innerException)
             : base(message, innerException)
         {

--- a/src/CommandLineUtils/Conventions/AttributeConvention.cs
+++ b/src/CommandLineUtils/Conventions/AttributeConvention.cs
@@ -6,9 +6,7 @@ using System.Reflection;
 
 namespace McMaster.Extensions.CommandLineUtils.Conventions
 {
-    /// <summary>
-    /// Searches the model type and its members for attributes that implement <see cref="IMemberConvention"/> or <see cref="IConvention"/>.
-    /// </summary>
+    /// <summary> Searches the model type and its members for attributes that implement <see cref="IMemberConvention"/> or <see cref="IConvention"/>. </summary>
     public class AttributeConvention : IConvention
     {
         /// <inheritdoc />

--- a/src/CommandLineUtils/Conventions/CommandAttributeConvention.cs
+++ b/src/CommandLineUtils/Conventions/CommandAttributeConvention.cs
@@ -13,7 +13,6 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
     /// <seealso cref="McMaster.Extensions.CommandLineUtils.Conventions.IConvention" />
     public class CommandAttributeConvention : IConvention
     {
-        /// <summary> Apply the convention. </summary>
         /// <param name="context">The context in which the convention is applied.</param>
         /// <inheritdoc />
         public virtual void Apply(ConventionContext context)

--- a/src/CommandLineUtils/Conventions/CommandAttributeConvention.cs
+++ b/src/CommandLineUtils/Conventions/CommandAttributeConvention.cs
@@ -9,15 +9,11 @@ using McMaster.Extensions.CommandLineUtils.Validation;
 
 namespace McMaster.Extensions.CommandLineUtils.Conventions
 {
-    /// <summary>
-    /// Adds settings from <see cref="CommandAttribute" /> and <see cref="ValidationAttribute"/> set on the model type for <see cref="CommandLineApplication{TModel}" />.
-    /// </summary>
+    /// <summary> Adds settings from <see cref="CommandAttribute" /> and <see cref="ValidationAttribute"/> set on the model type for <see cref="CommandLineApplication{TModel}" />. </summary>
     /// <seealso cref="McMaster.Extensions.CommandLineUtils.Conventions.IConvention" />
     public class CommandAttributeConvention : IConvention
     {
-        /// <summary>
-        /// Apply the convention.
-        /// </summary>
+        /// <summary> Apply the convention. </summary>
         /// <param name="context">The context in which the convention is applied.</param>
         /// <inheritdoc />
         public virtual void Apply(ConventionContext context)

--- a/src/CommandLineUtils/Conventions/ConstructorInjectionConvention.cs
+++ b/src/CommandLineUtils/Conventions/ConstructorInjectionConvention.cs
@@ -15,16 +15,12 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
     {
         private readonly IServiceProvider? _additionalServices;
 
-        /// <summary>
-        /// Initializes an instance of <see cref="ConstructorInjectionConvention" />.
-        /// </summary>
+        /// <summary> Initializes an instance of <see cref="ConstructorInjectionConvention" />. </summary>
         public ConstructorInjectionConvention()
         {
         }
 
-        /// <summary>
-        /// Initializes an instance of <see cref="ConstructorInjectionConvention" />.
-        /// </summary>
+        /// <summary> Initializes an instance of <see cref="ConstructorInjectionConvention" />. </summary>
         /// <param name="additionalServices">Additional services use to inject the constructor of the model</param>
         public ConstructorInjectionConvention(IServiceProvider additionalServices)
         {

--- a/src/CommandLineUtils/Conventions/ConventionBuilderExtensions.cs
+++ b/src/CommandLineUtils/Conventions/ConventionBuilderExtensions.cs
@@ -6,9 +6,7 @@ using McMaster.Extensions.CommandLineUtils.Conventions;
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    /// <summary>
-    /// Methods for adding commonly used conventions
-    /// </summary>
+    /// <summary> Methods for adding commonly used conventions </summary>
     public static class ConventionBuilderExtensions
     {
         /// <summary>
@@ -37,9 +35,7 @@ namespace McMaster.Extensions.CommandLineUtils
                 .UseCommandNameFromModelType();
         }
 
-        /// <summary>
-        /// Adds --help option, if there isn't already a help flag set.
-        /// </summary>
+        /// <summary> Adds --help option, if there isn't already a help flag set. </summary>
         /// <param name="builder">The builder.</param>
         /// <param name="template">The help template. Defaults to <c>-?|-h|--help</c>.</param>
         /// <returns>The builder.</returns>
@@ -112,73 +108,55 @@ namespace McMaster.Extensions.CommandLineUtils
         public static IConventionBuilder SetAppNameFromEntryAssembly(this IConventionBuilder builder)
             => builder.AddConvention(new AppNameFromEntryAssemblyConvention());
 
-        /// <summary>
-        /// Applies settings from <see cref="CommandAttribute" /> on the model type.
-        /// </summary>
+        /// <summary> Applies settings from <see cref="CommandAttribute" /> on the model type. </summary>
         /// <param name="builder">The builder.</param>
         /// <returns>The builder.</returns>
         public static IConventionBuilder UseCommandAttribute(this IConventionBuilder builder)
             => builder.AddConvention(new CommandAttributeConvention());
 
-        /// <summary>
-        /// Applies settings from <see cref="VersionOptionFromMemberAttribute" /> on the model type.
-        /// </summary>
+        /// <summary> Applies settings from <see cref="VersionOptionFromMemberAttribute" /> on the model type. </summary>
         /// <param name="builder">The builder.</param>
         /// <returns>The builder.</returns>
         public static IConventionBuilder UseVersionOptionFromMemberAttribute(this IConventionBuilder builder)
             => builder.AddConvention(new VersionOptionFromMemberAttributeConvention());
 
-        /// <summary>
-        /// Applies settings from <see cref="VersionOptionAttribute" /> on the model type.
-        /// </summary>
+        /// <summary> Applies settings from <see cref="VersionOptionAttribute" /> on the model type. </summary>
         /// <param name="builder">The builder.</param>
         /// <returns>The builder.</returns>
         public static IConventionBuilder UseVersionOptionAttribute(this IConventionBuilder builder)
             => builder.AddConvention(new VersionOptionAttributeConvention());
 
-        /// <summary>
-        /// Applies settings from <see cref="HelpOptionAttribute" /> on the model type.
-        /// </summary>
+        /// <summary> Applies settings from <see cref="HelpOptionAttribute" /> on the model type. </summary>
         /// <param name="builder">The builder.</param>
         /// <returns>The builder.</returns>
         public static IConventionBuilder UseHelpOptionAttribute(this IConventionBuilder builder)
             => builder.AddConvention(new HelpOptionAttributeConvention());
 
-        /// <summary>
-        /// Applies settings from <see cref="OptionAttribute" /> on the model type.
-        /// </summary>
+        /// <summary> Applies settings from <see cref="OptionAttribute" /> on the model type. </summary>
         /// <param name="builder">The builder.</param>
         /// <returns>The builder.</returns>
         public static IConventionBuilder UseOptionAttributes(this IConventionBuilder builder)
             => builder.AddConvention(new OptionAttributeConvention());
 
-        /// <summary>
-        /// Applies settings from <see cref="ArgumentAttribute" /> on the model type.
-        /// </summary>
+        /// <summary> Applies settings from <see cref="ArgumentAttribute" /> on the model type. </summary>
         /// <param name="builder">The builder.</param>
         /// <returns>The builder.</returns>
         public static IConventionBuilder UseArgumentAttributes(this IConventionBuilder builder)
             => builder.AddConvention(new ArgumentAttributeConvention());
 
-        /// <summary>
-        /// Adds subcommands for each <see cref="McMaster.Extensions.CommandLineUtils.SubcommandAttribute" /> on the model type.
-        /// </summary>
+        /// <summary> Adds subcommands for each <see cref="McMaster.Extensions.CommandLineUtils.SubcommandAttribute" /> on the model type. </summary>
         /// <param name="builder">The builder.</param>
         /// <returns>The builder.</returns>
         public static IConventionBuilder UseSubcommandAttributes(this IConventionBuilder builder)
             => builder.AddConvention(new SubcommandAttributeConvention());
 
-        /// <summary>
-        /// Invokes a method named "OnValidate" on the model type after parsing.
-        /// </summary>
+        /// <summary> Invokes a method named "OnValidate" on the model type after parsing. </summary>
         /// <param name="builder">The builder.</param>
         /// <returns>The builder.</returns>
         public static IConventionBuilder UseOnValidateMethodFromModel(this IConventionBuilder builder)
             => builder.AddConvention(new ValidateMethodConvention());
 
-        /// <summary>
-        /// Invokes a method named "OnValidationError" on the model type when validation fails.
-        /// </summary>
+        /// <summary> Invokes a method named "OnValidationError" on the model type when validation fails. </summary>
         /// <param name="builder">The builder.</param>
         /// <returns>The builder.</returns>
         public static IConventionBuilder UseOnValidationErrorMethodFromModel(this IConventionBuilder builder)
@@ -193,26 +171,16 @@ namespace McMaster.Extensions.CommandLineUtils
         public static IConventionBuilder UseOnExecuteMethodFromModel(this IConventionBuilder builder)
             => builder.AddConvention(new ExecuteMethodConvention());
 
-        /// <summary>
-        /// Enables using constructor injection to initialize the model type.
-        /// </summary>
-        /// <param name="builder"></param>
+        /// <summary> Enables using constructor injection to initialize the model type. </summary>
         public static IConventionBuilder UseConstructorInjection(this IConventionBuilder builder)
             => builder.AddConvention(new ConstructorInjectionConvention());
 
-        /// <summary>
-        /// Enables using constructor injection to initialize the model type.
-        /// </summary>
-        /// <param name="builder"></param>
+        /// <summary> Enables using constructor injection to initialize the model type. </summary>
         /// <param name="additionalServices">Additional services that should be passed to the service provider.</param>
         public static IConventionBuilder UseConstructorInjection(this IConventionBuilder builder, IServiceProvider additionalServices)
             => builder.AddConvention(new ConstructorInjectionConvention(additionalServices));
 
-        /// <summary>
-        /// Sets the subcommand name using the model type, if available and not otherwise set using <see cref="CommandAttribute"/>.
-        /// </summary>
-        /// <param name="builder"></param>
-        /// <returns></returns>
+        /// <summary> Sets the subcommand name using the model type, if available and not otherwise set using <see cref="CommandAttribute"/>. </summary>
         public static IConventionBuilder UseCommandNameFromModelType(this IConventionBuilder builder)
             => builder.AddConvention(new CommandNameFromTypeConvention());
     }

--- a/src/CommandLineUtils/Conventions/ConventionBuilderExtensions.cs
+++ b/src/CommandLineUtils/Conventions/ConventionBuilderExtensions.cs
@@ -36,7 +36,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Adds --help option, if there isn't already a help flag set. </summary>
-        /// <param name="builder">The builder.</param>
         /// <param name="template">The help template. Defaults to <c>-?|-h|--help</c>.</param>
         /// <returns>The builder.</returns>
         public static IConventionBuilder UseDefaultHelpOption(this IConventionBuilder builder, string template = DefaultHelpOptionConvention.DefaultHelpTemplate)
@@ -76,7 +75,6 @@ namespace McMaster.Extensions.CommandLineUtils
         /// Sets a property named "RemainingArgs" or "RemainingArguments" on the model type to the value
         /// of <see cref="CommandLineApplication.RemainingArguments" />.
         /// </summary>
-        /// <param name="builder">The builder.</param>
         /// <returns>The builder.</returns>
         public static IConventionBuilder SetRemainingArgsPropertyOnModel(this IConventionBuilder builder)
             => builder.AddConvention(new RemainingArgsPropertyConvention());
@@ -85,7 +83,6 @@ namespace McMaster.Extensions.CommandLineUtils
         /// Sets a property named "Subcommand" on the model type to the value
         /// of the model of the selected subcommand.
         /// </summary>
-        /// <param name="builder">The builder.</param>
         /// <returns>The builder.</returns>
         public static IConventionBuilder SetSubcommandPropertyOnModel(this IConventionBuilder builder)
             => builder.AddConvention(new SubcommandPropertyConvention());
@@ -94,7 +91,6 @@ namespace McMaster.Extensions.CommandLineUtils
         /// Sets a property named "Parent" on the model type to the value
         /// of the model of the parent command.
         /// </summary>
-        /// <param name="builder">The builder.</param>
         /// <returns>The builder.</returns>
         public static IConventionBuilder SetParentPropertyOnModel(this IConventionBuilder builder)
             => builder.AddConvention(new ParentPropertyConvention());
@@ -103,61 +99,51 @@ namespace McMaster.Extensions.CommandLineUtils
         /// Sets <see cref="CommandLineApplication.Name" /> to match the name of
         /// <see cref="System.Reflection.Assembly.GetEntryAssembly" />
         /// </summary>
-        /// <param name="builder">The builder.</param>
         /// <returns>The builder.</returns>
         public static IConventionBuilder SetAppNameFromEntryAssembly(this IConventionBuilder builder)
             => builder.AddConvention(new AppNameFromEntryAssemblyConvention());
 
         /// <summary> Applies settings from <see cref="CommandAttribute" /> on the model type. </summary>
-        /// <param name="builder">The builder.</param>
         /// <returns>The builder.</returns>
         public static IConventionBuilder UseCommandAttribute(this IConventionBuilder builder)
             => builder.AddConvention(new CommandAttributeConvention());
 
         /// <summary> Applies settings from <see cref="VersionOptionFromMemberAttribute" /> on the model type. </summary>
-        /// <param name="builder">The builder.</param>
         /// <returns>The builder.</returns>
         public static IConventionBuilder UseVersionOptionFromMemberAttribute(this IConventionBuilder builder)
             => builder.AddConvention(new VersionOptionFromMemberAttributeConvention());
 
         /// <summary> Applies settings from <see cref="VersionOptionAttribute" /> on the model type. </summary>
-        /// <param name="builder">The builder.</param>
         /// <returns>The builder.</returns>
         public static IConventionBuilder UseVersionOptionAttribute(this IConventionBuilder builder)
             => builder.AddConvention(new VersionOptionAttributeConvention());
 
         /// <summary> Applies settings from <see cref="HelpOptionAttribute" /> on the model type. </summary>
-        /// <param name="builder">The builder.</param>
         /// <returns>The builder.</returns>
         public static IConventionBuilder UseHelpOptionAttribute(this IConventionBuilder builder)
             => builder.AddConvention(new HelpOptionAttributeConvention());
 
         /// <summary> Applies settings from <see cref="OptionAttribute" /> on the model type. </summary>
-        /// <param name="builder">The builder.</param>
         /// <returns>The builder.</returns>
         public static IConventionBuilder UseOptionAttributes(this IConventionBuilder builder)
             => builder.AddConvention(new OptionAttributeConvention());
 
         /// <summary> Applies settings from <see cref="ArgumentAttribute" /> on the model type. </summary>
-        /// <param name="builder">The builder.</param>
         /// <returns>The builder.</returns>
         public static IConventionBuilder UseArgumentAttributes(this IConventionBuilder builder)
             => builder.AddConvention(new ArgumentAttributeConvention());
 
         /// <summary> Adds subcommands for each <see cref="McMaster.Extensions.CommandLineUtils.SubcommandAttribute" /> on the model type. </summary>
-        /// <param name="builder">The builder.</param>
         /// <returns>The builder.</returns>
         public static IConventionBuilder UseSubcommandAttributes(this IConventionBuilder builder)
             => builder.AddConvention(new SubcommandAttributeConvention());
 
         /// <summary> Invokes a method named "OnValidate" on the model type after parsing. </summary>
-        /// <param name="builder">The builder.</param>
         /// <returns>The builder.</returns>
         public static IConventionBuilder UseOnValidateMethodFromModel(this IConventionBuilder builder)
             => builder.AddConvention(new ValidateMethodConvention());
 
         /// <summary> Invokes a method named "OnValidationError" on the model type when validation fails. </summary>
-        /// <param name="builder">The builder.</param>
         /// <returns>The builder.</returns>
         public static IConventionBuilder UseOnValidationErrorMethodFromModel(this IConventionBuilder builder)
             => builder.AddConvention(new ValidationErrorMethodConvention());
@@ -166,7 +152,6 @@ namespace McMaster.Extensions.CommandLineUtils
         /// Sets a method named "OnExecute" or "OnExecuteAsync" on the model type to handle
         /// <see cref="CommandLineApplication.Invoke" />
         /// </summary>
-        /// <param name="builder">The builder.</param>
         /// <returns>The builder.</returns>
         public static IConventionBuilder UseOnExecuteMethodFromModel(this IConventionBuilder builder)
             => builder.AddConvention(new ExecuteMethodConvention());

--- a/src/CommandLineUtils/Conventions/ConventionContext.cs
+++ b/src/CommandLineUtils/Conventions/ConventionContext.cs
@@ -10,7 +10,6 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
     public class ConventionContext
     {
         /// <summary> Initializes an instance of <see cref="ConventionContext" />. </summary>
-        /// <param name="application">The application</param>
         /// <param name="modelType">The type of the model.</param>
         public ConventionContext(CommandLineApplication application, Type? modelType)
         {

--- a/src/CommandLineUtils/Conventions/ConventionContext.cs
+++ b/src/CommandLineUtils/Conventions/ConventionContext.cs
@@ -6,14 +6,10 @@ using McMaster.Extensions.CommandLineUtils.Abstractions;
 
 namespace McMaster.Extensions.CommandLineUtils.Conventions
 {
-    /// <summary>
-    /// The context in which a convention is applied.
-    /// </summary>
+    /// <summary> The context in which a convention is applied. </summary>
     public class ConventionContext
     {
-        /// <summary>
-        /// Initializes an instance of <see cref="ConventionContext" />.
-        /// </summary>
+        /// <summary> Initializes an instance of <see cref="ConventionContext" />. </summary>
         /// <param name="application">The application</param>
         /// <param name="modelType">The type of the model.</param>
         public ConventionContext(CommandLineApplication application, Type? modelType)
@@ -22,9 +18,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
             ModelType = modelType;
         }
 
-        /// <summary>
-        /// The application to which the convention is applied.
-        /// </summary>
+        /// <summary> The application to which the convention is applied. </summary>
         public CommandLineApplication Application { get; private set; }
 
         /// <summary>

--- a/src/CommandLineUtils/Conventions/DefaultHelpOptionConvention.cs
+++ b/src/CommandLineUtils/Conventions/DefaultHelpOptionConvention.cs
@@ -5,21 +5,14 @@ using System.Reflection;
 
 namespace McMaster.Extensions.CommandLineUtils.Conventions
 {
-    /// <summary>
-    /// Adds a help option of --help if no other help option is specified.
-    /// </summary>
+    /// <summary> Adds a help option of --help if no other help option is specified. </summary>
     public class DefaultHelpOptionConvention : IConvention
     {
-        /// <summary>
-        /// The default help template.
-        /// </summary>
+        /// <summary> The default help template. </summary>
         public const string DefaultHelpTemplate = Strings.DefaultHelpTemplate;
         private readonly string _template;
 
-        /// <summary>
-        /// Initializes an instance of <see cref="DefaultHelpOptionConvention"/>.
-        /// </summary>
-        /// <param name="template"></param>
+        /// <summary> Initializes an instance of <see cref="DefaultHelpOptionConvention"/>. </summary>
         public DefaultHelpOptionConvention(string template)
         {
             _template = template;

--- a/src/CommandLineUtils/Conventions/IConvention.cs
+++ b/src/CommandLineUtils/Conventions/IConvention.cs
@@ -3,14 +3,10 @@
 
 namespace McMaster.Extensions.CommandLineUtils.Conventions
 {
-    /// <summary>
-    /// Defines a convention for an instance of <see cref="CommandLineApplication{TModel}" />.
-    /// </summary>
+    /// <summary> Defines a convention for an instance of <see cref="CommandLineApplication{TModel}" />. </summary>
     public interface IConvention
     {
-        /// <summary>
-        /// Apply the convention.
-        /// </summary>
+        /// <summary> Apply the convention. </summary>
         /// <param name="context">The context in which the convention is applied.</param>
         void Apply(ConventionContext context);
     }

--- a/src/CommandLineUtils/Conventions/IConvention.cs
+++ b/src/CommandLineUtils/Conventions/IConvention.cs
@@ -6,7 +6,6 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
     /// <summary> Defines a convention for an instance of <see cref="CommandLineApplication{TModel}" />. </summary>
     public interface IConvention
     {
-        /// <summary> Apply the convention. </summary>
         /// <param name="context">The context in which the convention is applied.</param>
         void Apply(ConventionContext context);
     }

--- a/src/CommandLineUtils/Conventions/IConventionBuilder.cs
+++ b/src/CommandLineUtils/Conventions/IConventionBuilder.cs
@@ -3,14 +3,10 @@
 
 namespace McMaster.Extensions.CommandLineUtils.Conventions
 {
-    /// <summary>
-    /// Builds a collection of conventions.
-    /// </summary>
+    /// <summary> Builds a collection of conventions. </summary>
     public interface IConventionBuilder
     {
-        /// <summary>
-        /// Add a convention that will be applied later.
-        /// </summary>
+        /// <summary> Add a convention that will be applied later. </summary>
         /// <param name="convention">The convention</param>
         IConventionBuilder AddConvention(IConvention convention);
     }

--- a/src/CommandLineUtils/Conventions/IConventionBuilder.cs
+++ b/src/CommandLineUtils/Conventions/IConventionBuilder.cs
@@ -7,7 +7,6 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
     public interface IConventionBuilder
     {
         /// <summary> Add a convention that will be applied later. </summary>
-        /// <param name="convention">The convention</param>
         IConventionBuilder AddConvention(IConvention convention);
     }
 }

--- a/src/CommandLineUtils/Conventions/IMemberConvention.cs
+++ b/src/CommandLineUtils/Conventions/IMemberConvention.cs
@@ -9,7 +9,6 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
     public interface IMemberConvention
     {
         /// <summary> Apply the convention given a property or method. </summary>
-        /// <param name="context">The convention context.</param>
         /// <param name="member">A member of the model type to which the attribute is applied.</param>
         void Apply(ConventionContext context, MemberInfo member);
     }

--- a/src/CommandLineUtils/Conventions/IMemberConvention.cs
+++ b/src/CommandLineUtils/Conventions/IMemberConvention.cs
@@ -5,14 +5,10 @@ using System.Reflection;
 
 namespace McMaster.Extensions.CommandLineUtils.Conventions
 {
-    /// <summary>
-    /// Defines a convention that is implemented as an attribute on a model type.
-    /// </summary>
+    /// <summary> Defines a convention that is implemented as an attribute on a model type. </summary>
     public interface IMemberConvention
     {
-        /// <summary>
-        /// Apply the convention given a property or method.
-        /// </summary>
+        /// <summary> Apply the convention given a property or method. </summary>
         /// <param name="context">The convention context.</param>
         /// <param name="member">A member of the model type to which the attribute is applied.</param>
         void Apply(ConventionContext context, MemberInfo member);

--- a/src/CommandLineUtils/Conventions/OptionAttributeConventionBase.cs
+++ b/src/CommandLineUtils/Conventions/OptionAttributeConventionBase.cs
@@ -9,10 +9,7 @@ using McMaster.Extensions.CommandLineUtils.Validation;
 
 namespace McMaster.Extensions.CommandLineUtils.Conventions
 {
-    /// <summary>
-    /// Shared implementation for adding conventions based on <see cref="OptionAttributeBase"/>.
-    /// </summary>
-    /// <typeparam name="TAttribute"></typeparam>
+    /// <summary> Shared implementation for adding conventions based on <see cref="OptionAttributeBase"/>. </summary>
     public abstract class OptionAttributeConventionBase<TAttribute>
         where TAttribute : OptionAttributeBase
     {

--- a/src/CommandLineUtils/Conventions/ValidateMethodConvention.cs
+++ b/src/CommandLineUtils/Conventions/ValidateMethodConvention.cs
@@ -9,9 +9,7 @@ using McMaster.Extensions.CommandLineUtils.Conventions;
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    /// <summary>
-    /// Invokes a method named "OnValidate" on the model type after parsing.
-    /// </summary>
+    /// <summary> Invokes a method named "OnValidate" on the model type after parsing. </summary>
     public class ValidateMethodConvention : IConvention
     {
         /// <inheritdoc />

--- a/src/CommandLineUtils/Errors/MissingParameterlessConstructorException.cs
+++ b/src/CommandLineUtils/Errors/MissingParameterlessConstructorException.cs
@@ -6,19 +6,13 @@ using System.Reflection;
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    /// <summary>
-    /// The exception that is thrown when trying to instantiate a model with no parameterless constructor.
-    /// </summary>
+    /// <summary> The exception that is thrown when trying to instantiate a model with no parameterless constructor. </summary>
     public class MissingParameterlessConstructorException : TargetException
     {
-        /// <summary>
-        /// Gets the type that caused the exception.
-        /// </summary>
+        /// <summary> Gets the type that caused the exception. </summary>
         public Type Type { get; private set; }
 
-        /// <summary>
-        /// Initializes an instance of <see cref="MissingParameterlessConstructorException" />.
-        /// </summary>
+        /// <summary> Initializes an instance of <see cref="MissingParameterlessConstructorException" />. </summary>
         /// <param name="type">The type missing a parameterless constructor.</param>
         /// <param name="innerException">The original exception.</param>
         public MissingParameterlessConstructorException(Type type, Exception innerException)

--- a/src/CommandLineUtils/Errors/MissingParameterlessConstructorException.cs
+++ b/src/CommandLineUtils/Errors/MissingParameterlessConstructorException.cs
@@ -14,7 +14,6 @@ namespace McMaster.Extensions.CommandLineUtils
 
         /// <summary> Initializes an instance of <see cref="MissingParameterlessConstructorException" />. </summary>
         /// <param name="type">The type missing a parameterless constructor.</param>
-        /// <param name="innerException">The original exception.</param>
         public MissingParameterlessConstructorException(Type type, Exception innerException)
             : base($"Class {type.FullName} does not have a parameterless constructor", innerException)
         {

--- a/src/CommandLineUtils/Errors/SubcommandCycleException.cs
+++ b/src/CommandLineUtils/Errors/SubcommandCycleException.cs
@@ -5,14 +5,10 @@ using System;
 
 namespace McMaster.Extensions.CommandLineUtils.Errors
 {
-    /// <summary>
-    /// The exception that is thrown when a subcommand cycle is detected
-    /// </summary>
+    /// <summary> The exception that is thrown when a subcommand cycle is detected </summary>
     public class SubcommandCycleException : Exception
     {
-        /// <summary>
-        /// Initializes an instance of <see cref="SubcommandCycleException"/>.
-        /// </summary>
+        /// <summary> Initializes an instance of <see cref="SubcommandCycleException"/>. </summary>
         /// <param name="modelType">The type of the cycled command model</param>
         public SubcommandCycleException(Type modelType)
             : base($"Subcommand cycle detected: trying to add command of model {modelType} as its own direct or indirect subcommand")
@@ -20,9 +16,7 @@ namespace McMaster.Extensions.CommandLineUtils.Errors
             ModelType = modelType ?? throw new ArgumentNullException(nameof(modelType));
         }
 
-        /// <summary>
-        /// The type of the cycled command model
-        /// </summary>
+        /// <summary> The type of the cycled command model </summary>
         public Type ModelType { get; }
     }
 }

--- a/src/CommandLineUtils/Errors/UnrecognizedCommandParsingException.cs
+++ b/src/CommandLineUtils/Errors/UnrecognizedCommandParsingException.cs
@@ -12,12 +12,8 @@ namespace McMaster.Extensions.CommandLineUtils
     /// </summary>
     public class UnrecognizedCommandParsingException : CommandParsingException
     {
-        /// <summary>
-        /// Initializes an instance of <see cref="UnrecognizedCommandParsingException"/>.
-        /// </summary>
-        /// <param name="command"></param>
+        /// <summary> Initializes an instance of <see cref="UnrecognizedCommandParsingException"/>. </summary>
         /// <param name="nearestMatches">The options or commands that </param>
-        /// <param name="message"></param>
         public UnrecognizedCommandParsingException(CommandLineApplication command,
             IEnumerable<string> nearestMatches,
             string message)
@@ -30,9 +26,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// A collection of strings representing suggestions about similar and valid commands or options for the invalid
         /// argument that caused this <see cref="UnrecognizedCommandParsingException"/>.
         /// </summary>
-        /// <remarks>
-        /// This property always be empty <see cref="CommandLineApplication.MakeSuggestionsInErrorMessage"/> is false.
-        /// </remarks>
+        /// <remarks> This property always be empty <see cref="CommandLineApplication.MakeSuggestionsInErrorMessage"/> is false. </remarks>
         /// <value>This property get/set the suggestions for an invalid argument.</value>
         public IEnumerable<string> NearestMatches { get; }
     }

--- a/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
+++ b/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
@@ -43,7 +43,6 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
         }
 
         /// <summary> Generate the first few lines of help output text </summary>
-        /// <param name="output">Help text output</param>
         protected virtual void GenerateHeader(
             CommandLineApplication application,
             TextWriter output)
@@ -63,7 +62,6 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
         }
 
         /// <summary> Generate detailed help information </summary>
-        /// <param name="output">Help text output</param>
         protected virtual void GenerateBody(
             CommandLineApplication application,
             TextWriter output)
@@ -87,7 +85,6 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
         }
 
         /// <summary> Generate the line that shows usage </summary>
-        /// <param name="output">Help text output</param>
         /// <param name="visibleArguments">Arguments not hidden from help text</param>
         /// <param name="visibleOptions">Options not hidden from help text</param>
         /// <param name="visibleCommands">Commands not hidden from help text</param>
@@ -137,7 +134,6 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
         }
 
         /// <summary> Generate the lines that show information about arguments </summary>
-        /// <param name="output">Help text output</param>
         /// <param name="visibleArguments">Arguments not hidden from help text</param>
         /// <param name="firstColumnWidth">The width of the first column of commands, arguments, and options</param>
         protected virtual void GenerateArguments(
@@ -169,7 +165,6 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
         }
 
         /// <summary> Generate the lines that show information about options </summary>
-        /// <param name="output">Help text output</param>
         /// <param name="visibleOptions">Options not hidden from help text</param>
         /// <param name="firstColumnWidth">The width of the first column of commands, arguments, and options</param>
         protected virtual void GenerateOptions(
@@ -202,7 +197,6 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
 
 
         /// <summary> Generate the lines that show information about subcommands </summary>
-        /// <param name="output">Help text output</param>
         /// <param name="visibleCommands">Commands not hidden from help text</param>
         /// <param name="firstColumnWidth">The width of the first column of commands, arguments, and options</param>
         protected virtual void GenerateCommands(
@@ -241,7 +235,6 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
         }
 
         /// <summary> Generate the last lines of help text output </summary>
-        /// <param name="output">Help text output</param>
         protected virtual void GenerateFooter(
             CommandLineApplication application,
             TextWriter output)

--- a/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
+++ b/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
@@ -43,7 +43,6 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
         }
 
         /// <summary> Generate the first few lines of help output text </summary>
-        /// <param name="application">The app</param>
         /// <param name="output">Help text output</param>
         protected virtual void GenerateHeader(
             CommandLineApplication application,
@@ -64,7 +63,6 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
         }
 
         /// <summary> Generate detailed help information </summary>
-        /// <param name="application">The application</param>
         /// <param name="output">Help text output</param>
         protected virtual void GenerateBody(
             CommandLineApplication application,
@@ -89,7 +87,6 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
         }
 
         /// <summary> Generate the line that shows usage </summary>
-        /// <param name="application">The app</param>
         /// <param name="output">Help text output</param>
         /// <param name="visibleArguments">Arguments not hidden from help text</param>
         /// <param name="visibleOptions">Options not hidden from help text</param>
@@ -140,7 +137,6 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
         }
 
         /// <summary> Generate the lines that show information about arguments </summary>
-        /// <param name="application">The app</param>
         /// <param name="output">Help text output</param>
         /// <param name="visibleArguments">Arguments not hidden from help text</param>
         /// <param name="firstColumnWidth">The width of the first column of commands, arguments, and options</param>
@@ -173,7 +169,6 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
         }
 
         /// <summary> Generate the lines that show information about options </summary>
-        /// <param name="application">The app</param>
         /// <param name="output">Help text output</param>
         /// <param name="visibleOptions">Options not hidden from help text</param>
         /// <param name="firstColumnWidth">The width of the first column of commands, arguments, and options</param>
@@ -207,7 +202,6 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
 
 
         /// <summary> Generate the lines that show information about subcommands </summary>
-        /// <param name="application">The app</param>
         /// <param name="output">Help text output</param>
         /// <param name="visibleCommands">Commands not hidden from help text</param>
         /// <param name="firstColumnWidth">The width of the first column of commands, arguments, and options</param>
@@ -247,7 +241,6 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
         }
 
         /// <summary> Generate the last lines of help text output </summary>
-        /// <param name="application">The app</param>
         /// <param name="output">Help text output</param>
         protected virtual void GenerateFooter(
             CommandLineApplication application,

--- a/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
+++ b/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
@@ -10,14 +10,10 @@ using System.Text;
 
 namespace McMaster.Extensions.CommandLineUtils.HelpText
 {
-    /// <summary>
-    /// A default implementation of help text generation.
-    /// </summary>
+    /// <summary> A default implementation of help text generation. </summary>
     public class DefaultHelpTextGenerator : IHelpTextGenerator
     {
-        /// <summary>
-        /// The number of spaces between columns.
-        /// </summary>
+        /// <summary> The number of spaces between columns. </summary>
         protected const int ColumnSeparatorLength = 2;
 
         /// <summary>
@@ -26,24 +22,16 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
         /// </summary>
         protected HangingIndentWriter? IndentWriter { get; set; }
 
-        /// <summary>
-        /// A singleton instance of <see cref="DefaultHelpTextGenerator" />.
-        /// </summary>
+        /// <summary> A singleton instance of <see cref="DefaultHelpTextGenerator" />. </summary>
         public static DefaultHelpTextGenerator Singleton { get; } = new DefaultHelpTextGenerator();
 
-        /// <summary>
-        /// Initializes a new instance of <see cref="DefaultHelpTextGenerator"/>.
-        /// </summary>
+        /// <summary> Initializes a new instance of <see cref="DefaultHelpTextGenerator"/>. </summary>
         public DefaultHelpTextGenerator() { }
 
-        /// <summary>
-        /// Determines if commands are ordered by name in generated help text
-        /// </summary>
+        /// <summary> Determines if commands are ordered by name in generated help text </summary>
         public bool SortCommandsByName { get; set; } = true;
 
-        /// <summary>
-        /// Override the console width disregarding any value from the executing environment.
-        /// </summary>
+        /// <summary> Override the console width disregarding any value from the executing environment. </summary>
         public int? MaxLineLength { get; set; } = null;
 
         /// <inheritdoc />
@@ -54,9 +42,7 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
             GenerateFooter(application, output);
         }
 
-        /// <summary>
-        /// Generate the first few lines of help output text
-        /// </summary>
+        /// <summary> Generate the first few lines of help output text </summary>
         /// <param name="application">The app</param>
         /// <param name="output">Help text output</param>
         protected virtual void GenerateHeader(
@@ -77,9 +63,7 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
             }
         }
 
-        /// <summary>
-        /// Generate detailed help information
-        /// </summary>
+        /// <summary> Generate detailed help information </summary>
         /// <param name="application">The application</param>
         /// <param name="output">Help text output</param>
         protected virtual void GenerateBody(
@@ -104,9 +88,7 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
             GenerateCommands(application, output, commands, firstColumnWidth);
         }
 
-        /// <summary>
-        /// Generate the line that shows usage
-        /// </summary>
+        /// <summary> Generate the line that shows usage </summary>
         /// <param name="application">The app</param>
         /// <param name="output">Help text output</param>
         /// <param name="visibleArguments">Arguments not hidden from help text</param>
@@ -157,9 +139,7 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
             output.WriteLine();
         }
 
-        /// <summary>
-        /// Generate the lines that show information about arguments
-        /// </summary>
+        /// <summary> Generate the lines that show information about arguments </summary>
         /// <param name="application">The app</param>
         /// <param name="output">Help text output</param>
         /// <param name="visibleArguments">Arguments not hidden from help text</param>
@@ -192,9 +172,7 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
             }
         }
 
-        /// <summary>
-        /// Generate the lines that show information about options
-        /// </summary>
+        /// <summary> Generate the lines that show information about options </summary>
         /// <param name="application">The app</param>
         /// <param name="output">Help text output</param>
         /// <param name="visibleOptions">Options not hidden from help text</param>
@@ -228,9 +206,7 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
         }
 
 
-        /// <summary>
-        /// Generate the lines that show information about subcommands
-        /// </summary>
+        /// <summary> Generate the lines that show information about subcommands </summary>
         /// <param name="application">The app</param>
         /// <param name="output">Help text output</param>
         /// <param name="visibleCommands">Commands not hidden from help text</param>
@@ -270,9 +246,7 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
             }
         }
 
-        /// <summary>
-        /// Generate the last lines of help text output
-        /// </summary>
+        /// <summary> Generate the last lines of help text output </summary>
         /// <param name="application">The app</param>
         /// <param name="output">Help text output</param>
         protected virtual void GenerateFooter(
@@ -283,9 +257,7 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
             output.WriteLine();
         }
 
-        /// <summary>
-        /// Generates the template string in the format "-{Symbol}|-{Short}|--{Long} &lt;{Value}&gt;" for display in help text.
-        /// </summary>
+        /// <summary> Generates the template string in the format "-{Symbol}|-{Short}|--{Long} &lt;{Value}&gt;" for display in help text. </summary>
         /// <returns>The template string</returns>
         protected virtual string Format(CommandOption option)
         {
@@ -330,9 +302,7 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
             return sb.ToString();
         }
 
-        /// <summary>
-        /// Get the Console width.
-        /// </summary>
+        /// <summary> Get the Console width. </summary>
         /// <returns>BufferWidth or the default.</returns>
         private int? TryGetConsoleWidth()
         {

--- a/src/CommandLineUtils/HelpText/HangingIndentWriter.cs
+++ b/src/CommandLineUtils/HelpText/HangingIndentWriter.cs
@@ -13,9 +13,7 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
     /// </summary>
     public class HangingIndentWriter
     {
-        /// <summary>
-        /// The default console width used for wrapping if the width cannot be gotten from the Console.
-        /// </summary>
+        /// <summary> The default console width used for wrapping if the width cannot be gotten from the Console. </summary>
         public const int DefaultConsoleWidth = 80;
 
         private readonly bool _indentFirstLine;
@@ -23,9 +21,7 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
         private readonly int _maxLineLength;
         private readonly string _paddedLine;
 
-        /// <summary>
-        /// A description formatter for dynamically wrapping the description to print in a CLI usage.
-        /// </summary>
+        /// <summary> A description formatter for dynamically wrapping the description to print in a CLI usage. </summary>
         /// <param name="indentSize">The indent size in spaces to use.</param>
         /// <param name="maxLineLength">The max length an indented line can be.
         /// Defaults to <see cref="DefaultConsoleWidth"/>.
@@ -39,9 +35,7 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
             _paddedLine = Environment.NewLine + new string(' ', _indentSize);
         }
 
-        /// <summary>
-        /// Dynamically wrap text between.
-        /// </summary>
+        /// <summary> Dynamically wrap text between. </summary>
         /// <param name="input">The original description text.</param>
         /// <returns>Dynamically wrapped description with explicit newlines preserved.</returns>
         public string Write(string? input)
@@ -58,9 +52,7 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
             return (_indentFirstLine ? _paddedLine : string.Empty) + string.Join(_paddedLine, lines);
         }
 
-        /// <summary>
-        /// Wrap a single line based on console width.
-        /// </summary>
+        /// <summary> Wrap a single line based on console width. </summary>
         /// <param name="original">The original description text.</param>
         /// <returns>Description text wrapped with padded newlines.</returns>
         private string WrapSingle(string original)

--- a/src/CommandLineUtils/HelpText/IHelpTextGenerator.cs
+++ b/src/CommandLineUtils/HelpText/IHelpTextGenerator.cs
@@ -5,16 +5,10 @@ using System.IO;
 
 namespace McMaster.Extensions.CommandLineUtils.HelpText
 {
-    /// <summary>
-    /// Generates help text for a command line application.
-    /// </summary>
+    /// <summary> Generates help text for a command line application. </summary>
     public interface IHelpTextGenerator
     {
-        /// <summary>
-        /// Generate help text for the application.
-        /// </summary>
-        /// <param name="application"></param>
-        /// <param name="output"></param>
+        /// <summary> Generate help text for the application. </summary>
         void Generate(CommandLineApplication application, TextWriter output);
     }
 }

--- a/src/CommandLineUtils/IO/ConsoleExtensions.cs
+++ b/src/CommandLineUtils/IO/ConsoleExtensions.cs
@@ -3,19 +3,14 @@
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    /// <summary>
-    /// Helper methods for <see cref="IConsole"/>.
-    /// </summary>
+    /// <summary> Helper methods for <see cref="IConsole"/>. </summary>
     public static class ConsoleExtensions
     {
-
         //
         // WriteLine extensions
         //
 
-        /// <summary>
-        /// Writes an empty line.
-        /// </summary>
+        /// <summary> Writes an empty line. </summary>
         /// <param name="console">The console.</param>
         /// <returns>the console.</returns>
         public static IConsole WriteLine(this IConsole console)
@@ -24,9 +19,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return console;
         }
 
-        /// <summary>
-        /// Writes a string followed by a line terminator.
-        /// </summary>
+        /// <summary> Writes a string followed by a line terminator. </summary>
         /// <param name="console">The console.</param>
         /// <param name="value">The value.</param>
         /// <returns>the console.</returns>
@@ -36,9 +29,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return console;
         }
 
-        /// <summary>
-        /// Formats and writes a value as a new line.
-        /// </summary>
+        /// <summary> Formats and writes a value as a new line. </summary>
         /// <param name="console">The console.</param>
         /// <param name="format">The format string.</param>
         /// <param name="arg">Argument used to format.</param>
@@ -49,9 +40,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return console;
         }
 
-        /// <summary>
-        /// Formats and writes a value as a new line.
-        /// </summary>
+        /// <summary> Formats and writes a value as a new line. </summary>
         /// <param name="console">The console.</param>
         /// <param name="format">The format string.</param>
         /// <param name="arg0">The first argument to replace in the format string.</param>
@@ -62,9 +51,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return console;
         }
 
-        /// <summary>
-        /// Formats and writes a value as a new line.
-        /// </summary>
+        /// <summary> Formats and writes a value as a new line. </summary>
         /// <param name="console">The console.</param>
         /// <param name="format">The format string.</param>
         /// <param name="arg0">The first argument to replace in the format string.</param>
@@ -76,9 +63,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return console;
         }
 
-        /// <summary>
-        /// Formats and writes a value as a new line.
-        /// </summary>
+        /// <summary> Formats and writes a value as a new line. </summary>
         /// <param name="console">The console.</param>
         /// <param name="format">The format string.</param>
         /// <param name="arg0">The first argument to replace in the format string.</param>
@@ -91,9 +76,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return console;
         }
 
-        /// <summary>
-        /// Formats and writes a value as a new line.
-        /// </summary>
+        /// <summary> Formats and writes a value as a new line. </summary>
         /// <param name="console">The console.</param>
         /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
@@ -103,9 +86,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return console;
         }
 
-        /// <summary>
-        /// Formats and writes a value as a new line.
-        /// </summary>
+        /// <summary> Formats and writes a value as a new line. </summary>
         /// <param name="console">The console.</param>
         /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
@@ -115,9 +96,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return console;
         }
 
-        /// <summary>
-        /// Formats and writes a value as a new line.
-        /// </summary>
+        /// <summary> Formats and writes a value as a new line. </summary>
         /// <param name="console">The console.</param>
         /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
@@ -127,9 +106,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return console;
         }
 
-        /// <summary>
-        /// Formats and writes an array of characters as a new line.
-        /// </summary>
+        /// <summary> Formats and writes an array of characters as a new line. </summary>
         /// <param name="console">The console.</param>
         /// <param name="buffer">The buffer.</param>
         /// <returns>The console.</returns>
@@ -139,9 +116,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return console;
         }
 
-        /// <summary>
-        /// Formats and writes a portion of a character buffer as a new line.
-        /// </summary>
+        /// <summary> Formats and writes a portion of a character buffer as a new line. </summary>
         /// <param name="console">The console.</param>
         /// <param name="buffer">The buffer.</param>
         /// <param name="index">The start index.</param>
@@ -153,9 +128,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return console;
         }
 
-        /// <summary>
-        /// Formats and writes a value as a new line.
-        /// </summary>
+        /// <summary> Formats and writes a value as a new line. </summary>
         /// <param name="console">The console.</param>
         /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
@@ -165,9 +138,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return console;
         }
 
-        /// <summary>
-        /// Formats and writes a value as a new line.
-        /// </summary>
+        /// <summary> Formats and writes a value as a new line. </summary>
         /// <param name="console">The console.</param>
         /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
@@ -177,9 +148,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return console;
         }
 
-        /// <summary>
-        /// Formats and writes a value as a new line.
-        /// </summary>
+        /// <summary> Formats and writes a value as a new line. </summary>
         /// <param name="console">The console.</param>
         /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
@@ -189,9 +158,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return console;
         }
 
-        /// <summary>
-        /// Formats and writes a value as a new line.
-        /// </summary>
+        /// <summary> Formats and writes a value as a new line. </summary>
         /// <param name="console">The console.</param>
         /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
@@ -201,9 +168,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return console;
         }
 
-        /// <summary>
-        /// Formats and writes a value as a new line.
-        /// </summary>
+        /// <summary> Formats and writes a value as a new line. </summary>
         /// <param name="console">The console.</param>
         /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
@@ -213,9 +178,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return console;
         }
 
-        /// <summary>
-        /// Formats and writes a value as a new line.
-        /// </summary>
+        /// <summary> Formats and writes a value as a new line. </summary>
         /// <param name="console">The console.</param>
         /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
@@ -225,9 +188,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return console;
         }
 
-        /// <summary>
-        /// Formats and writes a value as a new line.
-        /// </summary>
+        /// <summary> Formats and writes a value as a new line. </summary>
         /// <param name="console">The console.</param>
         /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
@@ -241,9 +202,7 @@ namespace McMaster.Extensions.CommandLineUtils
         // Write methods
         //
 
-        /// <summary>
-        /// Writes a string console output.
-        /// </summary>
+        /// <summary> Writes a string console output. </summary>
         /// <param name="console">The console.</param>
         /// <param name="value">The value.</param>
         /// <returns>the console.</returns>
@@ -253,9 +212,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return console;
         }
 
-        /// <summary>
-        /// Formats and writes a value.
-        /// </summary>
+        /// <summary> Formats and writes a value. </summary>
         /// <param name="console">The console.</param>
         /// <param name="format">The format string.</param>
         /// <param name="arg">Argument used to format.</param>
@@ -266,9 +223,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return console;
         }
 
-        /// <summary>
-        /// Formats and writes a value.
-        /// </summary>
+        /// <summary> Formats and writes a value. </summary>
         /// <param name="console">The console.</param>
         /// <param name="format">The format string.</param>
         /// <param name="arg0">The first argument to replace in the format string.</param>
@@ -279,9 +234,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return console;
         }
 
-        /// <summary>
-        /// Formats and writes a value.
-        /// </summary>
+        /// <summary> Formats and writes a value. </summary>
         /// <param name="console">The console.</param>
         /// <param name="format">The format string.</param>
         /// <param name="arg0">The first argument to replace in the format string.</param>
@@ -293,9 +246,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return console;
         }
 
-        /// <summary>
-        /// Formats and writes a value.
-        /// </summary>
+        /// <summary> Formats and writes a value. </summary>
         /// <param name="console">The console.</param>
         /// <param name="format">The format string.</param>
         /// <param name="arg0">The first argument to replace in the format string.</param>
@@ -308,9 +259,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return console;
         }
 
-        /// <summary>
-        /// Formats and writes a value.
-        /// </summary>
+        /// <summary> Formats and writes a value. </summary>
         /// <param name="console">The console.</param>
         /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
@@ -320,9 +269,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return console;
         }
 
-        /// <summary>
-        /// Formats and writes a value.
-        /// </summary>
+        /// <summary> Formats and writes a value. </summary>
         /// <param name="console">The console.</param>
         /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
@@ -332,9 +279,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return console;
         }
 
-        /// <summary>
-        /// Formats and writes a value.
-        /// </summary>
+        /// <summary> Formats and writes a value. </summary>
         /// <param name="console">The console.</param>
         /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
@@ -344,9 +289,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return console;
         }
 
-        /// <summary>
-        /// Formats and writes a value.
-        /// </summary>
+        /// <summary> Formats and writes a value. </summary>
         /// <param name="console">The console.</param>
         /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
@@ -356,9 +299,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return console;
         }
 
-        /// <summary>
-        /// Formats and writes a value.
-        /// </summary>
+        /// <summary> Formats and writes a value. </summary>
         /// <param name="console">The console.</param>
         /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
@@ -368,9 +309,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return console;
         }
 
-        /// <summary>
-        /// Formats and writes a value.
-        /// </summary>
+        /// <summary> Formats and writes a value. </summary>
         /// <param name="console">The console.</param>
         /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
@@ -380,9 +319,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return console;
         }
 
-        /// <summary>
-        /// Formats and writes an array of characters.
-        /// </summary>
+        /// <summary> Formats and writes an array of characters. </summary>
         /// <param name="console">The console.</param>
         /// <param name="buffer">The buffer.</param>
         /// <returns>The console.</returns>
@@ -392,9 +329,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return console;
         }
 
-        /// <summary>
-        /// Formats and writes a portion of a character buffer.
-        /// </summary>
+        /// <summary> Formats and writes a portion of a character buffer. </summary>
         /// <param name="console">The console.</param>
         /// <param name="buffer">The buffer.</param>
         /// <param name="index">The start index.</param>
@@ -406,9 +341,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return console;
         }
 
-        /// <summary>
-        /// Formats and writes a value.
-        /// </summary>
+        /// <summary> Formats and writes a value. </summary>
         /// <param name="console">The console.</param>
         /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
@@ -418,9 +351,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return console;
         }
 
-        /// <summary>
-        /// Formats and writes a value.
-        /// </summary>
+        /// <summary> Formats and writes a value. </summary>
         /// <param name="console">The console.</param>
         /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
@@ -430,9 +361,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return console;
         }
 
-        /// <summary>
-        /// Formats and writes a value.
-        /// </summary>
+        /// <summary> Formats and writes a value. </summary>
         /// <param name="console">The console.</param>
         /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
@@ -442,9 +371,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return console;
         }
 
-        /// <summary>
-        /// Formats and writes a value.
-        /// </summary>
+        /// <summary> Formats and writes a value. </summary>
         /// <param name="console">The console.</param>
         /// <param name="value">The value.</param>
         /// <returns>The console.</returns>

--- a/src/CommandLineUtils/IO/ConsoleExtensions.cs
+++ b/src/CommandLineUtils/IO/ConsoleExtensions.cs
@@ -11,7 +11,6 @@ namespace McMaster.Extensions.CommandLineUtils
         //
 
         /// <summary> Writes an empty line. </summary>
-        /// <param name="console">The console.</param>
         /// <returns>the console.</returns>
         public static IConsole WriteLine(this IConsole console)
         {
@@ -20,8 +19,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Writes a string followed by a line terminator. </summary>
-        /// <param name="console">The console.</param>
-        /// <param name="value">The value.</param>
         /// <returns>the console.</returns>
         public static IConsole WriteLine(this IConsole console, string value)
         {
@@ -30,7 +27,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a value as a new line. </summary>
-        /// <param name="console">The console.</param>
         /// <param name="format">The format string.</param>
         /// <param name="arg">Argument used to format.</param>
         /// <returns>The console.</returns>
@@ -41,7 +37,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a value as a new line. </summary>
-        /// <param name="console">The console.</param>
         /// <param name="format">The format string.</param>
         /// <param name="arg0">The first argument to replace in the format string.</param>
         /// <returns>The console.</returns>
@@ -52,7 +47,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a value as a new line. </summary>
-        /// <param name="console">The console.</param>
         /// <param name="format">The format string.</param>
         /// <param name="arg0">The first argument to replace in the format string.</param>
         /// <param name="arg1">The second argument to replace in the format string.</param>
@@ -64,7 +58,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a value as a new line. </summary>
-        /// <param name="console">The console.</param>
         /// <param name="format">The format string.</param>
         /// <param name="arg0">The first argument to replace in the format string.</param>
         /// <param name="arg1">The second argument to replace in the format string.</param>
@@ -77,8 +70,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a value as a new line. </summary>
-        /// <param name="console">The console.</param>
-        /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
         public static IConsole WriteLine(this IConsole console, ulong value)
         {
@@ -87,8 +78,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a value as a new line. </summary>
-        /// <param name="console">The console.</param>
-        /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
         public static IConsole WriteLine(this IConsole console, bool value)
         {
@@ -97,8 +86,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a value as a new line. </summary>
-        /// <param name="console">The console.</param>
-        /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
         public static IConsole WriteLine(this IConsole console, char value)
         {
@@ -107,8 +94,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes an array of characters as a new line. </summary>
-        /// <param name="console">The console.</param>
-        /// <param name="buffer">The buffer.</param>
         /// <returns>The console.</returns>
         public static IConsole WriteLine(this IConsole console, char[] buffer)
         {
@@ -117,8 +102,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a portion of a character buffer as a new line. </summary>
-        /// <param name="console">The console.</param>
-        /// <param name="buffer">The buffer.</param>
         /// <param name="index">The start index.</param>
         /// <param name="count">The number of characters to write.</param>
         /// <returns>The console.</returns>
@@ -129,8 +112,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a value as a new line. </summary>
-        /// <param name="console">The console.</param>
-        /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
         public static IConsole WriteLine(this IConsole console, decimal value)
         {
@@ -139,8 +120,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a value as a new line. </summary>
-        /// <param name="console">The console.</param>
-        /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
         public static IConsole WriteLine(this IConsole console, double value)
         {
@@ -149,8 +128,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a value as a new line. </summary>
-        /// <param name="console">The console.</param>
-        /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
         public static IConsole WriteLine(this IConsole console, uint value)
         {
@@ -159,8 +136,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a value as a new line. </summary>
-        /// <param name="console">The console.</param>
-        /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
         public static IConsole WriteLine(this IConsole console, int value)
         {
@@ -169,8 +144,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a value as a new line. </summary>
-        /// <param name="console">The console.</param>
-        /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
         public static IConsole WriteLine(this IConsole console, object value)
         {
@@ -179,8 +152,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a value as a new line. </summary>
-        /// <param name="console">The console.</param>
-        /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
         public static IConsole WriteLine(this IConsole console, float value)
         {
@@ -189,8 +160,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a value as a new line. </summary>
-        /// <param name="console">The console.</param>
-        /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
         public static IConsole WriteLine(this IConsole console, long value)
         {
@@ -203,8 +172,6 @@ namespace McMaster.Extensions.CommandLineUtils
         //
 
         /// <summary> Writes a string console output. </summary>
-        /// <param name="console">The console.</param>
-        /// <param name="value">The value.</param>
         /// <returns>the console.</returns>
         public static IConsole Write(this IConsole console, string value)
         {
@@ -213,7 +180,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a value. </summary>
-        /// <param name="console">The console.</param>
         /// <param name="format">The format string.</param>
         /// <param name="arg">Argument used to format.</param>
         /// <returns>The console.</returns>
@@ -224,7 +190,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a value. </summary>
-        /// <param name="console">The console.</param>
         /// <param name="format">The format string.</param>
         /// <param name="arg0">The first argument to replace in the format string.</param>
         /// <returns>The console.</returns>
@@ -235,7 +200,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a value. </summary>
-        /// <param name="console">The console.</param>
         /// <param name="format">The format string.</param>
         /// <param name="arg0">The first argument to replace in the format string.</param>
         /// <param name="arg1">The second argument to replace in the format string.</param>
@@ -247,7 +211,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a value. </summary>
-        /// <param name="console">The console.</param>
         /// <param name="format">The format string.</param>
         /// <param name="arg0">The first argument to replace in the format string.</param>
         /// <param name="arg1">The second argument to replace in the format string.</param>
@@ -260,8 +223,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a value. </summary>
-        /// <param name="console">The console.</param>
-        /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
         public static IConsole Write(this IConsole console, uint value)
         {
@@ -270,8 +231,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a value. </summary>
-        /// <param name="console">The console.</param>
-        /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
         public static IConsole Write(this IConsole console, decimal value)
         {
@@ -280,8 +239,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a value. </summary>
-        /// <param name="console">The console.</param>
-        /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
         public static IConsole Write(this IConsole console, int value)
         {
@@ -290,8 +247,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a value. </summary>
-        /// <param name="console">The console.</param>
-        /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
         public static IConsole Write(this IConsole console, ulong value)
         {
@@ -300,8 +255,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a value. </summary>
-        /// <param name="console">The console.</param>
-        /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
         public static IConsole Write(this IConsole console, bool value)
         {
@@ -310,8 +263,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a value. </summary>
-        /// <param name="console">The console.</param>
-        /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
         public static IConsole Write(this IConsole console, char value)
         {
@@ -320,8 +271,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes an array of characters. </summary>
-        /// <param name="console">The console.</param>
-        /// <param name="buffer">The buffer.</param>
         /// <returns>The console.</returns>
         public static IConsole Write(this IConsole console, char[] buffer)
         {
@@ -330,8 +279,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a portion of a character buffer. </summary>
-        /// <param name="console">The console.</param>
-        /// <param name="buffer">The buffer.</param>
         /// <param name="index">The start index.</param>
         /// <param name="count">The number of characters to write.</param>
         /// <returns>The console.</returns>
@@ -342,8 +289,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a value. </summary>
-        /// <param name="console">The console.</param>
-        /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
         public static IConsole Write(this IConsole console, double value)
         {
@@ -352,8 +297,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a value. </summary>
-        /// <param name="console">The console.</param>
-        /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
         public static IConsole Write(this IConsole console, long value)
         {
@@ -362,8 +305,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a value. </summary>
-        /// <param name="console">The console.</param>
-        /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
         public static IConsole Write(this IConsole console, object value)
         {
@@ -372,8 +313,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a value. </summary>
-        /// <param name="console">The console.</param>
-        /// <param name="value">The value.</param>
         /// <returns>The console.</returns>
         public static IConsole Write(this IConsole console, float value)
         {

--- a/src/CommandLineUtils/IO/ConsoleExtensions.cs
+++ b/src/CommandLineUtils/IO/ConsoleExtensions.cs
@@ -27,7 +27,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a value as a new line. </summary>
-        /// <param name="format">The format string.</param>
         /// <param name="arg">Argument used to format.</param>
         /// <returns>The console.</returns>
         public static IConsole WriteLine(this IConsole console, string format, params object[] arg)
@@ -37,7 +36,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a value as a new line. </summary>
-        /// <param name="format">The format string.</param>
         /// <param name="arg0">The first argument to replace in the format string.</param>
         /// <returns>The console.</returns>
         public static IConsole WriteLine(this IConsole console, string format, object arg0)
@@ -47,7 +45,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a value as a new line. </summary>
-        /// <param name="format">The format string.</param>
         /// <param name="arg0">The first argument to replace in the format string.</param>
         /// <param name="arg1">The second argument to replace in the format string.</param>
         /// <returns>The console.</returns>
@@ -58,7 +55,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a value as a new line. </summary>
-        /// <param name="format">The format string.</param>
         /// <param name="arg0">The first argument to replace in the format string.</param>
         /// <param name="arg1">The second argument to replace in the format string.</param>
         /// <param name="arg2">The third argument to replace in the format string.</param>
@@ -102,7 +98,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a portion of a character buffer as a new line. </summary>
-        /// <param name="index">The start index.</param>
         /// <param name="count">The number of characters to write.</param>
         /// <returns>The console.</returns>
         public static IConsole WriteLine(this IConsole console, char[] buffer, int index, int count)
@@ -180,7 +175,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a value. </summary>
-        /// <param name="format">The format string.</param>
         /// <param name="arg">Argument used to format.</param>
         /// <returns>The console.</returns>
         public static IConsole Write(this IConsole console, string format, params object[] arg)
@@ -190,7 +184,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a value. </summary>
-        /// <param name="format">The format string.</param>
         /// <param name="arg0">The first argument to replace in the format string.</param>
         /// <returns>The console.</returns>
         public static IConsole Write(this IConsole console, string format, object arg0)
@@ -200,7 +193,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a value. </summary>
-        /// <param name="format">The format string.</param>
         /// <param name="arg0">The first argument to replace in the format string.</param>
         /// <param name="arg1">The second argument to replace in the format string.</param>
         /// <returns>The console.</returns>
@@ -211,7 +203,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a value. </summary>
-        /// <param name="format">The format string.</param>
         /// <param name="arg0">The first argument to replace in the format string.</param>
         /// <param name="arg1">The second argument to replace in the format string.</param>
         /// <param name="arg2">The third argument to replace in the format string.</param>
@@ -279,7 +270,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Formats and writes a portion of a character buffer. </summary>
-        /// <param name="index">The start index.</param>
         /// <param name="count">The number of characters to write.</param>
         /// <returns>The console.</returns>
         public static IConsole Write(this IConsole console, char[] buffer, int index, int count)

--- a/src/CommandLineUtils/IO/ConsoleReporter.cs
+++ b/src/CommandLineUtils/IO/ConsoleReporter.cs
@@ -7,25 +7,17 @@ using System.IO;
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    /// <summary>
-    /// A thread-safe reporter that forwards to console output.
-    /// </summary>
+    /// <summary> A thread-safe reporter that forwards to console output. </summary>
     public class ConsoleReporter : IReporter
     {
         private readonly object _writeLock = new object();
 
-        /// <summary>
-        /// Initializes an instance of <see cref="ConsoleReporter"/>.
-        /// </summary>
-        /// <param name="console"></param>
+        /// <summary> Initializes an instance of <see cref="ConsoleReporter"/>. </summary>
         public ConsoleReporter(IConsole console)
             : this(console, verbose: false, quiet: false)
         { }
 
-        /// <summary>
-        /// Initializes an instance of <see cref="ConsoleReporter"/>.
-        /// </summary>
-        /// <param name="console"></param>
+        /// <summary> Initializes an instance of <see cref="ConsoleReporter"/>. </summary>
         /// <param name="verbose">When false, Verbose does not display output.</param>
         /// <param name="quiet">When true, only Warn and Error display output</param>
         public ConsoleReporter(IConsole console, bool verbose, bool quiet)
@@ -35,28 +27,16 @@ namespace McMaster.Extensions.CommandLineUtils
             IsQuiet = quiet;
         }
 
-        /// <summary>
-        /// The console to write to.
-        /// </summary>
+        /// <summary> The console to write to. </summary>
         protected IConsole Console { get; }
 
-        /// <summary>
-        /// Is verbose output displayed.
-        /// </summary>
+        /// <summary> Is verbose output displayed. </summary>
         public bool IsVerbose { get; set; }
 
-        /// <summary>
-        /// Is verbose output and regular output hidden.
-        /// </summary>
+        /// <summary> Is verbose output and regular output hidden. </summary>
         public bool IsQuiet { get; set; }
 
-        /// <summary>
-        /// Write a line with color.
-        /// </summary>
-        /// <param name="writer"></param>
-        /// <param name="message"></param>
-        /// <param name="foregroundColor"></param>
-        /// <param name="backgroundColor"></param>
+        /// <summary> Write a line with color. </summary>
         protected virtual void WriteLine(TextWriter writer, string message, ConsoleColor? foregroundColor, ConsoleColor? backgroundColor = default)
         {
             lock (_writeLock)
@@ -80,24 +60,15 @@ namespace McMaster.Extensions.CommandLineUtils
             }
         }
 
-        /// <summary>
-        /// Writes a message in <see cref="ConsoleColor.Red"/> to <see cref="IConsole.Error"/>.
-        /// </summary>
-        /// <param name="message"></param>
+        /// <summary> Writes a message in <see cref="ConsoleColor.Red"/> to <see cref="IConsole.Error"/>. </summary>
         public virtual void Error(string message)
             => WriteLine(Console.Error, message, ConsoleColor.Red);
 
-        /// <summary>
-        /// Writes a message in <see cref="ConsoleColor.Yellow"/> to <see cref="IConsole.Out"/>.
-        /// </summary>
-        /// <param name="message"></param>
+        /// <summary> Writes a message in <see cref="ConsoleColor.Yellow"/> to <see cref="IConsole.Out"/>. </summary>
         public virtual void Warn(string message)
             => WriteLine(Console.Out, message, ConsoleColor.Yellow);
 
-        /// <summary>
-        /// Writes a message to <see cref="IConsole.Out"/>.
-        /// </summary>
-        /// <param name="message"></param>
+        /// <summary> Writes a message to <see cref="IConsole.Out"/>. </summary>
         public virtual void Output(string message)
         {
             if (IsQuiet)
@@ -107,10 +78,7 @@ namespace McMaster.Extensions.CommandLineUtils
             WriteLine(Console.Out, message, foregroundColor: null);
         }
 
-        /// <summary>
-        /// Writes a message in <see cref="ConsoleColor.DarkGray"/> to <see cref="IConsole.Out"/>.
-        /// </summary>
-        /// <param name="message"></param>
+        /// <summary> Writes a message in <see cref="ConsoleColor.DarkGray"/> to <see cref="IConsole.Out"/>. </summary>
         public virtual void Verbose(string message)
         {
             if (!IsVerbose)

--- a/src/CommandLineUtils/IO/IConsole.cs
+++ b/src/CommandLineUtils/IO/IConsole.cs
@@ -7,59 +7,37 @@ using System.IO;
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    /// <summary>
-    /// An abstract console.
-    /// </summary>
+    /// <summary> An abstract console. </summary>
     public interface IConsole
     {
-        /// <summary>
-        /// Raised when Ctrl+C is pressed.
-        /// </summary>
+        /// <summary> Raised when Ctrl+C is pressed. </summary>
         event ConsoleCancelEventHandler? CancelKeyPress;
 
-        /// <summary>
-        /// stdout
-        /// </summary>
+        /// <summary> stdout </summary>
         TextWriter Out { get; }
 
-        /// <summary>
-        /// stderr
-        /// </summary>
+        /// <summary> stderr </summary>
         TextWriter Error { get; }
 
-        /// <summary>
-        /// stdin
-        /// </summary>
+        /// <summary> stdin </summary>
         TextReader In { get; }
 
-        /// <summary>
-        /// Is stdin piped from somewhere?
-        /// </summary>
+        /// <summary> Is stdin piped from somewhere? </summary>
         bool IsInputRedirected { get; }
 
-        /// <summary>
-        /// Is stdout being piped to somewhere?
-        /// </summary>
+        /// <summary> Is stdout being piped to somewhere? </summary>
         bool IsOutputRedirected { get; }
 
-        /// <summary>
-        /// Is stderr being piped to somewhere?
-        /// </summary>
+        /// <summary> Is stderr being piped to somewhere? </summary>
         bool IsErrorRedirected { get; }
 
-        /// <summary>
-        /// The foreground color of output.
-        /// </summary>
+        /// <summary> The foreground color of output. </summary>
         ConsoleColor ForegroundColor { get; set; }
 
-        /// <summary>
-        /// The background color of output.
-        /// </summary>
+        /// <summary> The background color of output. </summary>
         ConsoleColor BackgroundColor { get; set; }
 
-        /// <summary>
-        /// Resets <see cref="ForegroundColor"/> and <see cref="BackgroundColor"/>.
-        /// </summary>
+        /// <summary> Resets <see cref="ForegroundColor"/> and <see cref="BackgroundColor"/>. </summary>
         void ResetColor();
     }
 }

--- a/src/CommandLineUtils/IO/IConsole.cs
+++ b/src/CommandLineUtils/IO/IConsole.cs
@@ -13,13 +13,10 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <summary> Raised when Ctrl+C is pressed. </summary>
         event ConsoleCancelEventHandler? CancelKeyPress;
 
-        /// <summary> stdout </summary>
         TextWriter Out { get; }
 
-        /// <summary> stderr </summary>
         TextWriter Error { get; }
 
-        /// <summary> stdin </summary>
         TextReader In { get; }
 
         /// <summary> Is stdin piped from somewhere? </summary>

--- a/src/CommandLineUtils/IO/IConsole.cs
+++ b/src/CommandLineUtils/IO/IConsole.cs
@@ -7,7 +7,6 @@ using System.IO;
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    /// <summary> An abstract console. </summary>
     public interface IConsole
     {
         /// <summary> Raised when Ctrl+C is pressed. </summary>

--- a/src/CommandLineUtils/IO/IReporter.cs
+++ b/src/CommandLineUtils/IO/IReporter.cs
@@ -10,13 +10,10 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <summary> Report a verbose message. </summary>
         void Verbose(string message);
 
-        /// <summary> Report console output. </summary>
         void Output(string message);
 
-        /// <summary> Report a warning. </summary>
         void Warn(string message);
 
-        /// <summary> Report an error. </summary>
         void Error(string message);
     }
 }

--- a/src/CommandLineUtils/IO/IReporter.cs
+++ b/src/CommandLineUtils/IO/IReporter.cs
@@ -4,33 +4,19 @@
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    /// <summary>
-    /// Gathers messages with levels.
-    /// </summary>
+    /// <summary> Gathers messages with levels. </summary>
     public interface IReporter
     {
-        /// <summary>
-        /// Report a verbose message.
-        /// </summary>
-        /// <param name="message"></param>
+        /// <summary> Report a verbose message. </summary>
         void Verbose(string message);
 
-        /// <summary>
-        /// Report console output.
-        /// </summary>
-        /// <param name="message"></param>
+        /// <summary> Report console output. </summary>
         void Output(string message);
 
-        /// <summary>
-        /// Report a warning.
-        /// </summary>
-        /// <param name="message"></param>
+        /// <summary> Report a warning. </summary>
         void Warn(string message);
 
-        /// <summary>
-        /// Report an error.
-        /// </summary>
-        /// <param name="message"></param>
+        /// <summary> Report an error. </summary>
         void Error(string message);
     }
 }

--- a/src/CommandLineUtils/IO/NullConsole.cs
+++ b/src/CommandLineUtils/IO/NullConsole.cs
@@ -7,9 +7,7 @@ using System.Text;
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    /// <summary>
-    /// An implementation of <see cref="IConsole"/> that does nothing.
-    /// </summary>
+    /// <summary> An implementation of <see cref="IConsole"/> that does nothing. </summary>
     public class NullConsole : IConsole
     {
         private NullConsole()
@@ -17,39 +15,25 @@ namespace McMaster.Extensions.CommandLineUtils
             Error = Out = new NullTextWriter();
         }
 
-        /// <summary>
-        /// A shared instance of <see cref="NullConsole"/>.
-        /// </summary>
+        /// <summary> A shared instance of <see cref="NullConsole"/>. </summary>
         public static NullConsole Singleton { get; } = new NullConsole();
 
-        /// <summary>
-        /// A writer that does nothing. 
-        /// </summary>
+        /// <summary> A writer that does nothing.  </summary>
         public TextWriter Out { get; }
 
-        /// <summary>
-        /// A writer that does nothing. 
-        /// </summary>
+        /// <summary> A writer that does nothing.  </summary>
         public TextWriter Error { get; }
 
-        /// <summary>
-        /// An empty reader.
-        /// </summary>
+        /// <summary> An empty reader. </summary>
         public TextReader In { get; } = new StringReader(string.Empty);
 
-        /// <summary>
-        /// Always <c>false</c>.
-        /// </summary>
+        /// <summary> Always <c>false</c>. </summary>
         public bool IsInputRedirected => false;
 
-        /// <summary>
-        /// Always <c>false</c>.
-        /// </summary>
+        /// <summary> Always <c>false</c>. </summary>
         public bool IsOutputRedirected => false;
 
-        /// <summary>
-        /// Always <c>false</c>.
-        /// </summary>
+        /// <summary> Always <c>false</c>. </summary>
         public bool IsErrorRedirected => false;
 
         /// <inheritdoc />
@@ -58,18 +42,14 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <inheritdoc />
         public ConsoleColor BackgroundColor { get; set; }
 
-        /// <summary>
-        /// This event never fires.
-        /// </summary>
+        /// <summary> This event never fires. </summary>
         public event ConsoleCancelEventHandler? CancelKeyPress
         {
             add { }
             remove { }
         }
 
-        /// <summary>
-        /// Does nothing.
-        /// </summary>
+        /// <summary> Does nothing. </summary>
         public void ResetColor()
         {
         }

--- a/src/CommandLineUtils/IO/NullReporter.cs
+++ b/src/CommandLineUtils/IO/NullReporter.cs
@@ -4,17 +4,13 @@
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    /// <summary>
-    /// A reporter that does nothing.
-    /// </summary>
+    /// <summary> A reporter that does nothing. </summary>
     public class NullReporter : IReporter
     {
         private NullReporter()
         { }
 
-        /// <summary>
-        /// A shared instance of <see cref="NullReporter"/>.
-        /// </summary>
+        /// <summary> A shared instance of <see cref="NullReporter"/>. </summary>
         public static IReporter Singleton { get; } = new NullReporter();
 
         /// <inheritdoc />

--- a/src/CommandLineUtils/IO/Pager.cs
+++ b/src/CommandLineUtils/IO/Pager.cs
@@ -25,16 +25,12 @@ namespace McMaster.Extensions.CommandLineUtils
         private bool _disposed;
         private string _prompt = "Use arrow keys to scroll\\. Press 'q' to exit\\.";
 
-        /// <summary>
-        /// Initializes a new instance of <see cref="Pager" /> which displays output in a console pager.
-        /// </summary>
+        /// <summary> Initializes a new instance of <see cref="Pager" /> which displays output in a console pager. </summary>
         public Pager()
             : this(PhysicalConsole.Singleton)
         { }
 
-        /// <summary>
-        /// Initializes a new instance of <see cref="Pager" /> which displays output in a console pager.
-        /// </summary>
+        /// <summary> Initializes a new instance of <see cref="Pager" /> which displays output in a console pager. </summary>
         /// <param name="console">The console to write to.</param>
         public Pager(IConsole console)
         {
@@ -95,14 +91,10 @@ namespace McMaster.Extensions.CommandLineUtils
             }
         }
 
-        /// <summary>
-        /// This will wait until the user exits the pager.
-        /// </summary>
+        /// <summary> This will wait until the user exits the pager. </summary>
         public void WaitForExit() => Dispose();
 
-        /// <summary>
-        /// Force close the pager.
-        /// </summary>
+        /// <summary> Force close the pager. </summary>
         public void Kill()
         {
             if (_less.IsValueCreated && _less.Value != null)
@@ -153,9 +145,7 @@ namespace McMaster.Extensions.CommandLineUtils
             }
         }
 
-        /// <summary>
-        /// This will wait until the user exits the pager.
-        /// </summary>
+        /// <summary> This will wait until the user exits the pager. </summary>
         public void Dispose()
         {
             if (_disposed)

--- a/src/CommandLineUtils/IO/PhysicalConsole.cs
+++ b/src/CommandLineUtils/IO/PhysicalConsole.cs
@@ -7,14 +7,10 @@ using System.IO;
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    /// <summary>
-    /// An implementation of <see cref="IConsole"/> that wraps <see cref="System.Console"/>.
-    /// </summary>
+    /// <summary> An implementation of <see cref="IConsole"/> that wraps <see cref="System.Console"/>. </summary>
     public class PhysicalConsole : IConsole
     {
-        /// <summary>
-        /// A shared instance of <see cref="PhysicalConsole"/>.
-        /// </summary>
+        /// <summary> A shared instance of <see cref="PhysicalConsole"/>. </summary>
         public static IConsole Singleton { get; } = new PhysicalConsole();
 
         // TODO: in 3.0 make this type truly a singleton by adding a private ctor
@@ -23,66 +19,46 @@ namespace McMaster.Extensions.CommandLineUtils
         // {
         // }
 
-        /// <summary>
-        /// <see cref="Console.CancelKeyPress"/>.
-        /// </summary>
+        /// <summary> <see cref="Console.CancelKeyPress"/>. </summary>
         public event ConsoleCancelEventHandler? CancelKeyPress
         {
             add => Console.CancelKeyPress += value;
             remove => Console.CancelKeyPress -= value;
         }
 
-        /// <summary>
-        /// <see cref="Console.Error"/>.
-        /// </summary>
+        /// <summary> <see cref="Console.Error"/>. </summary>
         public TextWriter Error => Console.Error;
 
-        /// <summary>
-        /// <see cref="Console.In"/>.
-        /// </summary>
+        /// <summary> <see cref="Console.In"/>. </summary>
         public TextReader In => Console.In;
 
-        /// <summary>
-        /// <see cref="Console.Out"/>.
-        /// </summary>
+        /// <summary> <see cref="Console.Out"/>. </summary>
         public TextWriter Out => Console.Out;
 
-        /// <summary>
-        /// <see cref="Console.IsInputRedirected"/>.
-        /// </summary>
+        /// <summary> <see cref="Console.IsInputRedirected"/>. </summary>
         public bool IsInputRedirected => Console.IsInputRedirected;
 
-        /// <summary>
-        /// <see cref="Console.IsOutputRedirected"/>.
-        /// </summary>
+        /// <summary> <see cref="Console.IsOutputRedirected"/>. </summary>
         public bool IsOutputRedirected => Console.IsOutputRedirected;
 
-        /// <summary>
-        /// <see cref="Console.IsErrorRedirected"/>.
-        /// </summary>
+        /// <summary> <see cref="Console.IsErrorRedirected"/>. </summary>
         public bool IsErrorRedirected => Console.IsErrorRedirected;
 
-        /// <summary>
-        /// <see cref="Console.ForegroundColor"/>.
-        /// </summary>
+        /// <summary> <see cref="Console.ForegroundColor"/>. </summary>
         public ConsoleColor ForegroundColor
         {
             get => Console.ForegroundColor;
             set => Console.ForegroundColor = value;
         }
 
-        /// <summary>
-        /// <see cref="Console.BackgroundColor"/>.
-        /// </summary>
+        /// <summary> <see cref="Console.BackgroundColor"/>. </summary>
         public ConsoleColor BackgroundColor
         {
             get => Console.BackgroundColor;
             set => Console.BackgroundColor = value;
         }
 
-        /// <summary>
-        /// <see cref="Console.ResetColor"/>.
-        /// </summary>
+        /// <summary> <see cref="Console.ResetColor"/>. </summary>
         public void ResetColor() => Console.ResetColor();
     }
 }

--- a/src/CommandLineUtils/Internal/FilePathType.cs
+++ b/src/CommandLineUtils/Internal/FilePathType.cs
@@ -5,25 +5,17 @@ using System;
 
 namespace McMaster.Extensions.CommandLineUtils.Abstractions
 {
-    /// <summary>
-    /// Represents file path types.
-    /// </summary>
+    /// <summary> Represents file path types. </summary>
     [Flags]
     internal enum FilePathType
     {
-        /// <summary>
-        /// A file path to a directory.
-        /// </summary>
+        /// <summary> A file path to a directory. </summary>
         Directory = 1 << 0,
 
-        /// <summary>
-        /// A file path to a file.
-        /// </summary>
+        /// <summary> A file path to a file. </summary>
         File = 1 << 1,
 
-        /// <summary>
-        /// Any type of filepath.
-        /// </summary>
+        /// <summary> Any type of filepath. </summary>
         Any = Directory | File,
     }
 }

--- a/src/CommandLineUtils/Internal/ITupleValueParser.cs
+++ b/src/CommandLineUtils/Internal/ITupleValueParser.cs
@@ -5,9 +5,7 @@ namespace McMaster.Extensions.CommandLineUtils
 {
     using System.Globalization;
 
-    /// <summary>
-    /// Parses a value to Tuple{bool,} or ValueTuple{bool,}
-    /// </summary>
+    /// <summary> Parses a value to Tuple{bool,} or ValueTuple{bool,} </summary>
     internal interface ITupleValueParser
     {
         object Parse(bool hasValue, string argName, string value, CultureInfo culture);

--- a/src/CommandLineUtils/Internal/StringDistance.cs
+++ b/src/CommandLineUtils/Internal/StringDistance.cs
@@ -9,13 +9,8 @@ namespace McMaster.Extensions.CommandLineUtils
 {
     internal static class StringDistance
     {
-        /// <summary>
-        /// Calculates the unnormalized (Damerau-)Levenshtein Distance of two strings
-        /// </summary>
-        /// <param name="s"></param>
-        /// <param name="t"></param>
+        /// <summary> Calculates the unnormalized (Damerau-)Levenshtein Distance of two strings </summary>
         /// <param name="damareu">Determites if the Damerau deviant is used</param>
-        /// <returns></returns>
         private static int LevenshteinDistance(string s, string t, bool damareu)
         {
             // Short circuit so we don't waste cpu time
@@ -83,33 +78,19 @@ namespace McMaster.Extensions.CommandLineUtils
             return matrix[s.Length, t.Length];
         }
 
-        /// <summary>
-        /// Calculates the unnormalized Levenshtein Distance of two strings
-        /// </summary>
-        /// <param name="s"></param>
-        /// <param name="t"></param>
-        /// <returns></returns>
+        /// <summary> Calculates the unnormalized Levenshtein Distance of two strings </summary>
         internal static int LevenshteinDistance(string s, string t)
         {
             return LevenshteinDistance(s, t, false);
         }
 
-        /// <summary>
-        /// Calculates the unnormalized Damareu-Levenshtein Distance of two strings
-        /// </summary>
-        /// <param name="s"></param>
-        /// <param name="t"></param>
-        /// <returns></returns>
+        /// <summary> Calculates the unnormalized Damareu-Levenshtein Distance of two strings </summary>
         internal static int DamareuLevenshteinDistance(string s, string t)
         {
             return LevenshteinDistance(s, t, true);
         }
 
-        /// <summary>
-        /// Normalizes the distance
-        /// </summary>
-        /// <param name="distance"></param>
-        /// <param name="length"></param>
+        /// <summary> Normalizes the distance </summary>
         /// <returns>A value from 0 to 1 with 1 being a perfect match and zero none at all</returns>
         internal static double NormalizeDistance(int distance, int length)
         {

--- a/src/CommandLineUtils/Internal/StringDistance.cs
+++ b/src/CommandLineUtils/Internal/StringDistance.cs
@@ -90,7 +90,6 @@ namespace McMaster.Extensions.CommandLineUtils
             return LevenshteinDistance(s, t, true);
         }
 
-        /// <summary> Normalizes the distance </summary>
         /// <returns>A value from 0 to 1 with 1 being a perfect match and zero none at all</returns>
         internal static double NormalizeDistance(int distance, int length)
         {

--- a/src/CommandLineUtils/Internal/SuggestionCreator.cs
+++ b/src/CommandLineUtils/Internal/SuggestionCreator.cs
@@ -6,17 +6,13 @@ using System.Linq;
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    /// <summary>
-    /// Creates suggestions based on an input string and a command object.
-    /// </summary>
+    /// <summary> Creates suggestions based on an input string and a command object. </summary>
     internal static class SuggestionCreator
     {
         /// <summary>
         /// Gets a list of suggestions from sub commands and options of <paramref name="command"/> that are likely to
         /// fix the invalid argument <paramref name="input"/>
         /// </summary>
-        /// <param name="command"></param>
-        /// <param name="input"></param>
         /// <returns>A list of string with suggestions or null if no suggestions were found</returns>
         public static IEnumerable<string> GetTopSuggestions(CommandLineApplication command, string input)
         {

--- a/src/CommandLineUtils/ResponseFileHandling.cs
+++ b/src/CommandLineUtils/ResponseFileHandling.cs
@@ -15,9 +15,7 @@ namespace McMaster.Extensions.CommandLineUtils
     /// </summary>
     public enum ResponseFileHandling
     {
-        /// <summary>
-        /// Do not parse response files or treat arguments with '@' as a response file
-        /// </summary>
+        /// <summary> Do not parse response files or treat arguments with '@' as a response file </summary>
         Disabled,
 
         /// <summary>

--- a/src/CommandLineUtils/Utilities/ArgumentEscaper.cs
+++ b/src/CommandLineUtils/Utilities/ArgumentEscaper.cs
@@ -8,18 +8,14 @@ using System.Text;
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    /// <summary>
-    /// A utility for escaping arguments for new processes.
-    /// </summary>
+    /// <summary> A utility for escaping arguments for new processes. </summary>
     public static class ArgumentEscaper
     {
         /// <summary>
         /// Undo the processing which took place to create string[] args in Main, so that the next process will
         /// receive the same string[] args.
         /// </summary>
-        /// <remarks>
-        /// See https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/
-        /// </remarks>
+        /// <remarks> See https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/ </remarks>
         /// <param name="args">The arguments</param>
         /// <returns>A single string of escaped arguments</returns>
         public static string EscapeAndConcatenate(IEnumerable<string> args)

--- a/src/CommandLineUtils/Utilities/ArgumentEscaper.cs
+++ b/src/CommandLineUtils/Utilities/ArgumentEscaper.cs
@@ -16,7 +16,6 @@ namespace McMaster.Extensions.CommandLineUtils
         /// receive the same string[] args.
         /// </summary>
         /// <remarks> See https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/ </remarks>
-        /// <param name="args">The arguments</param>
         /// <returns>A single string of escaped arguments</returns>
         public static string EscapeAndConcatenate(IEnumerable<string> args)
             => string.Join(" ", args.Select(EscapeSingleArg));

--- a/src/CommandLineUtils/Utilities/DebugHelper.cs
+++ b/src/CommandLineUtils/Utilities/DebugHelper.cs
@@ -9,9 +9,7 @@ using System.Threading;
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    /// <summary>
-    /// Helps handle debug command-line arguments.
-    /// </summary>
+    /// <summary> Helps handle debug command-line arguments. </summary>
     public static class DebugHelper
     {
         /// <summary>

--- a/src/CommandLineUtils/Utilities/DotNetCliContext.cs
+++ b/src/CommandLineUtils/Utilities/DotNetCliContext.cs
@@ -6,14 +6,10 @@ using System;
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    /// <summary>
-    /// APIs related to .NET Core CLI.
-    /// </summary>
+    /// <summary> APIs related to .NET Core CLI. </summary>
     public static class DotNetCliContext
     {
-        /// <summary>
-        /// `dotnet --diagnostics` was specified.
-        /// </summary>
+        /// <summary> `dotnet --diagnostics` was specified. </summary>
         public static bool IsGlobalVerbose()
         {
             bool.TryParse(Environment.GetEnvironmentVariable("DOTNET_CLI_CONTEXT_VERBOSE"), out bool globalVerbose);

--- a/src/CommandLineUtils/Utilities/DotNetExe.cs
+++ b/src/CommandLineUtils/Utilities/DotNetExe.cs
@@ -9,9 +9,7 @@ using System.Runtime.InteropServices;
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    /// <summary>
-    /// Utilities for finding the "dotnet.exe" file from the currently running .NET Core application.
-    /// </summary>
+    /// <summary> Utilities for finding the "dotnet.exe" file from the currently running .NET Core application. </summary>
     public static class DotNetExe
     {
         private const string FileName = "dotnet";

--- a/src/CommandLineUtils/Utilities/Prompt.cs
+++ b/src/CommandLineUtils/Utilities/Prompt.cs
@@ -7,9 +7,7 @@ using System.Text;
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    /// <summary>
-    /// Utilities for getting input from an interactive console.
-    /// </summary>
+    /// <summary> Utilities for getting input from an interactive console. </summary>
     public static class Prompt
     {
         private const char Backspace = '\b';
@@ -59,9 +57,7 @@ namespace McMaster.Extensions.CommandLineUtils
             while (true);
         }
 
-        /// <summary>
-        /// Gets a console response from the console after displaying a <paramref name="prompt" />.
-        /// </summary>
+        /// <summary> Gets a console response from the console after displaying a <paramref name="prompt" />. </summary>
         /// <param name="prompt">The question to display on command line</param>
         /// <param name="defaultValue">If the user enters a blank response, return this value instead.</param>
         /// <param name="promptColor">The console color to use for the prompt</param>
@@ -91,9 +87,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return defaultValue;
         }
 
-        /// <summary>
-        /// Gets a response that contains a password. Input is masked with an asterisk.
-        /// </summary>
+        /// <summary> Gets a response that contains a password. Input is masked with an asterisk. </summary>
         /// <param name="prompt">The question to display on command line</param>
         /// <param name="promptColor">The console color to use for the prompt</param>
         /// <param name="promptBgColor">The console background color for the prompt</param>
@@ -119,9 +113,7 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
 #if NET45 || NETSTANDARD2_0
-        /// <summary>
-        /// Gets a response as a SecureString object. Input is masked with an asterisk.
-        /// </summary>
+        /// <summary> Gets a response as a SecureString object. Input is masked with an asterisk. </summary>
         /// <param name="prompt">The question to display on the command line</param>
         /// <param name="promptColor">The console color to use for the prompt</param>
         /// <param name="promptBgColor">The console background color for the prompt</param>
@@ -212,9 +204,7 @@ namespace McMaster.Extensions.CommandLineUtils
             while (key.Key != ConsoleKey.Enter);
         }
 
-        /// <summary>
-        /// Gets an integer response from the console after displaying a <paramref name="prompt" />.
-        /// </summary>
+        /// <summary> Gets an integer response from the console after displaying a <paramref name="prompt" />. </summary>
         /// <param name="prompt">The question to display on the command line</param>
         /// <param name="defaultAnswer">If the user provides an empty response, which value should be returned</param>
         /// <param name="promptColor">The console color to display</param>

--- a/src/CommandLineUtils/Validation/AttributeValidator.cs
+++ b/src/CommandLineUtils/Validation/AttributeValidator.cs
@@ -8,28 +8,18 @@ using McMaster.Extensions.CommandLineUtils.Abstractions;
 
 namespace McMaster.Extensions.CommandLineUtils.Validation
 {
-    /// <summary>
-    /// A validator that uses a <see cref="ValidationAttribute"/> to validate a command, command line option, or argument.
-    /// </summary>
+    /// <summary> A validator that uses a <see cref="ValidationAttribute"/> to validate a command, command line option, or argument. </summary>
     public class AttributeValidator : IValidator, ICommandValidator
     {
         private readonly ValidationAttribute _attribute;
 
-        /// <summary>
-        /// Initializes an instance of <see cref="AttributeValidator"/>.
-        /// </summary>
-        /// <param name="attribute"></param>
+        /// <summary> Initializes an instance of <see cref="AttributeValidator"/>. </summary>
         public AttributeValidator(ValidationAttribute attribute)
         {
             _attribute = attribute ?? throw new ArgumentNullException(nameof(attribute));
         }
 
-        /// <summary>
-        /// Gets the validation result for a command line option.
-        /// </summary>
-        /// <param name="option"></param>
-        /// <param name="context"></param>
-        /// <returns></returns>
+        /// <summary> Gets the validation result for a command line option. </summary>
         public ValidationResult GetValidationResult(CommandOption option, ValidationContext context)
         {
             if (_attribute is RequiredAttribute && option.OptionType == CommandOptionType.NoValue)
@@ -43,12 +33,7 @@ namespace McMaster.Extensions.CommandLineUtils.Validation
             return GetValidationResult(option.Values, context);
         }
 
-        /// <summary>
-        /// Gets the validation result for a command line argument.
-        /// </summary>
-        /// <param name="argument"></param>
-        /// <param name="context"></param>
-        /// <returns></returns>
+        /// <summary> Gets the validation result for a command line argument. </summary>
         public ValidationResult GetValidationResult(CommandArgument argument, ValidationContext context)
             => GetValidationResult(argument.Values, context);
 

--- a/src/CommandLineUtils/Validation/DelegateValidator.cs
+++ b/src/CommandLineUtils/Validation/DelegateValidator.cs
@@ -6,17 +6,12 @@ using System.ComponentModel.DataAnnotations;
 
 namespace McMaster.Extensions.CommandLineUtils.Validation
 {
-    /// <summary>
-    /// Implements a validator with an anonymous function
-    /// </summary>
+    /// <summary> Implements a validator with an anonymous function </summary>
     public class DelegateValidator : ICommandValidator, IArgumentValidator, IOptionValidator
     {
         private readonly Func<ValidationContext, ValidationResult> _validator;
 
-        /// <summary>
-        /// Initializes an instance of <see cref="DelegateValidator"/>.
-        /// </summary>
-        /// <param name="validator"></param>
+        /// <summary> Initializes an instance of <see cref="DelegateValidator"/>. </summary>
         public DelegateValidator(Func<ValidationContext, ValidationResult> validator)
         {
             _validator = validator ?? throw new ArgumentNullException(nameof(validator));

--- a/src/CommandLineUtils/Validation/IArgumentValidationBuilder.cs
+++ b/src/CommandLineUtils/Validation/IArgumentValidationBuilder.cs
@@ -8,7 +8,6 @@ namespace McMaster.Extensions.CommandLineUtils.Validation
     public interface IArgumentValidationBuilder : IValidationBuilder
     {
         /// <summary> Use the given <see cref="IArgumentValidator"/>. </summary>
-        /// <param name="validator">The validator.</param>
         void Use(IArgumentValidator validator);
     }
 }

--- a/src/CommandLineUtils/Validation/IArgumentValidationBuilder.cs
+++ b/src/CommandLineUtils/Validation/IArgumentValidationBuilder.cs
@@ -3,17 +3,11 @@
 
 namespace McMaster.Extensions.CommandLineUtils.Validation
 {
-    /// <summary>
-    /// Creates a collection of validators for <see cref="CommandArgument"/>.
-    /// </summary>
-    /// <remarks>
-    /// Custom validation extension methods that only apply to <see cref="CommandArgument"/> should hang off this type.
-    /// </remarks>
+    /// <summary> Creates a collection of validators for <see cref="CommandArgument"/>. </summary>
+    /// <remarks> Custom validation extension methods that only apply to <see cref="CommandArgument"/> should hang off this type. </remarks>
     public interface IArgumentValidationBuilder : IValidationBuilder
     {
-        /// <summary>
-        /// Use the given <see cref="IArgumentValidator"/>.
-        /// </summary>
+        /// <summary> Use the given <see cref="IArgumentValidator"/>. </summary>
         /// <param name="validator">The validator.</param>
         void Use(IArgumentValidator validator);
     }

--- a/src/CommandLineUtils/Validation/IArgumentValidationBuilder{T}.cs
+++ b/src/CommandLineUtils/Validation/IArgumentValidationBuilder{T}.cs
@@ -3,12 +3,8 @@
 
 namespace McMaster.Extensions.CommandLineUtils.Validation
 {
-    /// <summary>
-    /// Creates a collection of validators for <see cref="CommandArgument{T}"/>.
-    /// </summary>
-    /// <remarks>
-    /// Custom validation extension methods that only apply to <see cref="CommandArgument{T}"/> should hang off this type.
-    /// </remarks>
+    /// <summary> Creates a collection of validators for <see cref="CommandArgument{T}"/>. </summary>
+    /// <remarks> Custom validation extension methods that only apply to <see cref="CommandArgument{T}"/> should hang off this type. </remarks>
     public interface IArgumentValidationBuilder<T> : IArgumentValidationBuilder, IValidationBuilder<T>
     {
     }

--- a/src/CommandLineUtils/Validation/IArgumentValidator.cs
+++ b/src/CommandLineUtils/Validation/IArgumentValidator.cs
@@ -9,7 +9,6 @@ namespace McMaster.Extensions.CommandLineUtils.Validation
     public interface IArgumentValidator
     {
         /// <summary> Validates the values specified for <see cref="CommandArgument.Values"/>. </summary>
-        /// <param name="context">The validation context.</param>
         /// <returns>The validation result. Returns <see cref="ValidationResult.Success"/> if the values pass validation.</returns>
         ValidationResult GetValidationResult(CommandArgument argument, ValidationContext context);
     }

--- a/src/CommandLineUtils/Validation/IArgumentValidator.cs
+++ b/src/CommandLineUtils/Validation/IArgumentValidator.cs
@@ -5,14 +5,10 @@ using System.ComponentModel.DataAnnotations;
 
 namespace McMaster.Extensions.CommandLineUtils.Validation
 {
-    /// <summary>
-    /// Provides validation for a <see cref="CommandArgument"/>.
-    /// </summary>
+    /// <summary> Provides validation for a <see cref="CommandArgument"/>. </summary>
     public interface IArgumentValidator
     {
-        /// <summary>
-        /// Validates the values specified for <see cref="CommandArgument.Values"/>.
-        /// </summary>
+        /// <summary> Validates the values specified for <see cref="CommandArgument.Values"/>. </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="context">The validation context.</param>
         /// <returns>The validation result. Returns <see cref="ValidationResult.Success"/> if the values pass validation.</returns>

--- a/src/CommandLineUtils/Validation/IArgumentValidator.cs
+++ b/src/CommandLineUtils/Validation/IArgumentValidator.cs
@@ -9,7 +9,6 @@ namespace McMaster.Extensions.CommandLineUtils.Validation
     public interface IArgumentValidator
     {
         /// <summary> Validates the values specified for <see cref="CommandArgument.Values"/>. </summary>
-        /// <param name="argument">The argument.</param>
         /// <param name="context">The validation context.</param>
         /// <returns>The validation result. Returns <see cref="ValidationResult.Success"/> if the values pass validation.</returns>
         ValidationResult GetValidationResult(CommandArgument argument, ValidationContext context);

--- a/src/CommandLineUtils/Validation/ICommandValidator.cs
+++ b/src/CommandLineUtils/Validation/ICommandValidator.cs
@@ -8,8 +8,6 @@ namespace McMaster.Extensions.CommandLineUtils.Validation
     /// <summary> Provides validation on a command </summary>
     public interface ICommandValidator
     {
-        /// <summary> Validates a command </summary>
-        /// <param name="context">The validation context.</param>
         /// <returns>The validation result. Returns <see cref="ValidationResult.Success"/> if the values pass validation.</returns>
         ValidationResult GetValidationResult(CommandLineApplication command, ValidationContext context);
     }

--- a/src/CommandLineUtils/Validation/ICommandValidator.cs
+++ b/src/CommandLineUtils/Validation/ICommandValidator.cs
@@ -9,7 +9,6 @@ namespace McMaster.Extensions.CommandLineUtils.Validation
     public interface ICommandValidator
     {
         /// <summary> Validates a command </summary>
-        /// <param name="command">The command.</param>
         /// <param name="context">The validation context.</param>
         /// <returns>The validation result. Returns <see cref="ValidationResult.Success"/> if the values pass validation.</returns>
         ValidationResult GetValidationResult(CommandLineApplication command, ValidationContext context);

--- a/src/CommandLineUtils/Validation/ICommandValidator.cs
+++ b/src/CommandLineUtils/Validation/ICommandValidator.cs
@@ -5,14 +5,10 @@ using System.ComponentModel.DataAnnotations;
 
 namespace McMaster.Extensions.CommandLineUtils.Validation
 {
-    /// <summary>
-    /// Provides validation on a command
-    /// </summary>
+    /// <summary> Provides validation on a command </summary>
     public interface ICommandValidator
     {
-        /// <summary>
-        /// Validates a command
-        /// </summary>
+        /// <summary> Validates a command </summary>
         /// <param name="command">The command.</param>
         /// <param name="context">The validation context.</param>
         /// <returns>The validation result. Returns <see cref="ValidationResult.Success"/> if the values pass validation.</returns>

--- a/src/CommandLineUtils/Validation/IOptionValidationBuilder.cs
+++ b/src/CommandLineUtils/Validation/IOptionValidationBuilder.cs
@@ -3,17 +3,11 @@
 
 namespace McMaster.Extensions.CommandLineUtils.Validation
 {
-    /// <summary>
-    /// Creates a collection of validators for <see cref="CommandOption"/>.
-    /// </summary>
-    /// <remarks>
-    /// Custom validation extension methods that only apply to <see cref="CommandOption"/> should hang off this type.
-    /// </remarks>
+    /// <summary> Creates a collection of validators for <see cref="CommandOption"/>. </summary>
+    /// <remarks> Custom validation extension methods that only apply to <see cref="CommandOption"/> should hang off this type. </remarks>
     public interface IOptionValidationBuilder : IValidationBuilder
     {
-        /// <summary>
-        /// Use the given <see cref="IOptionValidator"/>.
-        /// </summary>
+        /// <summary> Use the given <see cref="IOptionValidator"/>. </summary>
         /// <param name="validator">The validator.</param>
         void Use(IOptionValidator validator);
     }

--- a/src/CommandLineUtils/Validation/IOptionValidationBuilder.cs
+++ b/src/CommandLineUtils/Validation/IOptionValidationBuilder.cs
@@ -8,7 +8,6 @@ namespace McMaster.Extensions.CommandLineUtils.Validation
     public interface IOptionValidationBuilder : IValidationBuilder
     {
         /// <summary> Use the given <see cref="IOptionValidator"/>. </summary>
-        /// <param name="validator">The validator.</param>
         void Use(IOptionValidator validator);
     }
 }

--- a/src/CommandLineUtils/Validation/IOptionValidationBuilder{T}.cs
+++ b/src/CommandLineUtils/Validation/IOptionValidationBuilder{T}.cs
@@ -3,12 +3,8 @@
 
 namespace McMaster.Extensions.CommandLineUtils.Validation
 {
-    /// <summary>
-    /// Creates a collection of validators for <see cref="CommandOption{T}"/>.
-    /// </summary>
-    /// <remarks>
-    /// Custom validation extension methods that only apply to <see cref="CommandOption{T}"/> should hang off this type.
-    /// </remarks>
+    /// <summary> Creates a collection of validators for <see cref="CommandOption{T}"/>. </summary>
+    /// <remarks> Custom validation extension methods that only apply to <see cref="CommandOption{T}"/> should hang off this type. </remarks>
     public interface IOptionValidationBuilder<T> : IOptionValidationBuilder, IValidationBuilder<T>
     {
     }

--- a/src/CommandLineUtils/Validation/IOptionValidator.cs
+++ b/src/CommandLineUtils/Validation/IOptionValidator.cs
@@ -5,14 +5,10 @@ using System.ComponentModel.DataAnnotations;
 
 namespace McMaster.Extensions.CommandLineUtils.Validation
 {
-    /// <summary>
-    /// Provides validation for a <see cref="CommandOption"/>.
-    /// </summary>
+    /// <summary> Provides validation for a <see cref="CommandOption"/>. </summary>
     public interface IOptionValidator
     {
-        /// <summary>
-        /// Validates the values specified for <see cref="CommandOption.Values"/>.
-        /// </summary>
+        /// <summary> Validates the values specified for <see cref="CommandOption.Values"/>. </summary>
         /// <param name="option">The option.</param>
         /// <param name="context">The validation context.</param>
         /// <returns>The validation result. Returns <see cref="ValidationResult.Success"/> if the values pass validation.</returns>

--- a/src/CommandLineUtils/Validation/IOptionValidator.cs
+++ b/src/CommandLineUtils/Validation/IOptionValidator.cs
@@ -9,7 +9,6 @@ namespace McMaster.Extensions.CommandLineUtils.Validation
     public interface IOptionValidator
     {
         /// <summary> Validates the values specified for <see cref="CommandOption.Values"/>. </summary>
-        /// <param name="option">The option.</param>
         /// <param name="context">The validation context.</param>
         /// <returns>The validation result. Returns <see cref="ValidationResult.Success"/> if the values pass validation.</returns>
         ValidationResult GetValidationResult(CommandOption option, ValidationContext context);

--- a/src/CommandLineUtils/Validation/IOptionValidator.cs
+++ b/src/CommandLineUtils/Validation/IOptionValidator.cs
@@ -9,7 +9,6 @@ namespace McMaster.Extensions.CommandLineUtils.Validation
     public interface IOptionValidator
     {
         /// <summary> Validates the values specified for <see cref="CommandOption.Values"/>. </summary>
-        /// <param name="context">The validation context.</param>
         /// <returns>The validation result. Returns <see cref="ValidationResult.Success"/> if the values pass validation.</returns>
         ValidationResult GetValidationResult(CommandOption option, ValidationContext context);
     }

--- a/src/CommandLineUtils/Validation/IValidationBuilder.cs
+++ b/src/CommandLineUtils/Validation/IValidationBuilder.cs
@@ -3,17 +3,11 @@
 
 namespace McMaster.Extensions.CommandLineUtils.Validation
 {
-    /// <summary>
-    /// Creates a collection of validators.
-    /// </summary>
-    /// <remarks>
-    /// Custom validation extension methods should hang off this type.
-    /// </remarks>
+    /// <summary> Creates a collection of validators. </summary>
+    /// <remarks> Custom validation extension methods should hang off this type. </remarks>
     public interface IValidationBuilder
     {
-        /// <summary>
-        /// Use the <see cref="IValidator"/>.
-        /// </summary>
+        /// <summary> Use the <see cref="IValidator"/>. </summary>
         /// <param name="validator">The validator.</param>
         void Use(IValidator validator);
     }

--- a/src/CommandLineUtils/Validation/IValidationBuilder.cs
+++ b/src/CommandLineUtils/Validation/IValidationBuilder.cs
@@ -8,7 +8,6 @@ namespace McMaster.Extensions.CommandLineUtils.Validation
     public interface IValidationBuilder
     {
         /// <summary> Use the <see cref="IValidator"/>. </summary>
-        /// <param name="validator">The validator.</param>
         void Use(IValidator validator);
     }
 }

--- a/src/CommandLineUtils/Validation/IValidationBuilder{T}.cs
+++ b/src/CommandLineUtils/Validation/IValidationBuilder{T}.cs
@@ -3,12 +3,8 @@
 
 namespace McMaster.Extensions.CommandLineUtils.Validation
 {
-    /// <summary>
-    /// Creates a collection of validators on <see cref="CommandOption{T}" /> or <see cref="CommandArgument{T}" />
-    /// </summary>
-    /// <remarks>
-    /// Custom validation extension methods should hang off this type.
-    /// </remarks>
+    /// <summary> Creates a collection of validators on <see cref="CommandOption{T}" /> or <see cref="CommandArgument{T}" /> </summary>
+    /// <remarks> Custom validation extension methods should hang off this type. </remarks>
     public interface IValidationBuilder<T> : IValidationBuilder
     {
     }

--- a/src/CommandLineUtils/Validation/IValidator.cs
+++ b/src/CommandLineUtils/Validation/IValidator.cs
@@ -3,9 +3,7 @@
 
 namespace McMaster.Extensions.CommandLineUtils.Validation
 {
-    /// <summary>
-    /// Provides validation for <see cref="CommandArgument"/> and <see cref="CommandOption"/>.
-    /// </summary>
+    /// <summary> Provides validation for <see cref="CommandArgument"/> and <see cref="CommandOption"/>. </summary>
     public interface IValidator : IOptionValidator, IArgumentValidator
     {
     }

--- a/src/CommandLineUtils/Validation/ValidationBuilder.cs
+++ b/src/CommandLineUtils/Validation/ValidationBuilder.cs
@@ -5,36 +5,27 @@ using System;
 
 namespace McMaster.Extensions.CommandLineUtils.Validation
 {
-    /// <summary>
-    /// Default implementation of <see cref="IOptionValidationBuilder"/> and <see cref="IArgumentValidationBuilder"/>.
-    /// </summary>
+    /// <summary> Default implementation of <see cref="IOptionValidationBuilder"/> and <see cref="IArgumentValidationBuilder"/>. </summary>
     public class ValidationBuilder : IOptionValidationBuilder, IArgumentValidationBuilder
     {
         private readonly CommandArgument? _argument;
         private readonly CommandOption? _option;
 
-        /// <summary>
-        /// Creates a new instance of <see cref="ValidationBuilder"/> for a given <see cref="CommandArgument"/>.
-        /// </summary>
+        /// <summary> Creates a new instance of <see cref="ValidationBuilder"/> for a given <see cref="CommandArgument"/>. </summary>
         /// <param name="argument">The argument.</param>
         public ValidationBuilder(CommandArgument argument)
         {
             _argument = argument ?? throw new ArgumentNullException(nameof(argument));
         }
 
-        /// <summary>
-        /// Creates a new instance of <see cref="ValidationBuilder"/> for a given <see cref="CommandOption"/>.
-        /// </summary>
+        /// <summary> Creates a new instance of <see cref="ValidationBuilder"/> for a given <see cref="CommandOption"/>. </summary>
         /// <param name="option">The option.</param>
         public ValidationBuilder(CommandOption option)
         {
             _option = option ?? throw new ArgumentNullException(nameof(option));
         }
 
-        /// <summary>
-        /// Adds a validator to the argument or option.
-        /// </summary>
-        /// <param name="validator"></param>
+        /// <summary> Adds a validator to the argument or option. </summary>
         public void Use(IValidator validator)
         {
             _argument?.Validators.Add(validator);

--- a/src/CommandLineUtils/Validation/ValidationBuilder.cs
+++ b/src/CommandLineUtils/Validation/ValidationBuilder.cs
@@ -12,14 +12,12 @@ namespace McMaster.Extensions.CommandLineUtils.Validation
         private readonly CommandOption? _option;
 
         /// <summary> Creates a new instance of <see cref="ValidationBuilder"/> for a given <see cref="CommandArgument"/>. </summary>
-        /// <param name="argument">The argument.</param>
         public ValidationBuilder(CommandArgument argument)
         {
             _argument = argument ?? throw new ArgumentNullException(nameof(argument));
         }
 
         /// <summary> Creates a new instance of <see cref="ValidationBuilder"/> for a given <see cref="CommandOption"/>. </summary>
-        /// <param name="option">The option.</param>
         public ValidationBuilder(CommandOption option)
         {
             _option = option ?? throw new ArgumentNullException(nameof(option));

--- a/src/CommandLineUtils/Validation/ValidationBuilder{T}.cs
+++ b/src/CommandLineUtils/Validation/ValidationBuilder{T}.cs
@@ -4,22 +4,16 @@
 
 namespace McMaster.Extensions.CommandLineUtils.Validation
 {
-    /// <summary>
-    /// Default implementation of <see cref="IOptionValidationBuilder{T}"/> and <see cref="IArgumentValidationBuilder{T}"/>.
-    /// </summary>
+    /// <summary> Default implementation of <see cref="IOptionValidationBuilder{T}"/> and <see cref="IArgumentValidationBuilder{T}"/>. </summary>
     public class ValidationBuilder<T> : ValidationBuilder, IArgumentValidationBuilder<T>, IOptionValidationBuilder<T>
     {
-        /// <summary>
-        /// Creates a new instance of <see cref="ValidationBuilder"/> for a given <see cref="CommandArgument{T}"/>.
-        /// </summary>
+        /// <summary> Creates a new instance of <see cref="ValidationBuilder"/> for a given <see cref="CommandArgument{T}"/>. </summary>
         /// <param name="argument">The argument.</param>
         public ValidationBuilder(CommandArgument<T> argument) : base(argument)
         {
         }
 
-        /// <summary>
-        /// Creates a new instance of <see cref="ValidationBuilder"/> for a given <see cref="CommandOption{T}"/>.
-        /// </summary>
+        /// <summary> Creates a new instance of <see cref="ValidationBuilder"/> for a given <see cref="CommandOption{T}"/>. </summary>
         /// <param name="option">The option.</param>
         public ValidationBuilder(CommandOption<T> option) : base(option)
         {

--- a/src/CommandLineUtils/Validation/ValidationBuilder{T}.cs
+++ b/src/CommandLineUtils/Validation/ValidationBuilder{T}.cs
@@ -8,13 +8,11 @@ namespace McMaster.Extensions.CommandLineUtils.Validation
     public class ValidationBuilder<T> : ValidationBuilder, IArgumentValidationBuilder<T>, IOptionValidationBuilder<T>
     {
         /// <summary> Creates a new instance of <see cref="ValidationBuilder"/> for a given <see cref="CommandArgument{T}"/>. </summary>
-        /// <param name="argument">The argument.</param>
         public ValidationBuilder(CommandArgument<T> argument) : base(argument)
         {
         }
 
         /// <summary> Creates a new instance of <see cref="ValidationBuilder"/> for a given <see cref="CommandOption{T}"/>. </summary>
-        /// <param name="option">The option.</param>
         public ValidationBuilder(CommandOption<T> option) : base(option)
         {
         }

--- a/src/CommandLineUtils/Validation/ValidationExtensions.cs
+++ b/src/CommandLineUtils/Validation/ValidationExtensions.cs
@@ -8,15 +8,11 @@ using McMaster.Extensions.CommandLineUtils.Validation;
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    /// <summary>
-    /// Extension methods for adding validation rules to options and arguments.
-    /// </summary>
+    /// <summary> Extension methods for adding validation rules to options and arguments. </summary>
     public static class ValidationExtensions
     {
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
-        /// <summary>
-        /// Indicates the option is required.
-        /// </summary>
+        /// <summary> Indicates the option is required. </summary>
         /// <param name="option">The option.</param>
         /// <param name="allowEmptyStrings">Indicates whether an empty string is allowed.</param>
         /// <param name="errorMessage">The custom error message to display. See also <seealso cref="ValidationAttribute.ErrorMessage"/>.</param>
@@ -31,9 +27,7 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
-        /// <summary>
-        /// Indicates the option is required.
-        /// </summary>
+        /// <summary> Indicates the option is required. </summary>
         /// <param name="option">The option.</param>
         /// <param name="allowEmptyStrings">Indicates whether an empty string is allowed.</param>
         /// <param name="errorMessage">The custom error message to display. See also <seealso cref="ValidationAttribute.ErrorMessage"/>.</param>
@@ -42,15 +36,12 @@ namespace McMaster.Extensions.CommandLineUtils
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
             string? errorMessage = null)
         {
-
             IsRequired((CommandOption)option, allowEmptyStrings, errorMessage);
             return option;
         }
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
-        /// <summary>
-        /// Indicates the argument is required.
-        /// </summary>
+        /// <summary> Indicates the argument is required. </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="allowEmptyStrings">Indicates whether an empty string is allowed.</param>
         /// <param name="errorMessage">The custom error message to display. See also <seealso cref="ValidationAttribute.ErrorMessage"/>.</param>
@@ -65,9 +56,7 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
-        /// <summary>
-        /// Indicates the argument is required.
-        /// </summary>
+        /// <summary> Indicates the argument is required. </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="allowEmptyStrings">Indicates whether an empty string is allowed.</param>
         /// <param name="errorMessage">The custom error message to display. See also <seealso cref="ValidationAttribute.ErrorMessage"/>.</param>
@@ -79,9 +68,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return argument;
         }
 
-        /// <summary>
-        /// Specifies a set of rules used to determine if input is valid.
-        /// </summary>
+        /// <summary> Specifies a set of rules used to determine if input is valid. </summary>
         /// <param name="option">The option.</param>
         /// <param name="configure">A function to configure rules on the validation builder.</param>
         /// <returns>The option.</returns>
@@ -97,9 +84,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return option;
         }
 
-        /// <summary>
-        /// Specifies a set of rules used to determine if input is valid.
-        /// </summary>
+        /// <summary> Specifies a set of rules used to determine if input is valid. </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="configure">A function to configure rules on the validation builder.</param>
         /// <returns>The argument.</returns>
@@ -115,25 +100,19 @@ namespace McMaster.Extensions.CommandLineUtils
             return argument;
         }
 
-        /// <summary>
-        /// Creates a builder for specifying a set of rules used to determine if input is valid.
-        /// </summary>
+        /// <summary> Creates a builder for specifying a set of rules used to determine if input is valid. </summary>
         /// <param name="option">The option.</param>
         /// <returns>The builder.</returns>
         public static IOptionValidationBuilder Accepts(this CommandOption option)
             => new ValidationBuilder(option);
 
-        /// <summary>
-        /// Creates a builder for specifying a set of rules used to determine if input is valid.
-        /// </summary>
+        /// <summary> Creates a builder for specifying a set of rules used to determine if input is valid. </summary>
         /// <param name="argument">The argument.</param>
         /// <returns>The builder.</returns>
         public static IArgumentValidationBuilder Accepts(this CommandArgument argument)
             => new ValidationBuilder(argument);
 
-        /// <summary>
-        /// Specifies a set of rules used to determine if input is valid.
-        /// </summary>
+        /// <summary> Specifies a set of rules used to determine if input is valid. </summary>
         /// <param name="option">The option.</param>
         /// <param name="configure">A function to configure rules on the validation builder.</param>
         /// <returns>The option.</returns>
@@ -149,9 +128,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return option;
         }
 
-        /// <summary>
-        /// Specifies a set of rules used to determine if input is valid.
-        /// </summary>
+        /// <summary> Specifies a set of rules used to determine if input is valid. </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="configure">A function to configure rules on the validation builder.</param>
         /// <returns>The argument.</returns>
@@ -167,17 +144,13 @@ namespace McMaster.Extensions.CommandLineUtils
             return argument;
         }
 
-        /// <summary>
-        /// Creates a builder for specifying a set of rules used to determine if input is valid.
-        /// </summary>
+        /// <summary> Creates a builder for specifying a set of rules used to determine if input is valid. </summary>
         /// <param name="option">The option.</param>
         /// <returns>The builder.</returns>
         public static IOptionValidationBuilder<T> Accepts<T>(this CommandOption<T> option)
             => new ValidationBuilder<T>(option);
 
-        /// <summary>
-        /// Creates a builder for specifying a set of rules used to determine if input is valid.
-        /// </summary>
+        /// <summary> Creates a builder for specifying a set of rules used to determine if input is valid. </summary>
         /// <param name="argument">The argument.</param>
         /// <returns>The builder.</returns>
         public static IArgumentValidationBuilder<T> Accepts<T>(this CommandArgument<T> argument)
@@ -224,9 +197,7 @@ namespace McMaster.Extensions.CommandLineUtils
         public static IValidationBuilder Values(this IValidationBuilder builder, params string[] allowedValues)
             => builder.Values(ignoreCase: false, allowedValues: allowedValues);
 
-        /// <summary>
-        /// Specifies that values must be one of the values in a given set.
-        /// </summary>
+        /// <summary> Specifies that values must be one of the values in a given set. </summary>
         /// <param name="builder">The builder.</param>
         /// <param name="ignoreCase">Ignore case when comparing inputs to <paramref name="allowedValues"/>.</param>
         /// <param name="allowedValues">Allowed values.</param>
@@ -239,9 +210,7 @@ namespace McMaster.Extensions.CommandLineUtils
             return builder.Values(comparer, allowedValues);
         }
 
-        /// <summary>
-        /// Specifies that values must be one of the values in a given set.
-        /// </summary>
+        /// <summary> Specifies that values must be one of the values in a given set. </summary>
         /// <param name="builder">The builder.</param>
         /// <param name="comparer">The comparer used to determine if values match.</param>
         /// <param name="allowedValues">Allowed values.</param>
@@ -251,81 +220,63 @@ namespace McMaster.Extensions.CommandLineUtils
             return builder.Satisfies<AllowedValuesAttribute>(ctorArgs: new object[] { comparer, allowedValues });
         }
 
-        /// <summary>
-        /// Specifies that values must be a valid email address.
-        /// </summary>
+        /// <summary> Specifies that values must be a valid email address. </summary>
         /// <param name="builder">The builder.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
         public static IValidationBuilder EmailAddress(this IValidationBuilder builder, string? errorMessage = null)
             => builder.Satisfies<EmailAddressAttribute>(errorMessage);
 
-        /// <summary>
-        /// Specifies that values must be a path to a file that already exists.
-        /// </summary>
+        /// <summary> Specifies that values must be a path to a file that already exists. </summary>
         /// <param name="builder">The builder.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
         public static IValidationBuilder ExistingFile(this IValidationBuilder builder, string? errorMessage = null)
             => builder.Satisfies<FileExistsAttribute>(errorMessage);
 
-        /// <summary>
-        /// Specifies that values must be a path to a file that does not already exist.
-        /// </summary>
+        /// <summary> Specifies that values must be a path to a file that does not already exist. </summary>
         /// <param name="builder">The builder.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
         public static IValidationBuilder NonExistingFile(this IValidationBuilder builder, string? errorMessage = null)
             => builder.Satisfies<FileNotExistsAttribute>(errorMessage);
 
-        /// <summary>
-        /// Specifies that values must be a path to a directory that already exists.
-        /// </summary>
+        /// <summary> Specifies that values must be a path to a directory that already exists. </summary>
         /// <param name="builder">The builder.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
         public static IValidationBuilder ExistingDirectory(this IValidationBuilder builder, string? errorMessage = null)
             => builder.Satisfies<DirectoryExistsAttribute>(errorMessage);
 
-        /// <summary>
-        /// Specifies that values must be a path to a directory that does not already exist.
-        /// </summary>
+        /// <summary> Specifies that values must be a path to a directory that does not already exist. </summary>
         /// <param name="builder">The builder.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
         public static IValidationBuilder NonExistingDirectory(this IValidationBuilder builder, string? errorMessage = null)
             => builder.Satisfies<DirectoryNotExistsAttribute>(errorMessage);
 
-        /// <summary>
-        /// Specifies that values must be a valid file path or directory, and the file path must already exist.
-        /// </summary>
+        /// <summary> Specifies that values must be a valid file path or directory, and the file path must already exist. </summary>
         /// <param name="builder">The builder.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
         public static IValidationBuilder ExistingFileOrDirectory(this IValidationBuilder builder, string? errorMessage = null)
             => builder.Satisfies<FileOrDirectoryExistsAttribute>(errorMessage);
 
-        /// <summary>
-        /// Specifies that values must be a valid file path or directory, and the file path must not already exist.
-        /// </summary>
+        /// <summary> Specifies that values must be a valid file path or directory, and the file path must not already exist. </summary>
         /// <param name="builder">The builder.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
         public static IValidationBuilder NonExistingFileOrDirectory(this IValidationBuilder builder, string? errorMessage = null)
             => builder.Satisfies<FileOrDirectoryNotExistsAttribute>(errorMessage);
 
-        /// <summary>
-        /// Specifies that values must be legal file paths.
-        /// </summary>
+        /// <summary> Specifies that values must be legal file paths. </summary>
         /// <param name="builder">The builder.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
         public static IValidationBuilder LegalFilePath(this IValidationBuilder builder, string? errorMessage = null)
             => builder.Satisfies<LegalFilePathAttribute>(errorMessage);
 
-        /// <summary>
-        /// Specifies that values must be a string at least <paramref name="length"/> characters long.
-        /// </summary>
+        /// <summary> Specifies that values must be a string at least <paramref name="length"/> characters long. </summary>
         /// <param name="builder">The builder</param>
         /// <param name="length">The minimum length.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
@@ -333,9 +284,7 @@ namespace McMaster.Extensions.CommandLineUtils
         public static IValidationBuilder MinLength(this IValidationBuilder builder, int length, string? errorMessage = null)
             => builder.Satisfies<MinLengthAttribute>(errorMessage, length);
 
-        /// <summary>
-        /// Specifies that values must be a string no more than <paramref name="length"/> characters long.
-        /// </summary>
+        /// <summary> Specifies that values must be a string no more than <paramref name="length"/> characters long. </summary>
         /// <param name="builder">The builder.</param>
         /// <param name="length">The maximum length.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
@@ -343,9 +292,7 @@ namespace McMaster.Extensions.CommandLineUtils
         public static IValidationBuilder MaxLength(this IValidationBuilder builder, int length, string? errorMessage = null)
             => builder.Satisfies<MaxLengthAttribute>(errorMessage, length);
 
-        /// <summary>
-        /// Specifies that values must match a regular expression.
-        /// </summary>
+        /// <summary> Specifies that values must match a regular expression. </summary>
         /// <param name="builder">The builder.</param>
         /// <param name="pattern">The regular expression.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
@@ -353,9 +300,7 @@ namespace McMaster.Extensions.CommandLineUtils
         public static IValidationBuilder RegularExpression(this IValidationBuilder builder, string pattern, string? errorMessage = null)
             => builder.Satisfies<RegularExpressionAttribute>(errorMessage, pattern);
 
-        /// <summary>
-        /// Specifies that values must satisfy the requirements of the validation attribute of type <typeparamref name="TAttribute"/>.
-        /// </summary>
+        /// <summary> Specifies that values must satisfy the requirements of the validation attribute of type <typeparamref name="TAttribute"/>. </summary>
         /// <typeparam name="TAttribute">The validation attribute type.</typeparam>
         /// <param name="builder">The builder.</param>
         /// <param name="ctorArgs">Constructor arguments for <typeparamref name="TAttribute"/>.</param>
@@ -370,9 +315,7 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
-        /// <summary>
-        /// Specifies that values must be in a given range.
-        /// </summary>
+        /// <summary> Specifies that values must be in a given range. </summary>
         /// <param name="builder">The builder.</param>
         /// <param name="minimum">The minimum allowed value.</param>
         /// <param name="maximum">The maximum allowed value.</param>
@@ -387,9 +330,7 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
-        /// <summary>
-        /// Specifies that values must be in a given range.
-        /// </summary>
+        /// <summary> Specifies that values must be in a given range. </summary>
         /// <param name="builder">The builder.</param>
         /// <param name="minimum">The minimum allowed value.</param>
         /// <param name="maximum">The maximum allowed value.</param>
@@ -403,36 +344,27 @@ namespace McMaster.Extensions.CommandLineUtils
             return builder;
         }
 
-        /// <summary>
-        /// Adds a validator that runs after parsing is complete and before command execution.
-        /// </summary>
+        /// <summary> Adds a validator that runs after parsing is complete and before command execution. </summary>
         /// <param name="command">The command.</param>
         /// <param name="validate">The callback. Return <see cref="ValidationResult.Success"/> if there is no error.</param>
-        /// <returns></returns>
         public static CommandLineApplication OnValidate(this CommandLineApplication command, Func<ValidationContext, ValidationResult> validate)
         {
             command.Validators.Add(new DelegateValidator(validate));
             return command;
         }
 
-        /// <summary>
-        /// Adds a validator that runs after parsing is complete and before command execution.
-        /// </summary>
+        /// <summary> Adds a validator that runs after parsing is complete and before command execution. </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="validate">The callback. Return <see cref="ValidationResult.Success"/> if there is no error.</param>
-        /// <returns></returns>
         public static CommandArgument OnValidate(this CommandArgument argument, Func<ValidationContext, ValidationResult> validate)
         {
             argument.Validators.Add(new DelegateValidator(validate));
             return argument;
         }
 
-        /// <summary>
-        /// Adds a validator that runs after parsing is complete and before command execution.
-        /// </summary>
+        /// <summary> Adds a validator that runs after parsing is complete and before command execution. </summary>
         /// <param name="option">The option.</param>
         /// <param name="validate">The callback. Return <see cref="ValidationResult.Success"/> if there is no error.</param>
-        /// <returns></returns>
         public static CommandOption OnValidate(this CommandOption option, Func<ValidationContext, ValidationResult> validate)
         {
             option.Validators.Add(new DelegateValidator(validate));

--- a/src/CommandLineUtils/Validation/ValidationExtensions.cs
+++ b/src/CommandLineUtils/Validation/ValidationExtensions.cs
@@ -13,7 +13,6 @@ namespace McMaster.Extensions.CommandLineUtils
     {
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
         /// <summary> Indicates the option is required. </summary>
-        /// <param name="option">The option.</param>
         /// <param name="allowEmptyStrings">Indicates whether an empty string is allowed.</param>
         /// <param name="errorMessage">The custom error message to display. See also <seealso cref="ValidationAttribute.ErrorMessage"/>.</param>
         /// <returns>The option.</returns>
@@ -28,7 +27,6 @@ namespace McMaster.Extensions.CommandLineUtils
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
         /// <summary> Indicates the option is required. </summary>
-        /// <param name="option">The option.</param>
         /// <param name="allowEmptyStrings">Indicates whether an empty string is allowed.</param>
         /// <param name="errorMessage">The custom error message to display. See also <seealso cref="ValidationAttribute.ErrorMessage"/>.</param>
         /// <returns>The option.</returns>
@@ -42,7 +40,6 @@ namespace McMaster.Extensions.CommandLineUtils
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
         /// <summary> Indicates the argument is required. </summary>
-        /// <param name="argument">The argument.</param>
         /// <param name="allowEmptyStrings">Indicates whether an empty string is allowed.</param>
         /// <param name="errorMessage">The custom error message to display. See also <seealso cref="ValidationAttribute.ErrorMessage"/>.</param>
         /// <returns>The argument.</returns>
@@ -57,7 +54,6 @@ namespace McMaster.Extensions.CommandLineUtils
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
         /// <summary> Indicates the argument is required. </summary>
-        /// <param name="argument">The argument.</param>
         /// <param name="allowEmptyStrings">Indicates whether an empty string is allowed.</param>
         /// <param name="errorMessage">The custom error message to display. See also <seealso cref="ValidationAttribute.ErrorMessage"/>.</param>
         /// <returns>The argument.</returns>
@@ -69,7 +65,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Specifies a set of rules used to determine if input is valid. </summary>
-        /// <param name="option">The option.</param>
         /// <param name="configure">A function to configure rules on the validation builder.</param>
         /// <returns>The option.</returns>
         public static CommandOption Accepts(this CommandOption option, Action<IOptionValidationBuilder> configure)
@@ -85,7 +80,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Specifies a set of rules used to determine if input is valid. </summary>
-        /// <param name="argument">The argument.</param>
         /// <param name="configure">A function to configure rules on the validation builder.</param>
         /// <returns>The argument.</returns>
         public static CommandArgument Accepts(this CommandArgument argument, Action<IArgumentValidationBuilder> configure)
@@ -101,19 +95,16 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Creates a builder for specifying a set of rules used to determine if input is valid. </summary>
-        /// <param name="option">The option.</param>
         /// <returns>The builder.</returns>
         public static IOptionValidationBuilder Accepts(this CommandOption option)
             => new ValidationBuilder(option);
 
         /// <summary> Creates a builder for specifying a set of rules used to determine if input is valid. </summary>
-        /// <param name="argument">The argument.</param>
         /// <returns>The builder.</returns>
         public static IArgumentValidationBuilder Accepts(this CommandArgument argument)
             => new ValidationBuilder(argument);
 
         /// <summary> Specifies a set of rules used to determine if input is valid. </summary>
-        /// <param name="option">The option.</param>
         /// <param name="configure">A function to configure rules on the validation builder.</param>
         /// <returns>The option.</returns>
         public static CommandOption<T> Accepts<T>(this CommandOption<T> option, Action<IOptionValidationBuilder<T>> configure)
@@ -129,7 +120,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Specifies a set of rules used to determine if input is valid. </summary>
-        /// <param name="argument">The argument.</param>
         /// <param name="configure">A function to configure rules on the validation builder.</param>
         /// <returns>The argument.</returns>
         public static CommandArgument<T> Accepts<T>(this CommandArgument<T> argument, Action<IArgumentValidationBuilder<T>> configure)
@@ -145,13 +135,11 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Creates a builder for specifying a set of rules used to determine if input is valid. </summary>
-        /// <param name="option">The option.</param>
         /// <returns>The builder.</returns>
         public static IOptionValidationBuilder<T> Accepts<T>(this CommandOption<T> option)
             => new ValidationBuilder<T>(option);
 
         /// <summary> Creates a builder for specifying a set of rules used to determine if input is valid. </summary>
-        /// <param name="argument">The argument.</param>
         /// <returns>The builder.</returns>
         public static IArgumentValidationBuilder<T> Accepts<T>(this CommandArgument<T> argument)
             => new ValidationBuilder<T>(argument);
@@ -164,7 +152,6 @@ namespace McMaster.Extensions.CommandLineUtils
         /// By default, value comparison is case-sensitive. To make matches case-insensitive, set <paramref name="ignoreCase"/> to <c>true</c>.
         /// </para>
         /// </summary>
-        /// <param name="builder">The builder.</param>
         /// <param name="ignoreCase">Ignore case when parsing enums.</param>
         /// <exception cref="ArgumentException">When <typeparamref name="TEnum"/> is not an enum.</exception>
         /// <returns>The builder.</returns>
@@ -191,16 +178,12 @@ namespace McMaster.Extensions.CommandLineUtils
         /// By default, value comparison is case-sensitive. To make matches case-insensitive, use <see cref="Values(IValidationBuilder, bool, string[])"/>.
         /// </para>
         /// </summary>
-        /// <param name="builder">The builder.</param>
-        /// <param name="allowedValues">Allowed values.</param>
         /// <returns>The builder.</returns>
         public static IValidationBuilder Values(this IValidationBuilder builder, params string[] allowedValues)
             => builder.Values(ignoreCase: false, allowedValues: allowedValues);
 
         /// <summary> Specifies that values must be one of the values in a given set. </summary>
-        /// <param name="builder">The builder.</param>
         /// <param name="ignoreCase">Ignore case when comparing inputs to <paramref name="allowedValues"/>.</param>
-        /// <param name="allowedValues">Allowed values.</param>
         /// <returns>The builder.</returns>
         public static IValidationBuilder Values(this IValidationBuilder builder, bool ignoreCase, params string[] allowedValues)
         {
@@ -211,9 +194,7 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Specifies that values must be one of the values in a given set. </summary>
-        /// <param name="builder">The builder.</param>
         /// <param name="comparer">The comparer used to determine if values match.</param>
-        /// <param name="allowedValues">Allowed values.</param>
         /// <returns>The builder.</returns>
         public static IValidationBuilder Values(this IValidationBuilder builder, StringComparison comparer, params string[] allowedValues)
         {
@@ -221,63 +202,54 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Specifies that values must be a valid email address. </summary>
-        /// <param name="builder">The builder.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
         public static IValidationBuilder EmailAddress(this IValidationBuilder builder, string? errorMessage = null)
             => builder.Satisfies<EmailAddressAttribute>(errorMessage);
 
         /// <summary> Specifies that values must be a path to a file that already exists. </summary>
-        /// <param name="builder">The builder.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
         public static IValidationBuilder ExistingFile(this IValidationBuilder builder, string? errorMessage = null)
             => builder.Satisfies<FileExistsAttribute>(errorMessage);
 
         /// <summary> Specifies that values must be a path to a file that does not already exist. </summary>
-        /// <param name="builder">The builder.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
         public static IValidationBuilder NonExistingFile(this IValidationBuilder builder, string? errorMessage = null)
             => builder.Satisfies<FileNotExistsAttribute>(errorMessage);
 
         /// <summary> Specifies that values must be a path to a directory that already exists. </summary>
-        /// <param name="builder">The builder.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
         public static IValidationBuilder ExistingDirectory(this IValidationBuilder builder, string? errorMessage = null)
             => builder.Satisfies<DirectoryExistsAttribute>(errorMessage);
 
         /// <summary> Specifies that values must be a path to a directory that does not already exist. </summary>
-        /// <param name="builder">The builder.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
         public static IValidationBuilder NonExistingDirectory(this IValidationBuilder builder, string? errorMessage = null)
             => builder.Satisfies<DirectoryNotExistsAttribute>(errorMessage);
 
         /// <summary> Specifies that values must be a valid file path or directory, and the file path must already exist. </summary>
-        /// <param name="builder">The builder.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
         public static IValidationBuilder ExistingFileOrDirectory(this IValidationBuilder builder, string? errorMessage = null)
             => builder.Satisfies<FileOrDirectoryExistsAttribute>(errorMessage);
 
         /// <summary> Specifies that values must be a valid file path or directory, and the file path must not already exist. </summary>
-        /// <param name="builder">The builder.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
         public static IValidationBuilder NonExistingFileOrDirectory(this IValidationBuilder builder, string? errorMessage = null)
             => builder.Satisfies<FileOrDirectoryNotExistsAttribute>(errorMessage);
 
         /// <summary> Specifies that values must be legal file paths. </summary>
-        /// <param name="builder">The builder.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
         public static IValidationBuilder LegalFilePath(this IValidationBuilder builder, string? errorMessage = null)
             => builder.Satisfies<LegalFilePathAttribute>(errorMessage);
 
         /// <summary> Specifies that values must be a string at least <paramref name="length"/> characters long. </summary>
-        /// <param name="builder">The builder</param>
         /// <param name="length">The minimum length.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
@@ -285,7 +257,6 @@ namespace McMaster.Extensions.CommandLineUtils
             => builder.Satisfies<MinLengthAttribute>(errorMessage, length);
 
         /// <summary> Specifies that values must be a string no more than <paramref name="length"/> characters long. </summary>
-        /// <param name="builder">The builder.</param>
         /// <param name="length">The maximum length.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
@@ -293,7 +264,6 @@ namespace McMaster.Extensions.CommandLineUtils
             => builder.Satisfies<MaxLengthAttribute>(errorMessage, length);
 
         /// <summary> Specifies that values must match a regular expression. </summary>
-        /// <param name="builder">The builder.</param>
         /// <param name="pattern">The regular expression.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
@@ -302,7 +272,6 @@ namespace McMaster.Extensions.CommandLineUtils
 
         /// <summary> Specifies that values must satisfy the requirements of the validation attribute of type <typeparamref name="TAttribute"/>. </summary>
         /// <typeparam name="TAttribute">The validation attribute type.</typeparam>
-        /// <param name="builder">The builder.</param>
         /// <param name="ctorArgs">Constructor arguments for <typeparamref name="TAttribute"/>.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
@@ -316,7 +285,6 @@ namespace McMaster.Extensions.CommandLineUtils
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
         /// <summary> Specifies that values must be in a given range. </summary>
-        /// <param name="builder">The builder.</param>
         /// <param name="minimum">The minimum allowed value.</param>
         /// <param name="maximum">The maximum allowed value.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
@@ -331,7 +299,6 @@ namespace McMaster.Extensions.CommandLineUtils
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
         /// <summary> Specifies that values must be in a given range. </summary>
-        /// <param name="builder">The builder.</param>
         /// <param name="minimum">The minimum allowed value.</param>
         /// <param name="maximum">The maximum allowed value.</param>
         /// <param name="errorMessage">A custom error message to display.</param>
@@ -345,7 +312,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Adds a validator that runs after parsing is complete and before command execution. </summary>
-        /// <param name="command">The command.</param>
         /// <param name="validate">The callback. Return <see cref="ValidationResult.Success"/> if there is no error.</param>
         public static CommandLineApplication OnValidate(this CommandLineApplication command, Func<ValidationContext, ValidationResult> validate)
         {
@@ -354,7 +320,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Adds a validator that runs after parsing is complete and before command execution. </summary>
-        /// <param name="argument">The argument.</param>
         /// <param name="validate">The callback. Return <see cref="ValidationResult.Success"/> if there is no error.</param>
         public static CommandArgument OnValidate(this CommandArgument argument, Func<ValidationContext, ValidationResult> validate)
         {
@@ -363,7 +328,6 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary> Adds a validator that runs after parsing is complete and before command execution. </summary>
-        /// <param name="option">The option.</param>
         /// <param name="validate">The callback. Return <see cref="ValidationResult.Success"/> if there is no error.</param>
         public static CommandOption OnValidate(this CommandOption option, Func<ValidationContext, ValidationResult> validate)
         {

--- a/src/Hosting.CommandLine/HostBuilderExtensions.cs
+++ b/src/Hosting.CommandLine/HostBuilderExtensions.cs
@@ -13,9 +13,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.Extensions.Hosting
 {
-    /// <summary>
-    ///     Extension methods for <see cref="IHostBuilder" /> support.
-    /// </summary>
+    /// <summary> Extension methods for <see cref="IHostBuilder" /> support. </summary>
     /// <seealso href="https://github.com/natemcmaster/CommandLineUtils/issues/134">host support</seealso>
     public static class HostBuilderExtensions
     {

--- a/src/Hosting.CommandLine/HostBuilderExtensions.cs
+++ b/src/Hosting.CommandLine/HostBuilderExtensions.cs
@@ -23,7 +23,6 @@ namespace Microsoft.Extensions.Hosting
         ///     taken for command line applications.
         /// </summary>
         /// <typeparam name="TApp">The type of the command line application implementation</typeparam>
-        /// <param name="hostBuilder">This instance</param>
         /// <param name="args">The command line arguments</param>
         /// <param name="cancellationToken">A cancellation token</param>
         /// <returns>A task whose result is the exit code of the application</returns>

--- a/src/Hosting.CommandLine/HostBuilderExtensions.cs
+++ b/src/Hosting.CommandLine/HostBuilderExtensions.cs
@@ -24,7 +24,6 @@ namespace Microsoft.Extensions.Hosting
         /// </summary>
         /// <typeparam name="TApp">The type of the command line application implementation</typeparam>
         /// <param name="args">The command line arguments</param>
-        /// <param name="cancellationToken">A cancellation token</param>
         /// <returns>A task whose result is the exit code of the application</returns>
         public static async Task<int> RunCommandLineApplicationAsync<TApp>(
             this IHostBuilder hostBuilder, string[] args, CancellationToken cancellationToken = default)

--- a/src/Hosting.CommandLine/IUnhandledExceptionHandler.cs
+++ b/src/Hosting.CommandLine/IUnhandledExceptionHandler.cs
@@ -10,9 +10,7 @@ namespace McMaster.Extensions.Hosting.CommandLine
     /// </summary>
     public interface IUnhandledExceptionHandler
     {
-        /// <summary>
-        /// Handle otherwise uncaught exception. You are free to log, rethrow, … the exception 
-        /// </summary>
+        /// <summary> Handle otherwise uncaught exception. You are free to log, rethrow, … the exception  </summary>
         /// <param name="e">An otherwise uncaught exception</param>
         void HandleException(Exception e);
     }

--- a/src/Hosting.CommandLine/Internal/CommandLineLifetime.cs
+++ b/src/Hosting.CommandLine/Internal/CommandLineLifetime.cs
@@ -22,9 +22,7 @@ namespace McMaster.Extensions.Hosting.CommandLine.Internal
         private readonly IUnhandledExceptionHandler? _unhandledExceptionHandler;
         private readonly ManualResetEvent _blockProcessExit = new ManualResetEvent(false);
 
-        /// <summary>
-        ///     Creates a new instance.
-        /// </summary>
+        /// <summary> Creates a new instance. </summary>
         public CommandLineLifetime(IApplicationLifetime applicationLifetime,
             ICommandLineService cliService,
             IConsole console,
@@ -54,7 +52,6 @@ namespace McMaster.Extensions.Hosting.CommandLine.Internal
         ///     recorded and the application is stopped.
         /// </summary>
         /// <param name="cancellationToken">Used to indicate when stop should no longer be graceful.</param>
-        /// <returns></returns>
         /// <seealso cref="IHostLifetime.WaitForStartAsync(CancellationToken)" />
         public Task WaitForStartAsync(CancellationToken cancellationToken)
         {

--- a/src/Hosting.CommandLine/Internal/CommandLineService.cs
+++ b/src/Hosting.CommandLine/Internal/CommandLineService.cs
@@ -18,9 +18,7 @@ namespace McMaster.Extensions.Hosting.CommandLine.Internal
         private readonly ILogger _logger;
         private readonly CommandLineState _state;
 
-        /// <summary>
-        ///     Creates a new instance.
-        /// </summary>
+        /// <summary> Creates a new instance. </summary>
         /// <param name="logger">A logger</param>
         /// <param name="state">The command line state</param>
         /// <param name="serviceProvider">The DI service provider</param>

--- a/src/Hosting.CommandLine/Internal/CommandLineService.cs
+++ b/src/Hosting.CommandLine/Internal/CommandLineService.cs
@@ -19,7 +19,6 @@ namespace McMaster.Extensions.Hosting.CommandLine.Internal
         private readonly CommandLineState _state;
 
         /// <summary> Creates a new instance. </summary>
-        /// <param name="logger">A logger</param>
         /// <param name="state">The command line state</param>
         /// <param name="serviceProvider">The DI service provider</param>
         public CommandLineService(ILogger<CommandLineService<T>> logger, CommandLineState state,

--- a/src/Hosting.CommandLine/Internal/CommandLineState.cs
+++ b/src/Hosting.CommandLine/Internal/CommandLineState.cs
@@ -6,9 +6,7 @@ using McMaster.Extensions.CommandLineUtils.Abstractions;
 
 namespace McMaster.Extensions.Hosting.CommandLine.Internal
 {
-    /// <summary>
-    ///     A DI container for storing command line arguments.
-    /// </summary>
+    /// <summary> A DI container for storing command line arguments. </summary>
     internal class CommandLineState : CommandLineContext
     {
         public CommandLineState(string[] args)

--- a/src/Hosting.CommandLine/Internal/ICommandLineService.cs
+++ b/src/Hosting.CommandLine/Internal/ICommandLineService.cs
@@ -6,14 +6,10 @@ using System.Threading.Tasks;
 
 namespace McMaster.Extensions.Hosting.CommandLine.Internal
 {
-    /// <summary>
-    ///     A service to be run as part of the <see cref="CommandLineLifetime" />.
-    /// </summary>
+    /// <summary> A service to be run as part of the <see cref="CommandLineLifetime" />. </summary>
     internal interface ICommandLineService
     {
-        /// <summary>
-        ///     Runs the application asynchronously and returns the exit code.
-        /// </summary>
+        /// <summary> Runs the application asynchronously and returns the exit code. </summary>
         /// <param name="cancellationToken">Used to indicate when stop should no longer be graceful.</param>
         /// <returns>The exit code</returns>
         Task<int> RunAsync(CancellationToken cancellationToken);

--- a/src/Hosting.CommandLine/Internal/StoreExceptionHandler.cs
+++ b/src/Hosting.CommandLine/Internal/StoreExceptionHandler.cs
@@ -8,9 +8,7 @@ namespace McMaster.Extensions.Hosting.CommandLine.Internal
     /// </summary>
     internal class StoreExceptionHandler : IUnhandledExceptionHandler
     {
-        /// <summary>
-        /// The captured exception, if any
-        /// </summary>
+        /// <summary> The captured exception, if any </summary>
         public Exception? StoredException { get; private set; }
 
         /// <summary>

--- a/test/CommandLineUtils.Tests/CommandLineProcessorTests.cs
+++ b/test/CommandLineUtils.Tests/CommandLineProcessorTests.cs
@@ -131,14 +131,12 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         [Subcommand(typeof(ShortNameType))]
         private class ParentCommand
         {
-
         }
 
         [Command]
         [Subcommand(typeof(ParentCommand))]
         private class ParentParentCommand
         {
-
         }
 
         [Fact]

--- a/test/CommandLineUtils.Tests/ConstructorInjectionConventionTests.cs
+++ b/test/CommandLineUtils.Tests/ConstructorInjectionConventionTests.cs
@@ -90,7 +90,6 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         [Subcommand(typeof(Child))]
         private class Parent
         {
-
         }
 
         [Command("test")]

--- a/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
+++ b/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
@@ -161,7 +161,7 @@ Options:
         public class MyApp
         {
             [Option(ShortName = "strOpt", Description = "str option desc")]
-            public string strOpt{ get; set; }
+            public string strOpt { get; set; }
 
             [Option(ShortName = "intOpt", Description = "int option desc")]
             public int intOpt { get; set; }

--- a/test/CommandLineUtils.Tests/SubcommandAttributeTests.cs
+++ b/test/CommandLineUtils.Tests/SubcommandAttributeTests.cs
@@ -221,7 +221,6 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         [Command, Subcommand(typeof(SelfCycledCommand))]
         private class SelfCycledCommand
         {
-
         }
 
         [Fact]

--- a/test/CommandLineUtils.Tests/Utilities/CommandLineParser.cs
+++ b/test/CommandLineUtils.Tests/Utilities/CommandLineParser.cs
@@ -7,9 +7,7 @@ using Xunit.Abstractions;
 
 namespace McMaster.Extensions.CommandLineUtils
 {
-    /// <summary>
-    /// Utilities for parsing a command line application
-    /// </summary>
+    /// <summary> Utilities for parsing a command line application </summary>
     internal static class CommandLineParser
     {
         public static T ParseArgs<T>(params string[] args)


### PR DESCRIPTION
We remove around 1300 lines of code which is approximately 6,6% of the total lines of code consisting of excessive empty lines, empty comments, and short meaningles comments.
The stuff you get annoyed about when you speed-read code.

When we read code, we use techniques ranging from _scanning_ (fast-pased reading), to 
slow-pased _scrutiny_. 


              (code reading spectrum)
 
         fast                        slow 
       <---------------------------------->
    Scannning                     Scrutinizing


When discussing code readability, it often from the perspective slower-pased reading. 
I believe we do a great deal of _scanning_ when we read code. Much more than what is given credit. 
My belief is rooted in a lot of facts

  * Only source code is typeset with Mono-spaced fonts. Books, magazines , newspapers, etc. all use proportional fonts
  * Most programmers have an opinion and preference with regards to indentation size. The Linux kernel coding style serving one of the largest public code bases insist on indents being 8 characters to improve readability
  * 99.999% of programmer prefer using syntax highlighting and colors when working in editors/IDE's. 
  * 99.999% of code samples in programming blogs or Q/A sites like StackOverflow use syntax highligting and colors
  * People express difficulty in keeping concentration and focus when faced with code bases with large portions of text, that do not contribute meaning.

With this PR cleaning the code we impact code readability when _scanning_ code.

              (Scannning)
         
       ---------------------------- o ------>
       Impact

and much less so for when we are _scrutinizing_

              (scrutinizing)
         
       ---- o ------------------------------>
       Impact

