### PR TITLE
Delete pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,0 @@
-I'm glad you're about to open a PR. Just a few tips before you click submit:
-
-* Feel free to add a note to the CHANGELOG.md file and/or the releasenotes.props file. I'd like to give you credit for your work.
-* Please make sure you read, or at least skimmed, CONTRIBUTING.md
-* I may not take PRs if they come out of the blue and make big changes. 
-  If you're not sure if something is a "big change", please open an issue first.
-  
-Thanks!


### PR DESCRIPTION
This template was added a while ago. GitHub has since made improvements to the "new pull request" pages which I believe make this template obsolete.