### PR TITLE
Update DotNetExe.cs

### DIFF
--- a/src/CommandLineUtils/Utilities/DotNetExe.cs
+++ b/src/CommandLineUtils/Utilities/DotNetExe.cs
@@ -24,10 +24,11 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <summary>
         /// The full filepath to the .NET Core CLI executable.
         /// <para>
-        /// May be <c>null</c> if the CLI cannot be found. <seealso cref="FullPathOrDefault" />
+        /// May be <c>null</c> if the CLI cannot be found.
         /// </para>
         /// </summary>
         /// <returns>The path or null</returns>
+        /// <seealso cref="FullPathOrDefault" />
         public static string? FullPath { get; }
 
         /// <summary>


### PR DESCRIPTION
Moving the `<seealso>` outside of the `<summary>` should make the resulting docs include a "see also" section, rather than just a confusing hyperlink. See the [FullPath documentation](https://natemcmaster.github.io/CommandLineUtils/v2.4/api/McMaster.Extensions.CommandLineUtils.DotNetExe.html#McMaster_Extensions_CommandLineUtils_DotNetExe_FullPath).