### PR TITLE
Issue 303: Fixed usage help to display [command] first then [options].

### DIFF
--- a/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
+++ b/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
@@ -145,6 +145,11 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
                 output.Write(stack.Pop());
             }
 
+            if (visibleCommands.Any())
+            {
+                output.Write(" [command]");
+            }
+
             if (visibleOptions.Any())
             {
                 output.Write(" [options]");
@@ -155,11 +160,6 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
                 output.Write(" <");
                 output.Write(argument.Name);
                 output.Write(">");
-            }
-
-            if (visibleCommands.Any())
-            {
-                output.Write(" [command]");
             }
 
             if (application.AllowArgumentSeparator)

--- a/test/CommandLineUtils.Tests/CommandLineApplicationTests.cs
+++ b/test/CommandLineUtils.Tests/CommandLineApplicationTests.cs
@@ -800,7 +800,7 @@ Examples:
                 outData = outWriter.ToString();
 
                 Assert.True(helpOption.HasValue());
-                Assert.Contains("Usage: lvl1 [options]", outData);
+                Assert.Contains("Usage: lvl1 [command] [options]", outData);
             }
         }
 

--- a/test/CommandLineUtils.Tests/HelpOptionAttributeTests.cs
+++ b/test/CommandLineUtils.Tests/HelpOptionAttributeTests.cs
@@ -181,9 +181,9 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         [InlineData(new[] { "get", "--help" }, "Usage: updater get [options]")]
         [InlineData(new[] { "get", "-h" }, "Usage: updater get [options]")]
         [InlineData(new[] { "get", "-?" }, "Usage: updater get [options]")]
-        [InlineData(new[] { "--help" }, "Usage: updater [options] [command]")]
-        [InlineData(new[] { "-h" }, "Usage: updater [options] [command]")]
-        [InlineData(new[] { "-?" }, "Usage: updater [options] [command]")]
+        [InlineData(new[] { "--help" }, "Usage: updater [command] [options]")]
+        [InlineData(new[] { "-h" }, "Usage: updater [command] [options]")]
+        [InlineData(new[] { "-?" }, "Usage: updater [command] [options]")]
         public void NestedHelpOptionsChoosesHelpOptionNearestSelectedCommand(string[] args, string helpNeedle)
         {
             var sb = new StringBuilder();

--- a/test/CommandLineUtils.Tests/SubcommandAttributeTests.cs
+++ b/test/CommandLineUtils.Tests/SubcommandAttributeTests.cs
@@ -140,7 +140,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             };
             var rc = CommandLineApplication.Execute<MasterApp>(console, "level1", "--help");
             Assert.Equal(0, rc);
-            Assert.Contains("Usage: master level1 [options]", sb.ToString());
+            Assert.Contains("Usage: master level1 [command] [options]", sb.ToString());
         }
 
         [Fact]
@@ -154,7 +154,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             };
             var rc = CommandLineApplication.Execute<MasterApp>(console, "--help");
             Assert.Equal(0, rc);
-            Assert.Contains("Usage: master [options]", sb.ToString());
+            Assert.Contains("Usage: master [command] [options]", sb.ToString());
         }
 
         [Fact]


### PR DESCRIPTION
Should be:
  Usage: mytool [command] [options]
instead of:
  Usage: mytool [options] [command]

Having any options in front of the command verb fails, so the usage help should reflect this.

I'm glad you're about to open a PR. Just a few tips before you click submit:

* Feel free to add a note to the CHANGELOG.md file and/or the releasenotes.props file. I'd like to give you credit for your work.
* Please make sure you read, or at least skimmed, CONTRIBUTING.md
* I may not take PRs if they come out of the blue and make big changes. 
  If you're not sure if something is a "big change", please open an issue first.
  
Thanks!
