### PR TITLE
docs: fix all <seealso> tags in XML docs and reformat code

### DIFF
--- a/src/CommandLineUtils/Attributes/ArgumentAttribute.cs
+++ b/src/CommandLineUtils/Attributes/ArgumentAttribute.cs
@@ -9,8 +9,8 @@ namespace McMaster.Extensions.CommandLineUtils
     /// <summary>
     /// Represents one or many positional command line arguments.
     /// Arguments are parsed based the <see cref="Order"/> given.
-    /// Compare to <seealso cref="OptionAttribute"/>.
     /// </summary>
+    /// <seealso cref="OptionAttribute"/>
     [AttributeUsage(AttributeTargets.Property)]
     public sealed class ArgumentAttribute : Attribute
     {
@@ -50,18 +50,21 @@ namespace McMaster.Extensions.CommandLineUtils
         public int Order { get; set; }
 
         /// <summary>
-        /// The name of the argument. <seealso cref="CommandArgument.Name"/>.
+        /// The name of the argument.
         /// </summary>
+        /// <seealso cref="CommandArgument.Name"/>
         public string? Name { get; set; }
 
         /// <summary>
-        /// Determines if the argument appears in the generated help-text.  <seealso cref="CommandArgument.ShowInHelpText"/>.
+        /// Determines if the argument appears in the generated help-text.
         /// </summary>
+        /// <seealso cref="CommandArgument.ShowInHelpText"/>
         public bool ShowInHelpText { get; set; } = true;
 
         /// <summary>
-        /// A description of the argument.  <seealso cref="CommandArgument.Description"/>.
+        /// A description of the argument.
         /// </summary>
+        /// <seealso cref="CommandArgument.Description"/>
         public string? Description { get; set; }
 
         internal CommandArgument Configure(PropertyInfo prop)

--- a/src/CommandLineUtils/Attributes/CommandAttribute.cs
+++ b/src/CommandLineUtils/Attributes/CommandAttribute.cs
@@ -42,8 +42,8 @@ namespace McMaster.Extensions.CommandLineUtils
 
         /// <summary>
         /// The name of the command line application. When this is a subcommand, it is the name of the word used to invoke the subcommand.
-        /// <seealso cref="CommandLineApplication.Name" />
         /// </summary>
+        /// <seealso cref="CommandLineApplication.Name" />
         public string? Name
         {
             get => _names.Length > 0 ? _names[0] : null;
@@ -66,38 +66,45 @@ namespace McMaster.Extensions.CommandLineUtils
         public IEnumerable<string> Names => _names;
 
         /// <summary>
-        /// The full name of the command line application to show in help text. <seealso cref="CommandLineApplication.FullName" />
+        /// The full name of the command line application to show in help text.
         /// </summary>
+        /// <seealso cref="CommandLineApplication.FullName" />
         public string? FullName { get; set; }
 
         /// <summary>
-        /// A description of the command. <seealso cref="CommandLineApplication.Description"/>
+        /// A description of the command.
         /// </summary>
+        /// <seealso cref="CommandLineApplication.Description"/>
         public string? Description { get; set; }
 
         /// <summary>
-        /// Determines if this command appears in generated help text. <seealso cref="CommandLineApplication.ShowInHelpText"/>
+        /// Determines if this command appears in generated help text.
         /// </summary>
+        /// <seealso cref="CommandLineApplication.ShowInHelpText"/>
         public bool ShowInHelpText { get; set; } = true;
 
         /// <summary>
-        /// Additional text that appears at the bottom of generated help text. <seealso cref="CommandLineApplication.ExtendedHelpText"/>
+        /// Additional text that appears at the bottom of generated help text.
         /// </summary>
+        /// <seealso cref="CommandLineApplication.ExtendedHelpText"/>
         public string? ExtendedHelpText { get; set; }
 
         /// <summary>
-        /// Throw when unexpected arguments are encountered. <seealso cref="CommandLineApplication.ThrowOnUnexpectedArgument"/>
+        /// Throw when unexpected arguments are encountered.
         /// </summary>
+        /// <seealso cref="CommandLineApplication.ThrowOnUnexpectedArgument"/>
         public bool ThrowOnUnexpectedArgument { get; set; } = true;
 
         /// <summary>
-        /// Allow '--' to be used to stop parsing arguments. <seealso cref="CommandLineApplication.AllowArgumentSeparator"/>
+        /// Allow '--' to be used to stop parsing arguments.
         /// </summary>
+        /// <seealso cref="CommandLineApplication.AllowArgumentSeparator"/>
         public bool AllowArgumentSeparator { get; set; }
 
         /// <summary>
-        /// Treat arguments beginning as '@' as a response file. <seealso cref="CommandLineApplication.ResponseFileHandling"/>
+        /// Treat arguments beginning as '@' as a response file.
         /// </summary>
+        /// <seealso cref="CommandLineApplication.ResponseFileHandling"/>
         public ResponseFileHandling ResponseFileHandling { get; set; } = ResponseFileHandling.Disabled;
 
         /// <summary>

--- a/src/CommandLineUtils/Attributes/OptionAttribute.cs
+++ b/src/CommandLineUtils/Attributes/OptionAttribute.cs
@@ -61,8 +61,9 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary>
-        /// Defines the type of the option. When not set, this will be inferred from the CLR type of the property. <seealso cref="CommandOption.OptionType"/>
+        /// Defines the type of the option. When not set, this will be inferred from the CLR type of the property.
         /// </summary>
+        /// <seealso cref="CommandOption.OptionType"/>
         public CommandOptionType? OptionType { get; set; }
 
         internal CommandOption Configure(CommandLineApplication app, PropertyInfo prop)

--- a/src/CommandLineUtils/Attributes/OptionAttributeBase.cs
+++ b/src/CommandLineUtils/Attributes/OptionAttributeBase.cs
@@ -37,19 +37,22 @@ namespace McMaster.Extensions.CommandLineUtils
         public string? ValueName { get; set; }
 
         /// <summary>
-        /// A description of this option to show in generated help text. <seealso cref="CommandOption.Description"/>.
+        /// A description of this option to show in generated help text.
         /// </summary>
+        /// <seealso cref="CommandOption.Description"/>
         public string? Description { get; set; }
 
         /// <summary>
-        /// Determines if this option should be shown in generated help text. <seealso cref="CommandOption.ShowInHelpText"/>.
+        /// Determines if this option should be shown in generated help text.
         /// </summary>
+        /// <seealso cref="CommandOption.ShowInHelpText"/>
         public bool ShowInHelpText { get; set; } = true;
 
         /// <summary>
         /// Determines if subcommands added to <see cref="CommandLineApplication.Commands"/>
-        /// should also have access to this option. <seealso cref="CommandOption.Inherited"/>.
+        /// should also have access to this option.
         /// </summary>
+        /// <seealso cref="CommandOption.Inherited"/>
         public bool Inherited { get; set; }
 
         internal void Configure(CommandOption option)

--- a/src/CommandLineUtils/Attributes/VersionOptionAttribute.cs
+++ b/src/CommandLineUtils/Attributes/VersionOptionAttribute.cs
@@ -23,7 +23,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <summary>
         /// Initializes a new <see cref="VersionOptionAttribute"/>.
         /// </summary>
-        /// <param name="template">The string template. <seealso cref="CommandOption.Template"/>.</param>
+        /// <param name="template">The string template that will be used for <see cref="CommandOption.Template"/>.</param>
         /// <param name="version">The version</param>
         public VersionOptionAttribute(string template, string version)
         {

--- a/src/CommandLineUtils/CommandArgument.cs
+++ b/src/CommandLineUtils/CommandArgument.cs
@@ -12,8 +12,8 @@ namespace McMaster.Extensions.CommandLineUtils
     /// <summary>
     /// Represents one or many positional command line arguments.
     /// Arguments are parsed in the order in which <see cref="CommandLineApplication.Arguments"/> lists them.
-    /// Compare to <seealso cref="CommandOption"/>.
     /// </summary>
+    /// <seealso cref="CommandOption"/>
     public class CommandArgument
     {
         /// <summary>

--- a/src/CommandLineUtils/CommandArgument{T}.cs
+++ b/src/CommandLineUtils/CommandArgument{T}.cs
@@ -13,9 +13,9 @@ namespace McMaster.Extensions.CommandLineUtils
     /// <summary>
     /// Represents one or many positional command line arguments.
     /// Arguments are parsed in the order in which <see cref="CommandLineApplication.Arguments"/> lists them.
-    /// Compare to <seealso cref="CommandOption"/>. The raw value must be
-    /// parsable into type <typeparamref name="T" />
+    /// The raw value must be parsable into type <typeparamref name="T" />.
     /// </summary>
+    /// <seealso cref="CommandOption"/>
     public class CommandArgument<T> : CommandArgument, IInternalCommandParamOfT
     {
         private readonly List<T> _parsedValues = new List<T>();

--- a/src/CommandLineUtils/CommandLineApplication.Execute.cs
+++ b/src/CommandLineUtils/CommandLineApplication.Execute.cs
@@ -20,9 +20,11 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <summary>
         /// Creates an instance of <typeparamref name="TApp"/>, matching <see cref="CommandLineContext.Arguments"/>
         /// to all attributes on the type, and then invoking a method named "OnExecute" or "OnExecuteAsync" if it exists.
-        /// See <seealso cref="OptionAttribute" />, <seealso cref="ArgumentAttribute" />,
-        /// <seealso cref="HelpOptionAttribute"/>, and <seealso cref="VersionOptionAttribute"/>.
         /// </summary>
+        /// <seealso cref="OptionAttribute" />
+        /// <seealso cref="ArgumentAttribute" />
+        /// <seealso cref="HelpOptionAttribute"/>
+        /// <seealso cref="VersionOptionAttribute"/>
         /// <param name="context">The execution context.</param>
         /// <typeparam name="TApp">A type that should be bound to the arguments.</typeparam>
         /// <exception cref="InvalidOperationException">Thrown when attributes are incorrectly configured.</exception>
@@ -35,9 +37,11 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <summary>
         /// Creates an instance of <typeparamref name="TApp"/>, matching <see cref="CommandLineContext.Arguments"/>
         /// to all attributes on the type, and then invoking a method named "OnExecute" or "OnExecuteAsync" if it exists.
-        /// See <seealso cref="OptionAttribute" />, <seealso cref="ArgumentAttribute" />,
-        /// <seealso cref="HelpOptionAttribute"/>, and <seealso cref="VersionOptionAttribute"/>.
         /// </summary>
+        /// <seealso cref="OptionAttribute" />
+        /// <seealso cref="ArgumentAttribute" />
+        /// <seealso cref="HelpOptionAttribute"/>
+        /// <seealso cref="VersionOptionAttribute"/>
         /// <param name="context">The execution context.</param>
         /// <param name="cancellationToken"></param>
         /// <typeparam name="TApp">A type that should be bound to the arguments.</typeparam>
@@ -92,9 +96,11 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <summary>
         /// Creates an instance of <typeparamref name="TApp"/>, matching <paramref name="args"/>
         /// to all attributes on the type, and then invoking a method named "OnExecute" or "OnExecuteAsync" if it exists.
-        /// See <seealso cref="OptionAttribute" />, <seealso cref="ArgumentAttribute" />,
-        /// <seealso cref="HelpOptionAttribute"/>, and <seealso cref="VersionOptionAttribute"/>.
         /// </summary>
+        /// <seealso cref="OptionAttribute" />
+        /// <seealso cref="ArgumentAttribute" />
+        /// <seealso cref="HelpOptionAttribute"/>
+        /// <seealso cref="VersionOptionAttribute"/>
         /// <param name="args">The arguments</param>
         /// <typeparam name="TApp">A type that should be bound to the arguments.</typeparam>
         /// <exception cref="InvalidOperationException">Thrown when attributes are incorrectly configured.</exception>
@@ -106,9 +112,11 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <summary>
         /// Creates an instance of <typeparamref name="TApp"/>, matching <paramref name="args"/>
         /// to all attributes on the type, and then invoking a method named "OnExecute" or "OnExecuteAsync" if it exists.
-        /// See <seealso cref="OptionAttribute" />, <seealso cref="ArgumentAttribute" />,
-        /// <seealso cref="HelpOptionAttribute"/>, and <seealso cref="VersionOptionAttribute"/>.
         /// </summary>
+        /// <seealso cref="OptionAttribute" />
+        /// <seealso cref="ArgumentAttribute" />
+        /// <seealso cref="HelpOptionAttribute"/>
+        /// <seealso cref="VersionOptionAttribute"/>
         /// <param name="console">The console to use</param>
         /// <param name="args">The arguments</param>
         /// <typeparam name="TApp">A type that should be bound to the arguments.</typeparam>
@@ -125,9 +133,11 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <summary>
         /// Creates an instance of <typeparamref name="TApp"/>, matching <paramref name="args"/>
         /// to all attributes on the type, and then invoking a method named "OnExecute" or "OnExecuteAsync" if it exists.
-        /// See <seealso cref="OptionAttribute" />, <seealso cref="ArgumentAttribute" />,
-        /// <seealso cref="HelpOptionAttribute"/>, and <seealso cref="VersionOptionAttribute"/>.
         /// </summary>
+        /// <seealso cref="OptionAttribute" />
+        /// <seealso cref="ArgumentAttribute" />
+        /// <seealso cref="HelpOptionAttribute"/>
+        /// <seealso cref="VersionOptionAttribute"/>
         /// <param name="args">The arguments</param>
         /// <typeparam name="TApp">A type that should be bound to the arguments.</typeparam>
         /// <exception cref="InvalidOperationException">Thrown when attributes are incorrectly configured.</exception>
@@ -140,9 +150,11 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <summary>
         /// Creates an instance of <typeparamref name="TApp"/>, matching <paramref name="args"/>
         /// to all attributes on the type, and then invoking a method named "OnExecute" or "OnExecuteAsync" if it exists.
-        /// See <seealso cref="OptionAttribute" />, <seealso cref="ArgumentAttribute" />,
-        /// <seealso cref="HelpOptionAttribute"/>, and <seealso cref="VersionOptionAttribute"/>.
         /// </summary>
+        /// <seealso cref="OptionAttribute" />
+        /// <seealso cref="ArgumentAttribute" />
+        /// <seealso cref="HelpOptionAttribute"/>
+        /// <seealso cref="VersionOptionAttribute"/>
         /// <param name="args">The arguments</param>
         /// <param name="cancellationToken"></param>
         /// <typeparam name="TApp">A type that should be bound to the arguments.</typeparam>
@@ -160,9 +172,11 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <summary>
         /// Creates an instance of <typeparamref name="TApp"/>, matching <paramref name="args"/>
         /// to all attributes on the type, and then invoking a method named "OnExecute" or "OnExecuteAsync" if it exists.
-        /// See <seealso cref="OptionAttribute" />, <seealso cref="ArgumentAttribute" />,
-        /// <seealso cref="HelpOptionAttribute"/>, and <seealso cref="VersionOptionAttribute"/>.
         /// </summary>
+        /// <seealso cref="OptionAttribute" />
+        /// <seealso cref="ArgumentAttribute" />
+        /// <seealso cref="HelpOptionAttribute"/>
+        /// <seealso cref="VersionOptionAttribute"/>
         /// <param name="console">The console to use</param>
         /// <param name="args">The arguments</param>
         /// <typeparam name="TApp">A type that should be bound to the arguments.</typeparam>

--- a/src/CommandLineUtils/Validation/ValidationExtensions.cs
+++ b/src/CommandLineUtils/Validation/ValidationExtensions.cs
@@ -19,7 +19,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// </summary>
         /// <param name="option">The option.</param>
         /// <param name="allowEmptyStrings">Indicates whether an empty string is allowed.</param>
-        /// <param name="errorMessage">The custom error message to display. See also <seealso cref="ValidationAttribute.ErrorMessage"/>.</param>
+        /// <param name="errorMessage">The custom error message to display. See also: <see cref="ValidationAttribute.ErrorMessage"/>.</param>
         /// <returns>The option.</returns>
         public static CommandOption IsRequired(this CommandOption option, bool allowEmptyStrings = false, string? errorMessage = null)
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
@@ -36,7 +36,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// </summary>
         /// <param name="option">The option.</param>
         /// <param name="allowEmptyStrings">Indicates whether an empty string is allowed.</param>
-        /// <param name="errorMessage">The custom error message to display. See also <seealso cref="ValidationAttribute.ErrorMessage"/>.</param>
+        /// <param name="errorMessage">The custom error message to display. See also: <see cref="ValidationAttribute.ErrorMessage"/>.</param>
         /// <returns>The option.</returns>
         public static CommandOption<T> IsRequired<T>(this CommandOption<T> option, bool allowEmptyStrings = false,
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
@@ -53,7 +53,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="allowEmptyStrings">Indicates whether an empty string is allowed.</param>
-        /// <param name="errorMessage">The custom error message to display. See also <seealso cref="ValidationAttribute.ErrorMessage"/>.</param>
+        /// <param name="errorMessage">The custom error message to display. See also: <see cref="ValidationAttribute.ErrorMessage"/>.</param>
         /// <returns>The argument.</returns>
         public static CommandArgument IsRequired(this CommandArgument argument, bool allowEmptyStrings = false, string? errorMessage = null)
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
@@ -70,7 +70,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="allowEmptyStrings">Indicates whether an empty string is allowed.</param>
-        /// <param name="errorMessage">The custom error message to display. See also <seealso cref="ValidationAttribute.ErrorMessage"/>.</param>
+        /// <param name="errorMessage">The custom error message to display. See also: <see cref="ValidationAttribute.ErrorMessage"/>.</param>
         /// <returns>The argument.</returns>
         public static CommandArgument<T> IsRequired<T>(this CommandArgument<T> argument, bool allowEmptyStrings = false, string? errorMessage = null)
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters

--- a/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
+++ b/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
@@ -69,7 +69,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             app.Conventions.UseDefaultConventions();
             app.Command("b", _ => { });
             app.Command("a", _ => { });
-            var generator = new DefaultHelpTextGenerator() {SortCommandsByName = false};
+            var generator = new DefaultHelpTextGenerator() { SortCommandsByName = false };
             var helpText = GetHelpText(app, generator);
 
             var indexOfA = helpText.IndexOf("  a", StringComparison.InvariantCulture);
@@ -135,7 +135,7 @@ Options:
         [Fact]
         public void ShowHelpFromAttributes()
         {
-            var app = new CommandLineApplication<MyApp>(){Name = "test"};
+            var app = new CommandLineApplication<MyApp>() { Name = "test" };
             app.Conventions.UseDefaultConventions();
             var helpText = GetHelpText(app);
 
@@ -161,7 +161,7 @@ Options:
         public class MyApp
         {
             [Option(ShortName = "strOpt", Description = "str option desc")]
-            public string strOpt{ get; set; }
+            public string strOpt { get; set; }
 
             [Option(ShortName = "intOpt", Description = "int option desc")]
             public int intOpt { get; set; }


### PR DESCRIPTION
Same fix as #319 , but everywhere