### PR TITLE
Reference hosting abstractions from M.E.Hosting.CommandLine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,16 @@
 
 [Unreleased changes](https://github.com/natemcmaster/CommandLineUtils/compare/v2.5.0...HEAD):
 
-* Fix [#251] by [@mattnischan] - remove obsolete APIs
+### Breaking changes
+
+* Fix [#251] by [@mattnischan] - remove API that was marked as obsolete in 2.x releases
+* Fix [#294] by [@natemcmaster] - change dependencies on McMaster.Extensions.Hosting.CommandLine to just use Microsoft.Extensions.Hosting.Abstractions
 
 [@mattnischan]: https://github.com/mattnischan
+[@natemcmaster]: https://github.com/natemcmaster
 
 [#251]: https://github.com/natemcmaster/CommandLineUtils/issues/251
+[#294]: https://github.com/natemcmaster/CommandLineUtils/issues/294
 
 ## [v2.5.1](https://github.com/natemcmaster/CommandLineUtils/compare/v2.5.0...v2.5.1)
 

--- a/docs/docs/advanced/generic-host.md
+++ b/docs/docs/advanced/generic-host.md
@@ -8,9 +8,12 @@ The McMaster.Extensions.Hosting.CommandLine package provides support for integra
 
 ## Get started
 
-To get started, install the `McMaster.Extensions.Hosting.CommandLine` package.
+To get started, install the [McMaster.Extensions.Hosting.CommandLine] and [Microsoft.Extensions.Hosting] packages.
 The main usage for generic host is `RunCommandLineApplicationAsync<TApp>(args)`, where `TApp` is a class
 which will be bound to command line arguments and options using attributes and `CommandLineApplication.Execute<T>`.
+
+[McMaster.Extensions.Hosting.CommandLine]: https://nuget.org/packages/McMaster.Extensions.Hosting.CommandLine
+[Microsoft.Extensions.Hosting]: https://nuget.org/packages/Microsoft.Extensions.Hosting
 
 ### Sample
 

--- a/docs/samples/dependency-injection/generic-host/GenericHostDI.csproj
+++ b/docs/samples/dependency-injection/generic-host/GenericHostDI.csproj
@@ -1,13 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\Hosting.CommandLine\McMaster.Extensions.Hosting.CommandLine.csproj" />
   </ItemGroup>
+
 </Project>

--- a/docs/samples/generic-host/GenericHost.csproj
+++ b/docs/samples/generic-host/GenericHost.csproj
@@ -3,8 +3,11 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.1.1" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Hosting.CommandLine\McMaster.Extensions.Hosting.CommandLine.csproj" />

--- a/docs/v3.0/upgrade-guide.md
+++ b/docs/v3.0/upgrade-guide.md
@@ -1,0 +1,23 @@
+---
+uid: 2.x-to-3.0-upgrade
+---
+# Upgrading to CommandLineUtils 3.0
+
+## Upgrading McMaster.Extensions.Hosting.CommandLine
+
+In order to fix [#294], McMaster.Extensions.Hosting.CommandLine 3.0's dependency on Microsoft.Extensions.Hosting
+was lowered to a dependency on Microsoft.Extensions.Hosting.**Abstractions**. In some cases, this could
+cause your app to fail to compile when you upgrade with errors.
+
+[#294]: https://github.com/natemcmaster/CommandLineUtils/issues/294
+
+### Symptom
+
+After upgrading to 3.0, your app fails to compile with
+
+> error CS0246: The type or namespace name 'HostBuilder' could not be found"
+
+### Resolution
+
+Add a dependency on [Microsoft.Extensions.Hosting](https://nuget.org/packages/Microsoft.Extensions.Hosting)
+

--- a/src/Hosting.CommandLine/McMaster.Extensions.Hosting.CommandLine.csproj
+++ b/src/Hosting.CommandLine/McMaster.Extensions.Hosting.CommandLine.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Hosting.CommandLine/releasenotes.props
+++ b/src/Hosting.CommandLine/releasenotes.props
@@ -1,5 +1,11 @@
 <Project>
   <PropertyGroup>
+    <PackageReleaseNotes Condition="$(VersionPrefix.StartsWith('3.0.'))">
+Changes:
+* Dependency on Microsoft.Extensions.Hosting lowered to Microsoft.Extensions.Hosting.Abstractions.
+  You may need to add a direct reference to Microsoft.Extensions.Hosting if this is not already in your
+  project's dependencies.
+    </PackageReleaseNotes>
     <PackageReleaseNotes Condition="$(VersionPrefix.StartsWith('2.4.'))">
 Changes:
 * Support C# 8.0 and nullable reference types

--- a/test/Hosting.CommandLine.Tests/McMaster.Extensions.Hosting.CommandLine.Tests.csproj
+++ b/test/Hosting.CommandLine.Tests/McMaster.Extensions.Hosting.CommandLine.Tests.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
Fixes #294 

### What
Change McMaster.Extensions.Hosting.CommandLine to reference Microsoft.Extensions.Hosting.Abstractions 2.1.0

### Why
Some users experience arcane runtime errors when upgrading to .NET Core 3.0 because Microsoft made breaking changes to generic hosting in .NET Core 3.0. The root cause of this is typically a dependency mismatch caused by underspecified dependencies. This change forces users to be a little more direct about which dependency versions they use. 