### PR TITLE
Make ParserConfig internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 ## [v2.4.3](https://github.com/natemcmaster/CommandLineUtils/compare/v2.4.2...v2.4.3)
 
-* Fix [#292] by [@thomaslevesque](https://github.com/thomaslevesque) - fix deadlock when `Environment.Exit` is called
+* Fix [#292] by [@thomaslevesque] - fix deadlock when `Environment.Exit` is called
 
 [#292]: https://github.com/natemcmaster/CommandLineUtils/issues/292
 [@thomaslevesque]: https://github.com/thomaslevesque

--- a/src/CommandLineUtils/CommandLineApplication.cs
+++ b/src/CommandLineUtils/CommandLineApplication.cs
@@ -129,7 +129,7 @@ namespace McMaster.Extensions.CommandLineUtils
             SetContext(context);
             _services = new Lazy<IServiceProvider>(() => new ServiceProvider(this));
             ValueParsers = parent?.ValueParsers ?? new ValueParserProvider();
-            _parserConfig = parent?.ParserConfig ?? new ParserConfig();
+            _parserConfig = parent?._parserConfig ?? new ParserConfig();
             _clusterOptions = parent?._clusterOptions;
             UsePagerForHelpText = parent?.UsePagerForHelpText ?? true;
 
@@ -156,15 +156,6 @@ namespace McMaster.Extensions.CommandLineUtils
         {
             get => _helpTextGenerator;
             set => _helpTextGenerator = value ?? throw new ArgumentNullException(nameof(value));
-        }
-
-        /// <summary>
-        /// Configures the parser.
-        /// </summary>
-        public ParserConfig ParserConfig
-        {
-            get => _parserConfig;
-            set => _parserConfig = value ?? throw new ArgumentNullException(nameof(value));
         }
 
         /// <summary>
@@ -375,6 +366,25 @@ namespace McMaster.Extensions.CommandLineUtils
         private bool? _clusterOptions;
 
         internal bool ClusterOptionsWasSetExplicitly => _clusterOptions.HasValue;
+
+        /// <summary>
+        /// Characters used to separate the option name from the value.
+        /// <para>
+        /// By default, allowed separators are ' ' (space), :, and =
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// Space actually implies multiple spaces due to the way most operating system shells parse command
+        /// line arguments before starting a new process.
+        /// </remarks>
+        /// <example>
+        /// Given --name=value, = is the separator.
+        /// </example>
+        public char[] OptionNameValueSeparators
+        {
+            get => _parserConfig.OptionNameValueSeparators;
+            set => _parserConfig.OptionNameValueSeparators = value;
+        }
 
         /// <summary>
         /// Gets the default value parser provider.
@@ -769,7 +779,7 @@ namespace McMaster.Extensions.CommandLineUtils
 
             args ??= Util.EmptyArray<string>();
 
-            var processor = new CommandLineProcessor(this, ParserConfig, args);
+            var processor = new CommandLineProcessor(this, _parserConfig, args);
             var result = processor.Process();
             result.SelectedCommand.HandleParseResult(result);
             return result;

--- a/src/CommandLineUtils/Internal/ParserConfig.cs
+++ b/src/CommandLineUtils/Internal/ParserConfig.cs
@@ -8,7 +8,7 @@ namespace McMaster.Extensions.CommandLineUtils
     /// <summary>
     /// Configures the argument parser.
     /// </summary>
-    public class ParserConfig
+    internal class ParserConfig
     {
         private char[] _optionNameValueSeparators = { ' ', ':', '=' };
 

--- a/src/CommandLineUtils/Internal/ReflectionHelper.cs
+++ b/src/CommandLineUtils/Internal/ReflectionHelper.cs
@@ -104,11 +104,11 @@ namespace McMaster.Extensions.CommandLineUtils
             return result;
         }
 
-        static IEnumerable<MemberInfo> GetAllMembers(TypeInfo typeInfo)
+        private static IEnumerable<MemberInfo> GetAllMembers(TypeInfo typeInfo)
         {
             const BindingFlags binding = BindingFlags.Instance | BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.DeclaredOnly;
 
-            while (typeInfo != null) 
+            while (typeInfo != null)
             {
                 var members = typeInfo.GetMembers(binding);
                 foreach (var member in members)

--- a/src/CommandLineUtils/PublicAPI.Unshipped.txt
+++ b/src/CommandLineUtils/PublicAPI.Unshipped.txt
@@ -1,6 +1,2 @@
-McMaster.Extensions.CommandLineUtils.CommandLineApplication.ParserConfig.get -> McMaster.Extensions.CommandLineUtils.ParserConfig
-McMaster.Extensions.CommandLineUtils.CommandLineApplication.ParserConfig.set -> void
-McMaster.Extensions.CommandLineUtils.ParserConfig
-McMaster.Extensions.CommandLineUtils.ParserConfig.ParserConfig() -> void
-McMaster.Extensions.CommandLineUtils.ParserConfig.OptionNameValueSeparators.get -> char[]
-McMaster.Extensions.CommandLineUtils.ParserConfig.OptionNameValueSeparators.set -> void
+McMaster.Extensions.CommandLineUtils.CommandLineApplication.OptionNameValueSeparators.get -> char[]
+McMaster.Extensions.CommandLineUtils.CommandLineApplication.OptionNameValueSeparators.set -> void

--- a/test/CommandLineUtils.Tests/CommandLineApplicationTests.cs
+++ b/test/CommandLineUtils.Tests/CommandLineApplicationTests.cs
@@ -631,7 +631,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         public void OptionNameCanHaveSemicolon()
         {
             var app = new CommandLineApplication();
-            app.ParserConfig.OptionNameValueSeparators = new[] { ' ', '=' };
+            app.OptionNameValueSeparators = new[] { ' ', '=' };
             var option = new CommandOption(CommandOptionType.SingleValue)
             {
                 LongName = "debug:hive"
@@ -645,7 +645,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         public void OptionSeparatorMustNotUseSpace()
         {
             var app = new CommandLineApplication();
-            app.ParserConfig.OptionNameValueSeparators = new[] { '=' };
+            app.OptionNameValueSeparators = new[] { '=' };
             var option = new CommandOption(CommandOptionType.SingleValue)
             {
                 LongName = "debug:hive"


### PR DESCRIPTION
I added this API without anyone reviewing to resolve #252. After thinking about it more, I'm not sure the factoring is right just yet. I think it would be good to extract an class to represent parsing options, but I'm not ready to release an API for it yet. Making this internal while I work on the factoring.