### PR TITLE
[2.5.1] lazy load command object types to reduce unnecessary allocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 [Unreleased changes](https://github.com/natemcmaster/CommandLineUtils/compare/v2.5.0...HEAD):
 
+## [v2.5.1](https://github.com/natemcmaster/CommandLineUtils/compare/v2.5.0...v2.5.1)
+
+* Fix [#320] - lazy load command object types to reduce unnecessary allocations
+
 ## [v2.5.0](https://github.com/natemcmaster/CommandLineUtils/compare/v2.4.4...v2.5.0)
 
 * Fix [#92] by [@kbilsted] - Show enum names in help text for Options and Arguments stored as enum

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -46,7 +46,7 @@
   </PropertyGroup>
 
    <PropertyGroup>
-    <VersionPrefix>2.5.0</VersionPrefix>
+    <VersionPrefix>2.5.1</VersionPrefix>
     <VersionSuffix>rc</VersionSuffix>
     <IncludePreReleaseLabelInPackageVersion Condition="'$(IsStableBuild)' != 'true'">true</IncludePreReleaseLabelInPackageVersion>
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">$(BUILD_NUMBER)</BuildNumber>

--- a/src/CommandLineUtils/CommandLineApplication{T}.cs
+++ b/src/CommandLineUtils/CommandLineApplication{T}.cs
@@ -115,10 +115,9 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <inheritdoc />
+        // TODO remove in 3.0. This doesn't do anything anymore.
         protected override void HandleParseResult(ParseResult parseResult)
         {
-            (this as IModelAccessor).GetModel();
-
             base.HandleParseResult(parseResult);
         }
 
@@ -127,7 +126,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <inheritdoc />
         public override void Dispose()
         {
-            if (Model is IDisposable dt)
+            if (_lazy.IsValueCreated && Model is IDisposable dt)
             {
                 dt.Dispose();
             }

--- a/src/CommandLineUtils/releasenotes.props
+++ b/src/CommandLineUtils/releasenotes.props
@@ -7,6 +7,9 @@ Features and bug fixes:
 * @Alxandr: Add support for private base type options
 * @AndreGleichner: Update generated help to display [command] first then [options]
 * @daveMueller: Fix generated help to display the help options correctly
+
+Patch 2.5.1:
+* Lazy load command object types to reduce unnecessary allocations
     </PackageReleaseNotes>
     <PackageReleaseNotes Condition="$(VersionPrefix.StartsWith('2.4.'))">
 Features and bug fixes by some awesome contributors:

--- a/test/CommandLineUtils.Tests/CommandLineApplicationExecutorTests.cs
+++ b/test/CommandLineUtils.Tests/CommandLineApplicationExecutorTests.cs
@@ -293,7 +293,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         public void DisposesSubCommands()
         {
             var ex = Assert.Throws<InvalidOperationException>(
-                () => CommandLineApplication.Execute<ParentCommand>(NullConsole.Singleton, "sub"));
+                () => CommandLineApplication.Execute<ParentCommand>(NullConsole.Singleton, "disposable"));
             Assert.Equal("Hello", ex.Message);
         }
 
@@ -312,8 +312,12 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         [Command("sub")]
         private class Subcommand
         {
+            public DisposableParentCommand Parent { get; }
+            
             public void OnExecute()
-            { }
+            {
+                Assert.NotNull(Parent);
+            }
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #320 

* The default implementation of `CommandLineApplication<T>.HandleParseResult` is initializing the model class. This may not be necessary, depending on which conventions have been applied. Removing this prevents potentially unnecessary (and expensive) object initializations.
* `CommandLineApplication<T>.Dispose()` can actually initialize the Model class, which is just wrong. This fixes that too

cc @wtyneb 