### PR TITLE
Bump version to 3.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -46,8 +46,8 @@
   </PropertyGroup>
 
    <PropertyGroup>
-    <VersionPrefix>2.5.0</VersionPrefix>
-    <VersionSuffix>rc</VersionSuffix>
+    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionSuffix>alpha</VersionSuffix>
     <IncludePreReleaseLabelInPackageVersion Condition="'$(IsStableBuild)' != 'true'">true</IncludePreReleaseLabelInPackageVersion>
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">$(BUILD_NUMBER)</BuildNumber>
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">0</BuildNumber>


### PR DESCRIPTION
Starting work on 3.0 https://github.com/natemcmaster/CommandLineUtils/issues/326. After this merges, we can start accepting changes for 3.0 and producing nightlies of 3.0 builds.

Also, I have created a "release/2.x" branch in the event we need to release hot fixes for 2.x before 3.0 is done. https://github.com/natemcmaster/CommandLineUtils/tree/release/2.x

cc @vpkopylov 