### PR TITLE
Remove .NET Standard 1.6 target framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@
 
 * Fix [#251] by [@mattnischan] - remove API that was marked as obsolete in 2.x releases
 * Fix [#294] by [@natemcmaster] - change dependencies on McMaster.Extensions.Hosting.CommandLine to just use Microsoft.Extensions.Hosting.Abstractions
+* Fix [#337] by [@natemcmaster] - removed .NET Standard 1.6 target from library
 
 [@mattnischan]: https://github.com/mattnischan
 [@natemcmaster]: https://github.com/natemcmaster
 
 [#251]: https://github.com/natemcmaster/CommandLineUtils/issues/251
 [#294]: https://github.com/natemcmaster/CommandLineUtils/issues/294
+[#337]: https://github.com/natemcmaster/CommandLineUtils/issues/337
 
 ## [v2.5.1](https://github.com/natemcmaster/CommandLineUtils/compare/v2.5.0...v2.5.1)
 

--- a/docs/v3.0/upgrade-guide.md
+++ b/docs/v3.0/upgrade-guide.md
@@ -3,6 +3,24 @@ uid: 2.x-to-3.0-upgrade
 ---
 # Upgrading to CommandLineUtils 3.0
 
+For more technical details, see [this list of GitHub issues](https://github.com/natemcmaster/CommandLineUtils/issues?q=label%3Abreaking-change+milestone%3A3.0).
+
+## NuGet compatibility with older platforms
+
+3.0 removed support for older .NET platforms, like .NET Standard 1.6, .NET Core 1.x, and UWP 8.0. The library still supports .NET Framework 4.5 and .NET Standard 2.0.
+
+## Symptom
+
+NuGet fails to install your project with an error like
+
+> error NU1202: Package McMaster.Extensions.CommandLineUtils 3.0.0 is not compatible with netcoreapp1.1 (.NETCoreApp,Version=v1.1). Package McMaster.Extensions.CommandLineUtils 3.1.0 supports:
+> error NU1202:   - net45 (.NETFramework,Version=v4.5)
+> error NU1202:   - netstandard2.0 (.NETStandard,Version=v2.0)
+
+## Resolution
+
+Either keep using CommandLineUtils 2.x, or upgrade your application to something newer. See https://dotnet.microsoft.com/platform/dotnet-standard for a list of .NET platforms compatible with .NET Standard 2.0.
+
 ## Upgrading McMaster.Extensions.Hosting.CommandLine
 
 In order to fix [#294], McMaster.Extensions.Hosting.CommandLine 3.0's dependency on Microsoft.Extensions.Hosting

--- a/src/CommandLineUtils/Attributes/AllowedValuesAttribute.cs
+++ b/src/CommandLineUtils/Attributes/AllowedValuesAttribute.cs
@@ -56,12 +56,7 @@ namespace McMaster.Extensions.CommandLineUtils
             get
             {
                 return Comparer == StringComparison.CurrentCultureIgnoreCase
-#if (NETSTANDARD2_0 || NET45)
                     || Comparer == StringComparison.InvariantCultureIgnoreCase
-#elif NETSTANDARD1_6
-#else
-#error Target frameworks should be updated
-#endif
                     || Comparer == StringComparison.OrdinalIgnoreCase;
             }
             set

--- a/src/CommandLineUtils/Conventions/AppNameFromEntryAssemblyConvention.cs
+++ b/src/CommandLineUtils/Conventions/AppNameFromEntryAssemblyConvention.cs
@@ -22,7 +22,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
             var assembly = Assembly.GetEntryAssembly();
             if (assembly == null && context.ModelType != null)
             {
-                assembly = context.ModelType.GetTypeInfo().Assembly;
+                assembly = context.ModelType.Assembly;
             }
 
             if (assembly != null)

--- a/src/CommandLineUtils/Conventions/ArgumentAttributeConvention.cs
+++ b/src/CommandLineUtils/Conventions/ArgumentAttributeConvention.cs
@@ -83,7 +83,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
 
             argument.MultipleValues =
                 prop.PropertyType.IsArray
-                || (typeof(IEnumerable).GetTypeInfo().IsAssignableFrom(prop.PropertyType)
+                || (typeof(IEnumerable).IsAssignableFrom(prop.PropertyType)
                     && prop.PropertyType != typeof(string));
 
             if (argPropOrder.TryGetValue(argumentAttr.Order, out var otherProp))

--- a/src/CommandLineUtils/Conventions/AttributeConvention.cs
+++ b/src/CommandLineUtils/Conventions/AttributeConvention.cs
@@ -19,7 +19,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                 return;
             }
 
-            foreach (var attr in context.ModelType.GetTypeInfo().GetCustomAttributes().OfType<IConvention>())
+            foreach (var attr in context.ModelType.GetCustomAttributes().OfType<IConvention>())
             {
                 attr.Apply(context);
             }

--- a/src/CommandLineUtils/Conventions/CommandAttributeConvention.cs
+++ b/src/CommandLineUtils/Conventions/CommandAttributeConvention.cs
@@ -27,7 +27,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                 return;
             }
 
-            var attribute = context.ModelType.GetTypeInfo().GetCustomAttribute<CommandAttribute>();
+            var attribute = context.ModelType.GetCustomAttribute<CommandAttribute>();
             attribute?.Configure(context.Application);
 
             foreach (var subcommand in context.Application.Commands)
@@ -38,7 +38,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                 }
             }
 
-            foreach (var attr in context.ModelType.GetTypeInfo().GetCustomAttributes<ValidationAttribute>())
+            foreach (var attr in context.ModelType.GetCustomAttributes<ValidationAttribute>())
             {
                 context.Application.Validators.Add(new AttributeValidator(attr));
             }

--- a/src/CommandLineUtils/Conventions/ConstructorInjectionConvention.cs
+++ b/src/CommandLineUtils/Conventions/ConstructorInjectionConvention.cs
@@ -53,9 +53,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
         private void ApplyImpl<TModel>(ConventionContext context)
             where TModel : class
         {
-            var constructors = typeof(TModel)
-                .GetTypeInfo()
-                .GetConstructors(BindingFlags.Public | BindingFlags.Instance);
+            var constructors = typeof(TModel).GetConstructors(BindingFlags.Public | BindingFlags.Instance);
 
             var factory = FindMatchedConstructor<TModel>(constructors, context.Application,
                 constructors.Length == 1);

--- a/src/CommandLineUtils/Conventions/DefaultHelpOptionConvention.cs
+++ b/src/CommandLineUtils/Conventions/DefaultHelpOptionConvention.cs
@@ -33,14 +33,11 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                 return;
             }
 
-            if (context.ModelType != null)
+            if (context.ModelType != null
+                && (context.ModelType.GetCustomAttribute<SuppressDefaultHelpOptionAttribute>() != null
+                || context.ModelType.Assembly.GetCustomAttribute<SuppressDefaultHelpOptionAttribute>() != null))
             {
-                var typeInfo = context.ModelType.GetTypeInfo();
-                if (typeInfo.GetCustomAttribute<SuppressDefaultHelpOptionAttribute>() != null
-                    || typeInfo.Assembly.GetCustomAttribute<SuppressDefaultHelpOptionAttribute>() != null)
-                {
-                    return;
-                }
+                return;
             }
 
             var help = new CommandOption(_template, CommandOptionType.NoValue)

--- a/src/CommandLineUtils/Conventions/ExecuteMethodConvention.cs
+++ b/src/CommandLineUtils/Conventions/ExecuteMethodConvention.cs
@@ -31,13 +31,12 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
         {
             const BindingFlags binding = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
 
-            var typeInfo = context.ModelType.GetTypeInfo();
             MethodInfo? method;
             MethodInfo? asyncMethod;
             try
             {
-                method = typeInfo.GetMethod("OnExecute", binding);
-                asyncMethod = typeInfo.GetMethod("OnExecuteAsync", binding);
+                method = context.ModelType.GetMethod("OnExecute", binding);
+                asyncMethod = context.ModelType.GetMethod("OnExecuteAsync", binding);
             }
             catch (AmbiguousMatchException ex)
             {

--- a/src/CommandLineUtils/Conventions/HelpOptionAttributeConvention.cs
+++ b/src/CommandLineUtils/Conventions/HelpOptionAttributeConvention.cs
@@ -20,7 +20,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                 return;
             }
 
-            var helpOptionAttrOnType = context.ModelType.GetTypeInfo().GetCustomAttribute<HelpOptionAttribute>();
+            var helpOptionAttrOnType = context.ModelType.GetCustomAttribute<HelpOptionAttribute>();
             helpOptionAttrOnType?.Configure(context.Application);
 
             var props = ReflectionHelper.GetProperties(context.ModelType);

--- a/src/CommandLineUtils/Conventions/ParentPropertyConvention.cs
+++ b/src/CommandLineUtils/Conventions/ParentPropertyConvention.cs
@@ -21,7 +21,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                 return;
             }
 
-            var parentProp = context.ModelType.GetTypeInfo().GetProperty("Parent", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+            var parentProp = context.ModelType.GetProperty("Parent", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
             if (parentProp == null)
             {
                 return;

--- a/src/CommandLineUtils/Conventions/RemainingArgsPropertyConvention.cs
+++ b/src/CommandLineUtils/Conventions/RemainingArgsPropertyConvention.cs
@@ -26,9 +26,8 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                 return;
             }
 
-            var typeInfo = context.ModelType.GetTypeInfo();
-            var prop = typeInfo.GetProperty("RemainingArguments", PropertyBindingFlags);
-            prop ??= typeInfo.GetProperty("RemainingArgs", PropertyBindingFlags);
+            var prop = context.ModelType.GetProperty("RemainingArguments", PropertyBindingFlags);
+            prop ??= context.ModelType.GetProperty("RemainingArgs", PropertyBindingFlags);
             if (prop == null)
             {
                 return;
@@ -43,9 +42,9 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                 return;
             }
 
-            if (!typeof(IReadOnlyList<string>).GetTypeInfo().IsAssignableFrom(prop.PropertyType))
+            if (!typeof(IReadOnlyList<string>).IsAssignableFrom(prop.PropertyType))
             {
-                throw new InvalidOperationException(Strings.RemainingArgsPropsIsUnassignable(typeInfo));
+                throw new InvalidOperationException(Strings.RemainingArgsPropsIsUnassignable(context.ModelType));
             }
 
             context.Application.OnParsingComplete(r =>

--- a/src/CommandLineUtils/Conventions/SubcommandAttributeConvention.cs
+++ b/src/CommandLineUtils/Conventions/SubcommandAttributeConvention.cs
@@ -24,7 +24,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                 return;
             }
 
-            var attributes = context.ModelType.GetTypeInfo().GetCustomAttributes<SubcommandAttribute>();
+            var attributes = context.ModelType.GetCustomAttributes<SubcommandAttribute>();
 
             foreach (var attribute in attributes)
             {

--- a/src/CommandLineUtils/Conventions/SubcommandPropertyConvention.cs
+++ b/src/CommandLineUtils/Conventions/SubcommandPropertyConvention.cs
@@ -21,7 +21,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                 return;
             }
 
-            var subcommandProp = context.ModelType.GetTypeInfo().GetProperty("Subcommand", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+            var subcommandProp = context.ModelType.GetProperty("Subcommand", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
             if (subcommandProp == null)
             {
                 return;

--- a/src/CommandLineUtils/Conventions/ValidateMethodConvention.cs
+++ b/src/CommandLineUtils/Conventions/ValidateMethodConvention.cs
@@ -25,10 +25,7 @@ namespace McMaster.Extensions.CommandLineUtils
 
             const BindingFlags MethodFlags = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
 
-            var method = context.ModelType
-                .GetTypeInfo()
-                .GetMethod("OnValidate", MethodFlags);
-
+            var method = context.ModelType.GetMethod("OnValidate", MethodFlags);
             if (method == null)
             {
                 return;
@@ -48,11 +45,11 @@ namespace McMaster.Extensions.CommandLineUtils
                 {
                     var methodParam = methodParams[i];
 
-                    if (typeof(ValidationContext).GetTypeInfo().IsAssignableFrom(methodParam.ParameterType))
+                    if (typeof(ValidationContext).IsAssignableFrom(methodParam.ParameterType))
                     {
                         arguments[i] = ctx;
                     }
-                    else if (typeof(CommandLineContext).GetTypeInfo().IsAssignableFrom(methodParam.ParameterType))
+                    else if (typeof(CommandLineContext).IsAssignableFrom(methodParam.ParameterType))
                     {
                         arguments[i] = context.Application._context;
                     }

--- a/src/CommandLineUtils/Conventions/ValidationErrorMethodConvention.cs
+++ b/src/CommandLineUtils/Conventions/ValidationErrorMethodConvention.cs
@@ -22,10 +22,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
 
             const BindingFlags MethodFlags = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
 
-            var method = context.ModelType
-                .GetTypeInfo()
-                .GetMethod("OnValidationError", MethodFlags);
-
+            var method = context.ModelType.GetMethod("OnValidationError", MethodFlags);
             if (method == null)
             {
                 return;

--- a/src/CommandLineUtils/Conventions/VersionOptionAttributeConvention.cs
+++ b/src/CommandLineUtils/Conventions/VersionOptionAttributeConvention.cs
@@ -21,7 +21,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                 return;
             }
 
-            var versionOptionAttrOnType = context.ModelType.GetTypeInfo().GetCustomAttribute<VersionOptionAttribute>();
+            var versionOptionAttrOnType = context.ModelType.GetCustomAttribute<VersionOptionAttribute>();
             versionOptionAttrOnType?.Configure(context.Application);
 
             var props = ReflectionHelper.GetProperties(context.ModelType);

--- a/src/CommandLineUtils/Conventions/VersionOptionFromMemberAttributeConvention.cs
+++ b/src/CommandLineUtils/Conventions/VersionOptionFromMemberAttributeConvention.cs
@@ -20,7 +20,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                 return;
             }
 
-            var versionOptionFromMember = context.ModelType.GetTypeInfo().GetCustomAttribute<VersionOptionFromMemberAttribute>();
+            var versionOptionFromMember = context.ModelType.GetCustomAttribute<VersionOptionFromMemberAttribute>();
             versionOptionFromMember?.Configure(context.Application, context.ModelType, modelAccessor.GetModel);
         }
     }

--- a/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
+++ b/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
@@ -367,7 +367,7 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
 
         private string[] ExtractNamesFromEnum(Type type)
         {
-            if (type == null || !type.GetTypeInfo().IsEnum)
+            if (type == null || !type.IsEnum)
             {
                 return Util.EmptyArray<string>();
             }

--- a/src/CommandLineUtils/IO/Pager.cs
+++ b/src/CommandLineUtils/IO/Pager.cs
@@ -46,7 +46,7 @@ namespace McMaster.Extensions.CommandLineUtils
 #if NET45
             // if .NET Framework, assume we're on Windows unless it's running on Mono.
             _enabled = Type.GetType("Mono.Runtime") != null;
-#elif NETSTANDARD1_6 || NETSTANDARD2_0
+#elif NETSTANDARD2_0
             _enabled = !RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !console.IsOutputRedirected;
 #else
 #error Update target frameworks

--- a/src/CommandLineUtils/Internal/CollectionParserProvider.cs
+++ b/src/CommandLineUtils/Internal/CollectionParserProvider.cs
@@ -30,11 +30,10 @@ namespace McMaster.Extensions.CommandLineUtils
                 return new ArrayParser(elementType, elementParser, valueParsers.ParseCulture);
             }
 
-            var typeInfo = type.GetTypeInfo();
-            if (typeInfo.IsGenericType)
+            if (type.IsGenericType)
             {
                 var typeDef = type.GetGenericTypeDefinition();
-                var elementType = typeInfo.GetGenericArguments().First();
+                var elementType = type.GetGenericArguments().First();
                 var elementParser = valueParsers.GetParser(elementType);
 
                 if (typeof(IList<>) == typeDef

--- a/src/CommandLineUtils/Internal/CommandOptionTypeMapper.cs
+++ b/src/CommandLineUtils/Internal/CommandOptionTypeMapper.cs
@@ -45,36 +45,35 @@ namespace McMaster.Extensions.CommandLineUtils
                 return CommandOptionType.SingleValue;
             }
 
-            if (clrType.IsArray || typeof(IEnumerable).GetTypeInfo().IsAssignableFrom(clrType))
+            if (clrType.IsArray || typeof(IEnumerable).IsAssignableFrom(clrType))
             {
                 return CommandOptionType.MultipleValue;
             }
 
-            var typeInfo = clrType.GetTypeInfo();
-            if (typeInfo.IsEnum)
+            if (clrType.IsEnum)
             {
                 return CommandOptionType.SingleValue;
             }
 
-            if (typeInfo.IsGenericType)
+            if (clrType.IsGenericType)
             {
-                var typeDef = typeInfo.GetGenericTypeDefinition();
+                var typeDef = clrType.GetGenericTypeDefinition();
                 if (typeDef == typeof(Nullable<>))
                 {
-                    return GetOptionType(typeInfo.GetGenericArguments().First(), valueParsers);
+                    return GetOptionType(clrType.GetGenericArguments().First(), valueParsers);
                 }
 
-                if (typeDef == typeof(Tuple<,>) && typeInfo.GenericTypeArguments[0] == typeof(bool))
+                if (typeDef == typeof(Tuple<,>) && clrType.GenericTypeArguments[0] == typeof(bool))
                 {
-                    if (GetOptionType(typeInfo.GenericTypeArguments[1], valueParsers) == CommandOptionType.SingleValue)
+                    if (GetOptionType(clrType.GenericTypeArguments[1], valueParsers) == CommandOptionType.SingleValue)
                     {
                         return CommandOptionType.SingleOrNoValue;
                     }
                 }
 
-                if (typeDef == typeof(ValueTuple<,>) && typeInfo.GenericTypeArguments[0] == typeof(bool))
+                if (typeDef == typeof(ValueTuple<,>) && clrType.GenericTypeArguments[0] == typeof(bool))
                 {
-                    if (GetOptionType(typeInfo.GenericTypeArguments[1], valueParsers) == CommandOptionType.SingleValue)
+                    if (GetOptionType(clrType.GenericTypeArguments[1], valueParsers) == CommandOptionType.SingleValue)
                     {
                         return CommandOptionType.SingleOrNoValue;
                     }

--- a/src/CommandLineUtils/Internal/Util.cs
+++ b/src/CommandLineUtils/Internal/Util.cs
@@ -16,7 +16,7 @@ namespace McMaster.Extensions.CommandLineUtils
             internal static readonly T[] Value = new T[0];
         }
 
-#elif (NETSTANDARD1_6 || NETSTANDARD2_0)
+#elif NETSTANDARD2_0
             => Array.Empty<T>();
 #else
 #error Update target frameworks

--- a/src/CommandLineUtils/McMaster.Extensions.CommandLineUtils.csproj
+++ b/src/CommandLineUtils/McMaster.Extensions.CommandLineUtils.csproj
@@ -1,12 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard1.6;net45</TargetFrameworks>
-    <!--
-      The ns1.6 API is a subset of the API available in ns2.0 and net45. The public API tool doesn't handle multiple TFMs.
-      https://github.com/dotnet/roslyn-analyzers/issues/2621
-    -->
-    <DisablePublicApiAnalyzer Condition="'$(TargetFramework)' == 'netstandard1.6'">true</DisablePublicApiAnalyzer>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
     <Description>Command-line parsing API.</Description>
@@ -33,15 +28,6 @@ McMaster.Extensions.CommandLineUtils.ArgumentEscaper
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
-    <!-- Keep these at the lowest possible version to support .NET Core 1. -->
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.1.0" />
-    <PackageReference Include="System.Diagnostics.Process" Version="4.1.0" />
-    <PackageReference Include="System.Threading.Thread" Version="4.0.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
-    <PackageReference Update="NETStandard.Library" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/CommandLineUtils/Properties/Strings.cs
+++ b/src/CommandLineUtils/Properties/Strings.cs
@@ -90,8 +90,8 @@ namespace McMaster.Extensions.CommandLineUtils
         public const string MultipleVersionOptionPropertiesFound
             = "Multiple VersionOptionAttributes found. VersionOptionAttribute should only be used on one property per type.";
 
-        public static string RemainingArgsPropsIsUnassignable(TypeInfo typeInfo)
-            => $"The RemainingArguments property type on {typeInfo.Name} is invalid. It must be assignable from string[].";
+        public static string RemainingArgsPropsIsUnassignable(Type type)
+            => $"The RemainingArguments property type on {type.Name} is invalid. It must be assignable from string[].";
 
         public static string NoPropertyOrMethodFound(string memberName, Type type)
             => $"Could not find a property or method named {memberName} on type {type.FullName}";

--- a/src/CommandLineUtils/Utilities/DotNetExe.cs
+++ b/src/CommandLineUtils/Utilities/DotNetExe.cs
@@ -44,7 +44,7 @@ namespace McMaster.Extensions.CommandLineUtils
             var fileName = FileName;
 #if NET45
             fileName += ".exe";
-#elif (NETSTANDARD1_6 || NETSTANDARD2_0)
+#elif NETSTANDARD2_0
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 fileName += ".exe";

--- a/src/CommandLineUtils/Utilities/Prompt.cs
+++ b/src/CommandLineUtils/Utilities/Prompt.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Security;
 using System.Text;
 
 namespace McMaster.Extensions.CommandLineUtils
@@ -118,7 +119,6 @@ namespace McMaster.Extensions.CommandLineUtils
             return resp.ToString();
         }
 
-#if NET45 || NETSTANDARD2_0
         /// <summary>
         /// Gets a response as a SecureString object. Input is masked with an asterisk.
         /// </summary>
@@ -126,9 +126,9 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="promptColor">The console color to use for the prompt</param>
         /// <param name="promptBgColor">The console background color for the prompt</param>
         /// <returns>A finalized SecureString object, may be empty.</returns>
-        public static System.Security.SecureString GetPasswordAsSecureString(string prompt, ConsoleColor? promptColor = null, ConsoleColor? promptBgColor = null)
+        public static SecureString GetPasswordAsSecureString(string prompt, ConsoleColor? promptColor = null, ConsoleColor? promptBgColor = null)
         {
-            var secureString = new System.Security.SecureString();
+            var secureString = new SecureString();
 
             foreach (var key in ReadObfuscatedLine(prompt, promptColor, promptBgColor))
             {
@@ -146,10 +146,6 @@ namespace McMaster.Extensions.CommandLineUtils
             secureString.MakeReadOnly();
             return secureString;
         }
-#elif NETSTANDARD1_6
-#else
-#error Target frameworks should be updated
-#endif
 
         /// <summary>
         /// Base implementation of GetPassword and GetPasswordAsString. Prompts the user for

--- a/src/CommandLineUtils/Validation/ValidationExtensions.cs
+++ b/src/CommandLineUtils/Validation/ValidationExtensions.cs
@@ -198,7 +198,7 @@ namespace McMaster.Extensions.CommandLineUtils
         public static IValidationBuilder Enum<TEnum>(this IValidationBuilder builder, bool ignoreCase = false)
             where TEnum : struct
         {
-            if (!typeof(TEnum).GetTypeInfo().IsEnum)
+            if (!typeof(TEnum).IsEnum)
             {
                 throw new ArgumentException("Type parameter T must be an enum.");
             }

--- a/test/CommandLineUtils.Tests/CommandLineApplicationExecutorTests.cs
+++ b/test/CommandLineUtils.Tests/CommandLineApplicationExecutorTests.cs
@@ -157,7 +157,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         {
             var ex = Assert.Throws<InvalidOperationException>(
                 () => CommandLineApplication.Execute<ExecuteWithUnknownTypes>());
-            var method = typeof(ExecuteWithUnknownTypes).GetTypeInfo().GetMethod("OnExecute", BindingFlags.Instance | BindingFlags.NonPublic);
+            var method = typeof(ExecuteWithUnknownTypes).GetMethod("OnExecute", BindingFlags.Instance | BindingFlags.NonPublic);
             var param = Assert.Single(method.GetParameters());
             Assert.Equal(Strings.UnsupportedParameterTypeOnMethod(method.Name, param), ex.Message);
         }

--- a/test/CommandLineUtils.Tests/OptionAttributeTests.cs
+++ b/test/CommandLineUtils.Tests/OptionAttributeTests.cs
@@ -310,8 +310,8 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             var ctor = typeof(OptionAttribute).GetConstructor(Array.Empty<Type>());
             var ab = new CustomAttributeBuilder(ctor, Array.Empty<object>());
             pb.SetCustomAttribute(ab);
-            var program = tb.CreateTypeInfo();
-            var appBuilder = typeof(CommandLineApplication<>).MakeGenericType(program.AsType());
+            var program = tb.CreateType();
+            var appBuilder = typeof(CommandLineApplication<>).MakeGenericType(program);
             var app = (CommandLineApplication)Activator.CreateInstance(appBuilder, new object[] { false });
             app.Conventions.UseOptionAttributes();
             return app.Options[0];


### PR DESCRIPTION
Fixes #337 

### What 

Remove "netstandard1.6" from package target frameworks and delete some related dead code.

### Why

Usage of .NET Core 1.x was the main driver of this, and it has been out of support since June 2019. If you're still on this, you should upgrade to a newer .NET Core version.