### PR TITLE
Refactor: obsolete throwOnUnexpectedArg in favor of UnrecognizedArgumentHandling enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-[Unreleased changes](https://github.com/natemcmaster/CommandLineUtils/compare/v2.5.0...HEAD):
+[Unreleased changes](https://github.com/natemcmaster/CommandLineUtils/compare/v2.5.1...HEAD):
+
+## [v2.6.0](https://github.com/natemcmaster/CommandLineUtils/compare/v2.5.1...v2.6.0)
+
+* Refactor: obsolete throwOnUnexpectedArg in favor of UnrecognizedArgumentHandling. See https://github.com/natemcmaster/CommandLineUtils/issues/339 for details
 
 ## [v2.5.1](https://github.com/natemcmaster/CommandLineUtils/compare/v2.5.0...v2.5.1)
 

--- a/docs/docs/arguments.md
+++ b/docs/docs/arguments.md
@@ -145,8 +145,8 @@ or the Windows command `cmd` take some arguments, and pass the rest on to the co
 > In this example, `-l` is an option on `time`. This starts a timer which then invokes `ls` with additional arguments.
 > `-l` is also an option on `ls`.
 
-Normally, unrecognized arguments is an error. You must set ThrowOnUnexpectedArgument to `false` to allow the parser
-to allow unrecognized arguments and options.
+Normally, unrecognized arguments is an error. You must set `UnrecognizedArgumentHandling` to `StopParsingAndCollect` to allow the parser
+to collect unrecognized arguments and options.
 
 ### The double-dash convention `--`
 
@@ -171,6 +171,6 @@ to include all values. See @McMaster.Extensions.CommandLineUtils.Conventions.Rem
 
 ### [Using Builder API](#tab/using-builder-api)
 
-When `throwOnUnexpctedArg` is set to false,
+When `UnrecognizedArgumentHandling` is set to `Stop`,
 
 [!code-csharp[Program](../samples/passthru-args/builder-api/Program.cs)]

--- a/docs/samples/passthru-args/attributes/Program.cs
+++ b/docs/samples/passthru-args/attributes/Program.cs
@@ -3,7 +3,9 @@ using System.Diagnostics;
 using System.Linq;
 using McMaster.Extensions.CommandLineUtils;
 
-[Command(ThrowOnUnexpectedArgument = false, AllowArgumentSeparator = true)]
+[Command(
+    UnrecognizedArgumentHandling = UnrecognizedArgumentHandling.StopParsingAndCollect,
+    AllowArgumentSeparator = true)]
 public class Program
 {
     public static int Main(string[] args) => CommandLineApplication.Execute<Program>(args);

--- a/docs/samples/passthru-args/builder-api/Program.cs
+++ b/docs/samples/passthru-args/builder-api/Program.cs
@@ -7,9 +7,10 @@ public class Program
 {
     public static int Main(string[] args)
     {
-        var app = new CommandLineApplication(throwOnUnexpectedArg: false)
+        var app = new CommandLineApplication
         {
-            AllowArgumentSeparator = true
+            AllowArgumentSeparator = true,
+            UnrecognizedArgumentHandling = UnrecognizedArgumentHandling.StopParsingAndCollect,
         };
 
         var showMilliseconds = app.Option<int>("-m", "Show time in milliseconds", CommandOptionType.NoValue);

--- a/docs/samples/subcommands/nested-types/Program.cs
+++ b/docs/samples/subcommands/nested-types/Program.cs
@@ -57,7 +57,7 @@ namespace SubcommandSample
 
             [Command("run", Description = "Run a command in a new container",
                 AllowArgumentSeparator = true,
-                ThrowOnUnexpectedArgument = false)]
+                UnrecognizedArgumentHandling = UnrecognizedArgumentHandling.StopParsingAndCollect)]
             private class Run
             {
                 [Required(ErrorMessage = "You must specify the image name")]
@@ -94,7 +94,7 @@ namespace SubcommandSample
 
 
             [Command("ls", Description = "List images",
-                ThrowOnUnexpectedArgument = false)]
+                UnrecognizedArgumentHandling = UnrecognizedArgumentHandling.StopParsingAndCollect)]
             private class List
             {
                 [Option(Description = "Show all containers (default shows just running)")]

--- a/src/CommandLineUtils/Attributes/CommandAttribute.cs
+++ b/src/CommandLineUtils/Attributes/CommandAttribute.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
 
@@ -90,10 +91,30 @@ namespace McMaster.Extensions.CommandLineUtils
         public string? ExtendedHelpText { get; set; }
 
         /// <summary>
+        /// <para>
+        /// This property is obsolete and will be removed in a future version.
+        /// The recommended replacement is <seealso cref="UnrecognizedArgumentHandling"/>.
+        /// </para>
+        /// <para>
         /// Throw when unexpected arguments are encountered.
+        /// </para>
         /// </summary>
         /// <seealso cref="CommandLineApplication.ThrowOnUnexpectedArgument"/>
-        public bool ThrowOnUnexpectedArgument { get; set; } = true;
+        [Obsolete("This property is obsolete and will be removed in a future version. " +
+            "The recommended replacement is UnrecognizedArgumentHandling.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool ThrowOnUnexpectedArgument
+        {
+            get => UnrecognizedArgumentHandling == UnrecognizedArgumentHandling.Throw;
+            set => UnrecognizedArgumentHandling = value
+                ? UnrecognizedArgumentHandling.Throw
+                : UnrecognizedArgumentHandling.StopParsingAndCollect;
+        }
+
+        /// <summary>
+        /// Set the behavior for how to handle unrecognized arguments.
+        /// </summary>
+        public UnrecognizedArgumentHandling UnrecognizedArgumentHandling { get; set; } = UnrecognizedArgumentHandling.Throw;
 
         /// <summary>
         /// Allow '--' to be used to stop parsing arguments.
@@ -167,7 +188,7 @@ namespace McMaster.Extensions.CommandLineUtils
             app.FullName = FullName;
             app.ResponseFileHandling = ResponseFileHandling;
             app.ShowInHelpText = ShowInHelpText;
-            app.ThrowOnUnexpectedArgument = ThrowOnUnexpectedArgument;
+            app.UnrecognizedArgumentHandling = UnrecognizedArgumentHandling;
             app.OptionsComparison = OptionsComparison;
             app.ValueParsers.ParseCulture = ParseCulture;
 

--- a/src/CommandLineUtils/CommandLineApplication.cs
+++ b/src/CommandLineUtils/CommandLineApplication.cs
@@ -58,14 +58,11 @@ namespace McMaster.Extensions.CommandLineUtils
         private readonly ConventionContext _conventionContext;
         private readonly List<IConvention> _conventions = new List<IConvention>();
 
-#pragma warning disable RS0027 // Public API with optional parameter(s) should have the most parameters amongst its public overloads.
         /// <summary>
         /// Initializes a new instance of <see cref="CommandLineApplication"/>.
         /// </summary>
-        /// <param name="throwOnUnexpectedArg">Initial value for <see cref="ThrowOnUnexpectedArgument"/>.</param>
-        public CommandLineApplication(bool throwOnUnexpectedArg = true)
-#pragma warning restore RS0027 // Public API with optional parameter(s) should have the most parameters amongst its public overloads.
-            : this(null, DefaultHelpTextGenerator.Singleton, new DefaultCommandLineContext(), throwOnUnexpectedArg)
+        public CommandLineApplication()
+            : this(null, DefaultHelpTextGenerator.Singleton, new DefaultCommandLineContext())
         {
         }
 
@@ -74,7 +71,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// </summary>
         /// <param name="console">The console implementation to use.</param>
         public CommandLineApplication(IConsole console)
-            : this(null, DefaultHelpTextGenerator.Singleton, new DefaultCommandLineContext(console), throwOnUnexpectedArg: true)
+            : this(null, DefaultHelpTextGenerator.Singleton, new DefaultCommandLineContext(console))
         { }
 
         /// <summary>
@@ -82,9 +79,8 @@ namespace McMaster.Extensions.CommandLineUtils
         /// </summary>
         /// <param name="console">The console implementation to use.</param>
         /// <param name="workingDirectory">The current working directory.</param>
-        /// <param name="throwOnUnexpectedArg">Initial value for <see cref="ThrowOnUnexpectedArgument"/>.</param>
-        public CommandLineApplication(IConsole console, string workingDirectory, bool throwOnUnexpectedArg)
-            : this(null, DefaultHelpTextGenerator.Singleton, new DefaultCommandLineContext(console, workingDirectory), throwOnUnexpectedArg)
+        public CommandLineApplication(IConsole console, string workingDirectory)
+            : this(null, DefaultHelpTextGenerator.Singleton, new DefaultCommandLineContext(console, workingDirectory))
         { }
 
         /// <summary>
@@ -93,14 +89,83 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="helpTextGenerator">The help text generator to use.</param>
         /// <param name="console">The console implementation to use.</param>
         /// <param name="workingDirectory">The current working directory.</param>
-        /// <param name="throwOnUnexpectedArg">Initial value for <see cref="ThrowOnUnexpectedArgument"/>.</param>
-        public CommandLineApplication(IHelpTextGenerator helpTextGenerator, IConsole console, string workingDirectory, bool throwOnUnexpectedArg)
-            : this(null, helpTextGenerator, new DefaultCommandLineContext(console, workingDirectory), throwOnUnexpectedArg)
+        public CommandLineApplication(IHelpTextGenerator helpTextGenerator, IConsole console, string workingDirectory)
+            : this(null, helpTextGenerator, new DefaultCommandLineContext(console, workingDirectory))
         {
         }
 
-        internal CommandLineApplication(CommandLineApplication parent, string name, bool throwOnUnexpectedArg)
-            : this(parent, parent._helpTextGenerator, parent._context, throwOnUnexpectedArg)
+        /// <summary>
+        /// <para>
+        /// This constructor is obsolete and will be removed in a future version.
+        /// The recommended replacement is the parameterless constructor <see cref="CommandLineApplication()" />
+        /// and <see cref="UnrecognizedArgumentHandling"/>.
+        /// See https://github.com/natemcmaster/CommandLineUtils/issues/339 for details.
+        /// </para>
+        /// <para>
+        /// Initializes a new instance of <see cref="CommandLineApplication"/>.
+        /// </para>
+        /// </summary>
+        /// <param name="throwOnUnexpectedArg">Initial value for <see cref="ThrowOnUnexpectedArgument"/>.</param>
+        [Obsolete("This constructor is obsolete and will be removed in a future version. " +
+            "The recommended replacement is the parameterless constructor CommandLineApplication() and the property UnrecognizedArgumentHandling." +
+            "See https://github.com/natemcmaster/CommandLineUtils/issues/339 for details.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public CommandLineApplication(bool throwOnUnexpectedArg)
+            : this(null, DefaultHelpTextGenerator.Singleton, new DefaultCommandLineContext())
+        {
+            ThrowOnUnexpectedArgument = throwOnUnexpectedArg;
+        }
+
+        /// <summary>
+        /// <para>
+        /// This constructor is obsolete and will be removed in a future version.
+        /// The recommended replacement is <see cref="CommandLineApplication(IConsole, string)" />
+        /// and <see cref="UnrecognizedArgumentHandling"/>.
+        /// See https://github.com/natemcmaster/CommandLineUtils/issues/339 for details.
+        /// </para>
+        /// <para>
+        /// Initializes a new instance of <see cref="CommandLineApplication"/>.
+        /// </para>
+        /// </summary>
+        /// <param name="console">The console implementation to use.</param>
+        /// <param name="workingDirectory">The current working directory.</param>
+        /// <param name="throwOnUnexpectedArg">Initial value for <see cref="ThrowOnUnexpectedArgument"/>.</param>
+        [Obsolete("This constructor is obsolete and will be removed in a future version. " +
+            "The recommended replacement is the constructor CommandLineApplication(IConsole, string) and the property UnrecognizedArgumentHandling." +
+            "See https://github.com/natemcmaster/CommandLineUtils/issues/339 for details.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public CommandLineApplication(IConsole console, string workingDirectory, bool throwOnUnexpectedArg)
+            : this(null, DefaultHelpTextGenerator.Singleton, new DefaultCommandLineContext(console, workingDirectory))
+        {
+            ThrowOnUnexpectedArgument = throwOnUnexpectedArg;
+        }
+
+        /// <summary>
+        /// <para>
+        /// This constructor is obsolete and will be removed in a future version.
+        /// The recommended replacement is <see cref="CommandLineApplication(IHelpTextGenerator, IConsole, string)" />
+        /// See https://github.com/natemcmaster/CommandLineUtils/issues/339 for details.
+        /// </para>
+        /// <para>
+        /// Initializes a new instance of <see cref="CommandLineApplication"/>.
+        /// </para>
+        /// </summary>
+        /// <param name="helpTextGenerator">The help text generator to use.</param>
+        /// <param name="console">The console implementation to use.</param>
+        /// <param name="workingDirectory">The current working directory.</param>
+        /// <param name="throwOnUnexpectedArg">Initial value for <see cref="ThrowOnUnexpectedArgument"/>.</param>
+        [Obsolete("This constructor is obsolete and will be removed in a future version. " +
+            "The recommended replacement is the constructor CommandLineApplication(IHelpTextGenerator, IConsole, string) and the property UnrecognizedArgumentHandling." +
+            "See https://github.com/natemcmaster/CommandLineUtils/issues/339 for details.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public CommandLineApplication(IHelpTextGenerator helpTextGenerator, IConsole console, string workingDirectory, bool throwOnUnexpectedArg)
+            : this(null, helpTextGenerator, new DefaultCommandLineContext(console, workingDirectory))
+        {
+            ThrowOnUnexpectedArgument = throwOnUnexpectedArg;
+        }
+
+        internal CommandLineApplication(CommandLineApplication parent, string name)
+            : this(parent, parent._helpTextGenerator, parent._context)
         {
             if (name != null)
             {
@@ -111,12 +176,10 @@ namespace McMaster.Extensions.CommandLineUtils
         internal CommandLineApplication(
             CommandLineApplication? parent,
             IHelpTextGenerator helpTextGenerator,
-            CommandLineContext context,
-            bool throwOnUnexpectedArg)
+            CommandLineContext context)
         {
             _context = context ?? throw new ArgumentNullException(nameof(context));
             Parent = parent;
-            ThrowOnUnexpectedArgument = throwOnUnexpectedArg;
             Options = new List<CommandOption>();
             Arguments = new List<CommandArgument>();
             Commands = new List<CommandLineApplication>();
@@ -257,11 +320,35 @@ namespace McMaster.Extensions.CommandLineUtils
         public List<string> RemainingArguments { get; private set; }
 
         /// <summary>
+        /// <para>
+        /// This property is obsolete and will be removed in a future version.
+        /// The recommended replacement is <seealso cref="UnrecognizedArgumentHandling"/>.
+        /// </para>
+        /// <para>
         /// Indicates whether the parser should throw an exception when it runs into an unexpected argument.
         /// If this field is set to false, the parser will stop parsing when it sees an unexpected argument, and all
         /// remaining arguments, including the first unexpected argument, will be stored in RemainingArguments property.
+        /// </para>
         /// </summary>
-        public bool ThrowOnUnexpectedArgument { get; set; }
+        [Obsolete("This property is obsolete and will be removed in a future version. " +
+            "The recommended replacement is UnrecognizedArgumentHandling.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool ThrowOnUnexpectedArgument
+        {
+            get => UnrecognizedArgumentHandling == UnrecognizedArgumentHandling.Throw;
+            set => UnrecognizedArgumentHandling = value
+                ? UnrecognizedArgumentHandling.Throw
+                : UnrecognizedArgumentHandling.StopParsingAndCollect;
+        }
+
+        /// <summary>
+        /// Configures what the parser should do when it runs into an unexpected argument.
+        /// </summary>
+        public UnrecognizedArgumentHandling UnrecognizedArgumentHandling
+        {
+            get => _parserConfig.UnrecognizedArgumentHandling;
+            set => _parserConfig.UnrecognizedArgumentHandling = value;
+        }
 
         /// <summary>
         /// True when <see cref="OptionHelp"/> or <see cref="OptionVersion"/> was matched.
@@ -495,19 +582,15 @@ namespace McMaster.Extensions.CommandLineUtils
             }
         }
 
-#pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
         /// <summary>
         /// Adds a subcommand.
         /// </summary>
         /// <param name="name">The word used to invoke the subcommand.</param>
-        /// <param name="configuration"></param>
-        /// <param name="throwOnUnexpectedArg"></param>
+        /// <param name="configuration">A callback to configure the created subcommand.</param>
         /// <returns></returns>
-        public CommandLineApplication Command(string name, Action<CommandLineApplication> configuration,
-#pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
-            bool throwOnUnexpectedArg = true)
+        public CommandLineApplication Command(string name, Action<CommandLineApplication> configuration)
         {
-            var command = new CommandLineApplication(this, name, throwOnUnexpectedArg);
+            var command = new CommandLineApplication(this, name);
 
             AddSubcommand(command);
 
@@ -516,21 +599,80 @@ namespace McMaster.Extensions.CommandLineUtils
             return command;
         }
 
-#pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
+        /// <summary>
+        /// <para>
+        /// This method is obsolete and will be removed in a future version.
+        /// The recommended replacement is to use<see cref="Command(string, Action{CommandLineApplication})" />
+        /// and set <see cref="UnrecognizedArgumentHandling" />.
+        /// </para>
+        /// <para>
+        /// Adds a subcommand.
+        /// </para>
+        /// </summary>
+        /// <param name="name">The word used to invoke the subcommand.</param>
+        /// <param name="configuration">A callback to configure the created subcommand.</param>
+        /// <param name="throwOnUnexpectedArg"></param>
+        /// <returns></returns>
+        [Obsolete("This constructor is obsolete and will be removed in a future version. " +
+            "The recommended replacement is Command(string, Action<CommandLineApplication>) and the property UnrecognizedArgumentHandling")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public CommandLineApplication Command(string name, Action<CommandLineApplication> configuration, bool throwOnUnexpectedArg)
+        {
+            var command = new CommandLineApplication(this, name);
+            command.ThrowOnUnexpectedArgument = throwOnUnexpectedArg;
+
+            AddSubcommand(command);
+
+            configuration?.Invoke(command);
+
+            return command;
+        }
+
         /// <summary>
         /// Adds a subcommand with model of type <typeparamref name="TModel" />.
         /// </summary>
         /// <param name="name">The word used to invoke the subcommand.</param>
-        /// <param name="configuration"></param>
+        /// <param name="configuration">A callback used to configure the subcommand object.</param>
+        /// <typeparam name="TModel">The model type of the subcommand.</typeparam>
+        /// <returns></returns>
+        public CommandLineApplication<TModel> Command<TModel>(string name, Action<CommandLineApplication<TModel>> configuration)
+            where TModel : class
+        {
+            var command = new CommandLineApplication<TModel>(this, name);
+
+            AddSubcommand(command);
+
+            configuration?.Invoke(command);
+
+            return command;
+        }
+
+        /// <summary>
+        /// <para>
+        /// This method is obsolete and will be removed in a future version.
+        /// The recommended replacement is to use<see cref="Command(string, Action{CommandLineApplication})" />
+        /// and set <see cref="UnrecognizedArgumentHandling" />.
+        /// </para>
+        /// <para>
+        /// Adds a subcommand with model of type <typeparamref name="TModel" />.
+        /// </para>
+        /// </summary>
+        /// <param name="name">The word used to invoke the subcommand.</param>
+        /// <param name="configuration">A callback used to configure the subcommand object.</param>
         /// <param name="throwOnUnexpectedArg"></param>
         /// <typeparam name="TModel">The model type of the subcommand.</typeparam>
         /// <returns></returns>
+        [Obsolete("This constructor is obsolete and will be removed in a future version. " +
+            "The recommended replacement is Command(string, Action<CommandLineApplication>) and the property UnrecognizedArgumentHandling")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public CommandLineApplication<TModel> Command<TModel>(string name, Action<CommandLineApplication<TModel>> configuration,
-#pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
-            bool throwOnUnexpectedArg = true)
+            bool throwOnUnexpectedArg)
             where TModel : class
         {
-            var command = new CommandLineApplication<TModel>(this, name, throwOnUnexpectedArg);
+            var command = new CommandLineApplication<TModel>(this, name)
+            {
+                ThrowOnUnexpectedArgument = throwOnUnexpectedArg
+            };
 
             AddSubcommand(command);
 

--- a/src/CommandLineUtils/CommandLineApplication{T}.cs
+++ b/src/CommandLineUtils/CommandLineApplication{T}.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.ComponentModel;
 using McMaster.Extensions.CommandLineUtils.Abstractions;
 using McMaster.Extensions.CommandLineUtils.Conventions;
 using McMaster.Extensions.CommandLineUtils.HelpText;
@@ -19,20 +20,17 @@ namespace McMaster.Extensions.CommandLineUtils
         private Func<TModel> _modelFactory = DefaultModelFactory;
 
 #nullable disable
-#pragma warning disable RS0027 // Public API with optional parameter(s) should have the most parameters amongst its public overloads.
         /// <summary>
-        /// Initializes a new instance of <see cref="CommandLineApplication"/>.
+        /// Initializes a new instance of <see cref="CommandLineApplication{TModel}"/>.
         /// </summary>
-        /// <param name="throwOnUnexpectedArg">Initial value for <see cref="CommandLineApplication.ThrowOnUnexpectedArgument"/>.</param>
-        public CommandLineApplication(bool throwOnUnexpectedArg = true)
-#pragma warning restore RS0027 // Public API with optional parameter(s) should have the most parameters amongst its public overloads.
-            : base(throwOnUnexpectedArg)
+        public CommandLineApplication()
+            : base()
         {
             Initialize();
         }
 
         /// <summary>
-        /// Initializes a new instance of <see cref="CommandLineApplication"/>.
+        /// Initializes a new instance of <see cref="CommandLineApplication{TModel}"/>.
         /// </summary>
         /// <param name="console">The console implementation to use.</param>
         public CommandLineApplication(IConsole console)
@@ -42,11 +40,72 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary>
-        /// Initializes a new instance of <see cref="CommandLineApplication"/>.
+        /// Initializes a new instance of <see cref="CommandLineApplication{TModel}"/>.
+        /// </summary>
+        /// <param name="console">The console implementation to use.</param>
+        /// <param name="workingDirectory">The current working directory.</param>
+        public CommandLineApplication(IConsole console, string workingDirectory)
+            : base(console, workingDirectory)
+        {
+            Initialize();
+        }
+
+        /// <summary>
+        /// <para>
+        /// This constructor is obsolete and will be removed in a future version.
+        /// The recommended replacement is <see cref="CommandLineApplication{TModel}(IHelpTextGenerator, IConsole, string)" />
+        /// </para>
+        /// <para>
+        /// Initializes a new instance of <see cref="CommandLineApplication{TModel}"/>.
+        /// </para>
+        /// </summary>
+        /// <param name="helpTextGenerator">The help text generator to use.</param>
+        /// <param name="console">The console implementation to use.</param>
+        /// <param name="workingDirectory">The current working directory.</param>
+        public CommandLineApplication(IHelpTextGenerator helpTextGenerator, IConsole console, string workingDirectory)
+            : base(helpTextGenerator, console, workingDirectory)
+        {
+            Initialize();
+        }
+
+        /// <summary>
+        /// <para>
+        /// This constructor is obsolete and will be removed in a future version.
+        /// The recommended replacement is <see cref="CommandLineApplication{TModel}()" />.
+        /// See https://github.com/natemcmaster/CommandLineUtils/issues/339 for details.
+        /// </para>
+        /// <para>
+        /// Initializes a new instance of <see cref="CommandLineApplication{TModel}"/>.
+        /// </para>
+        /// </summary>
+        /// <param name="throwOnUnexpectedArg">Initial value for <see cref="CommandLineApplication.ThrowOnUnexpectedArgument"/>.</param>
+        [Obsolete("This constructor is obsolete and will be removed in a future version. " +
+            "The recommended replacement is CommandLineApplication<T>() and UnrecognizedArgumentHandling. " +
+            "See https://github.com/natemcmaster/CommandLineUtils/issues/339 for details.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public CommandLineApplication(bool throwOnUnexpectedArg)
+            : base(throwOnUnexpectedArg)
+        {
+            Initialize();
+        }
+
+        /// <summary>
+        /// <para>
+        /// This constructor is obsolete and will be removed in a future version.
+        /// The recommended replacement is <see cref="CommandLineApplication{TModel}(IConsole, string)" />
+        /// See https://github.com/natemcmaster/CommandLineUtils/issues/339 for details.
+        /// </para>
+        /// <para>
+        /// Initializes a new instance of <see cref="CommandLineApplication{TModel}"/>.
+        /// </para>
         /// </summary>
         /// <param name="console">The console implementation to use.</param>
         /// <param name="workingDirectory">The current working directory.</param>
         /// <param name="throwOnUnexpectedArg">Initial value for <see cref="CommandLineApplication.ThrowOnUnexpectedArgument"/>.</param>
+        [Obsolete("This constructor is obsolete and will be removed in a future version. " +
+            "The recommended replacement is CommandLineApplication<T>(IConsole, string) and UnrecognizedArgumentHandling. " +
+            "See https://github.com/natemcmaster/CommandLineUtils/issues/339 for details.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public CommandLineApplication(IConsole console, string workingDirectory, bool throwOnUnexpectedArg)
             : base(console, workingDirectory, throwOnUnexpectedArg)
         {
@@ -54,20 +113,31 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary>
-        /// Initializes a new instance of <see cref="CommandLineApplication"/>.
+        /// <para>
+        /// This constructor is obsolete and will be removed in a future version.
+        /// The recommended replacement is <see cref="CommandLineApplication{TModel}(IHelpTextGenerator, IConsole, string)" />
+        /// See https://github.com/natemcmaster/CommandLineUtils/issues/339 for details.
+        /// </para>
+        /// <para>
+        /// Initializes a new instance of <see cref="CommandLineApplication{TModel}"/>.
+        /// </para>
         /// </summary>
         /// <param name="helpTextGenerator">The help text generator to use.</param>
         /// <param name="console">The console implementation to use.</param>
         /// <param name="workingDirectory">The current working directory.</param>
         /// <param name="throwOnUnexpectedArg">Initial value for <see cref="CommandLineApplication.ThrowOnUnexpectedArgument"/>.</param>
+        [Obsolete("This constructor is obsolete and will be removed in a future version. " +
+            "The recommended replacement is CommandLineApplication<T>(IHelpTextGenerator, IConsole, string) and UnrecognizedArgumentHandling. " +
+            "See https://github.com/natemcmaster/CommandLineUtils/issues/339 for details.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public CommandLineApplication(IHelpTextGenerator helpTextGenerator, IConsole console, string workingDirectory, bool throwOnUnexpectedArg)
             : base(helpTextGenerator, console, workingDirectory, throwOnUnexpectedArg)
         {
             Initialize();
         }
 
-        internal CommandLineApplication(CommandLineApplication parent, string name, bool throwOnUnexpectedArg)
-            : base(parent, name, throwOnUnexpectedArg)
+        internal CommandLineApplication(CommandLineApplication parent, string name)
+            : base(parent, name)
         {
             Initialize();
         }

--- a/src/CommandLineUtils/Internal/CommandLineProcessor.cs
+++ b/src/CommandLineUtils/Internal/CommandLineProcessor.cs
@@ -365,20 +365,25 @@ namespace McMaster.Extensions.CommandLineUtils
 
         private void HandleUnexpectedArg(string argTypeName, string? argValue = null)
         {
-            if (_currentCommand.ThrowOnUnexpectedArgument)
+            switch (_config.UnrecognizedArgumentHandling)
             {
-                _currentCommand.ShowHint();
-                var value = argValue ?? _enumerator.Current?.Raw;
+                case UnrecognizedArgumentHandling.Throw:
+                    _currentCommand.ShowHint();
+                    var value = argValue ?? _enumerator.Current?.Raw;
 
-                var suggestions = Enumerable.Empty<string>();
+                    var suggestions = Enumerable.Empty<string>();
 
-                if (_currentCommand.MakeSuggestionsInErrorMessage && !string.IsNullOrEmpty(value))
-                {
-                    suggestions = SuggestionCreator.GetTopSuggestions(_currentCommand, value);
-                }
+                    if (_currentCommand.MakeSuggestionsInErrorMessage && !string.IsNullOrEmpty(value))
+                    {
+                        suggestions = SuggestionCreator.GetTopSuggestions(_currentCommand, value);
+                    }
 
-                throw new UnrecognizedCommandParsingException(_currentCommand, suggestions,
-                    $"Unrecognized {argTypeName} '{value}'");
+                    throw new UnrecognizedCommandParsingException(_currentCommand, suggestions,
+                        $"Unrecognized {argTypeName} '{value}'");
+
+                case UnrecognizedArgumentHandling.StopParsingAndCollect:
+                default:
+                    break;
             }
 
             // All remaining arguments are stored for further use

--- a/src/CommandLineUtils/Internal/ParserConfig.cs
+++ b/src/CommandLineUtils/Internal/ParserConfig.cs
@@ -40,5 +40,11 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         internal bool OptionNameAndValueCanBeSpaceSeparated { get; private set; } = true;
+
+        /// <summary>
+        /// Set the behavior for how to handle unrecognized arguments.
+        /// </summary>
+        public UnrecognizedArgumentHandling UnrecognizedArgumentHandling { get; set; } =
+            UnrecognizedArgumentHandling.Throw;
     }
 }

--- a/src/CommandLineUtils/PublicAPI.Shipped.txt
+++ b/src/CommandLineUtils/PublicAPI.Shipped.txt
@@ -106,9 +106,6 @@ McMaster.Extensions.CommandLineUtils.CommandLineApplication.Argument<T>(string n
 McMaster.Extensions.CommandLineUtils.CommandLineApplication.Arguments.get -> System.Collections.Generic.List<McMaster.Extensions.CommandLineUtils.CommandArgument>
 McMaster.Extensions.CommandLineUtils.CommandLineApplication.ClusterOptions.get -> bool
 McMaster.Extensions.CommandLineUtils.CommandLineApplication.ClusterOptions.set -> void
-McMaster.Extensions.CommandLineUtils.CommandLineApplication.Command(string name, System.Action<McMaster.Extensions.CommandLineUtils.CommandLineApplication> configuration, bool throwOnUnexpectedArg = true) -> McMaster.Extensions.CommandLineUtils.CommandLineApplication
-McMaster.Extensions.CommandLineUtils.CommandLineApplication.Command<TModel>(string name, System.Action<McMaster.Extensions.CommandLineUtils.CommandLineApplication<TModel>> configuration, bool throwOnUnexpectedArg = true) -> McMaster.Extensions.CommandLineUtils.CommandLineApplication<TModel>
-McMaster.Extensions.CommandLineUtils.CommandLineApplication.CommandLineApplication(bool throwOnUnexpectedArg = true) -> void
 McMaster.Extensions.CommandLineUtils.CommandLineApplication.CommandLineApplication(McMaster.Extensions.CommandLineUtils.HelpText.IHelpTextGenerator helpTextGenerator, McMaster.Extensions.CommandLineUtils.IConsole console, string workingDirectory, bool throwOnUnexpectedArg) -> void
 McMaster.Extensions.CommandLineUtils.CommandLineApplication.CommandLineApplication(McMaster.Extensions.CommandLineUtils.IConsole console, string workingDirectory, bool throwOnUnexpectedArg) -> void
 McMaster.Extensions.CommandLineUtils.CommandLineApplication.CommandLineApplication(McMaster.Extensions.CommandLineUtils.IConsole console) -> void
@@ -186,7 +183,6 @@ McMaster.Extensions.CommandLineUtils.CommandLineApplication.VersionOption(string
 McMaster.Extensions.CommandLineUtils.CommandLineApplication.VersionOption(string template, System.Func<string> shortFormVersionGetter, System.Func<string> longFormVersionGetter = null) -> McMaster.Extensions.CommandLineUtils.CommandOption
 McMaster.Extensions.CommandLineUtils.CommandLineApplication.WorkingDirectory.get -> string
 McMaster.Extensions.CommandLineUtils.CommandLineApplication<TModel>
-McMaster.Extensions.CommandLineUtils.CommandLineApplication<TModel>.CommandLineApplication(bool throwOnUnexpectedArg = true) -> void
 McMaster.Extensions.CommandLineUtils.CommandLineApplication<TModel>.CommandLineApplication(McMaster.Extensions.CommandLineUtils.HelpText.IHelpTextGenerator helpTextGenerator, McMaster.Extensions.CommandLineUtils.IConsole console, string workingDirectory, bool throwOnUnexpectedArg) -> void
 McMaster.Extensions.CommandLineUtils.CommandLineApplication<TModel>.CommandLineApplication(McMaster.Extensions.CommandLineUtils.IConsole console, string workingDirectory, bool throwOnUnexpectedArg) -> void
 McMaster.Extensions.CommandLineUtils.CommandLineApplication<TModel>.CommandLineApplication(McMaster.Extensions.CommandLineUtils.IConsole console) -> void

--- a/src/CommandLineUtils/PublicAPI.Unshipped.txt
+++ b/src/CommandLineUtils/PublicAPI.Unshipped.txt
@@ -1,0 +1,19 @@
+McMaster.Extensions.CommandLineUtils.CommandAttribute.UnrecognizedArgumentHandling.set -> void
+McMaster.Extensions.CommandLineUtils.CommandAttribute.UnrecognizedArgumentHandling.get -> McMaster.Extensions.CommandLineUtils.UnrecognizedArgumentHandling
+McMaster.Extensions.CommandLineUtils.CommandLineApplication.CommandLineApplication(McMaster.Extensions.CommandLineUtils.HelpText.IHelpTextGenerator helpTextGenerator, McMaster.Extensions.CommandLineUtils.IConsole console, string workingDirectory) -> void
+McMaster.Extensions.CommandLineUtils.CommandLineApplication.CommandLineApplication(McMaster.Extensions.CommandLineUtils.IConsole console, string workingDirectory) -> void
+McMaster.Extensions.CommandLineUtils.CommandLineApplication.CommandLineApplication(bool throwOnUnexpectedArg) -> void
+McMaster.Extensions.CommandLineUtils.CommandLineApplication.CommandLineApplication() -> void
+McMaster.Extensions.CommandLineUtils.CommandLineApplication<TModel>.CommandLineApplication(McMaster.Extensions.CommandLineUtils.HelpText.IHelpTextGenerator helpTextGenerator, McMaster.Extensions.CommandLineUtils.IConsole console, string workingDirectory) -> void
+McMaster.Extensions.CommandLineUtils.CommandLineApplication<TModel>.CommandLineApplication(McMaster.Extensions.CommandLineUtils.IConsole console, string workingDirectory) -> void
+McMaster.Extensions.CommandLineUtils.CommandLineApplication<TModel>.CommandLineApplication(bool throwOnUnexpectedArg) -> void
+McMaster.Extensions.CommandLineUtils.CommandLineApplication<TModel>.CommandLineApplication() -> void
+McMaster.Extensions.CommandLineUtils.CommandLineApplication.UnrecognizedArgumentHandling.set -> void
+McMaster.Extensions.CommandLineUtils.CommandLineApplication.UnrecognizedArgumentHandling.get -> McMaster.Extensions.CommandLineUtils.UnrecognizedArgumentHandling
+McMaster.Extensions.CommandLineUtils.CommandLineApplication.Command(string name, System.Action<McMaster.Extensions.CommandLineUtils.CommandLineApplication> configuration) -> McMaster.Extensions.CommandLineUtils.CommandLineApplication
+McMaster.Extensions.CommandLineUtils.CommandLineApplication.Command(string name, System.Action<McMaster.Extensions.CommandLineUtils.CommandLineApplication> configuration, bool throwOnUnexpectedArg) -> McMaster.Extensions.CommandLineUtils.CommandLineApplication
+McMaster.Extensions.CommandLineUtils.CommandLineApplication.Command<TModel>(string name, System.Action<McMaster.Extensions.CommandLineUtils.CommandLineApplication<TModel>> configuration) -> McMaster.Extensions.CommandLineUtils.CommandLineApplication<TModel>
+McMaster.Extensions.CommandLineUtils.CommandLineApplication.Command<TModel>(string name, System.Action<McMaster.Extensions.CommandLineUtils.CommandLineApplication<TModel>> configuration, bool throwOnUnexpectedArg) -> McMaster.Extensions.CommandLineUtils.CommandLineApplication<TModel>
+McMaster.Extensions.CommandLineUtils.UnrecognizedArgumentHandling
+McMaster.Extensions.CommandLineUtils.UnrecognizedArgumentHandling.StopParsingAndCollect = 1 -> McMaster.Extensions.CommandLineUtils.UnrecognizedArgumentHandling
+McMaster.Extensions.CommandLineUtils.UnrecognizedArgumentHandling.Throw = 0 -> McMaster.Extensions.CommandLineUtils.UnrecognizedArgumentHandling

--- a/src/CommandLineUtils/UnrecognizedArgumentHandling.cs
+++ b/src/CommandLineUtils/UnrecognizedArgumentHandling.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Nate McMaster.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace McMaster.Extensions.CommandLineUtils
+{
+    /// <summary>
+    /// Defines behaviors for for how unrecognized arguments should be handled.
+    /// </summary>
+    public enum UnrecognizedArgumentHandling
+    {
+        /// <summary>
+        /// When an unrecognized argument is encountered, throw <see cref="CommandParsingException"/>.
+        /// </summary>
+        Throw = 0,
+
+        /// <summary>
+        /// When an unrecognized argument is encountered, stop parsing arguments and put all remaining arguments,
+        /// including the first unrecognized argument, in <see cref="CommandLineApplication.RemainingArguments"/>.
+        /// </summary>
+        StopParsingAndCollect,
+    }
+}

--- a/src/CommandLineUtils/releasenotes.props
+++ b/src/CommandLineUtils/releasenotes.props
@@ -1,5 +1,14 @@
 <Project>
   <PropertyGroup>
+    <PackageReleaseNotes Condition="$(VersionPrefix.StartsWith('2.6.'))">
+The refactor-prep release.
+
+The purpose of this release is to introduce new API and obsolete existing API. Obsolete API still works as expected,
+but you will get compiler warnings about what is going to change in 3.0.
+
+Changes:
+* throwOnUnexpectedArg deprecated in favor of UnrecognizedArgumentHandling
+    </PackageReleaseNotes>
     <PackageReleaseNotes Condition="$(VersionPrefix.StartsWith('2.5.'))">
 Features and bug fixes:
 

--- a/src/Hosting.CommandLine/Internal/CommandLineService.cs
+++ b/src/Hosting.CommandLine/Internal/CommandLineService.cs
@@ -32,7 +32,7 @@ namespace McMaster.Extensions.Hosting.CommandLine.Internal
 
             logger.LogDebug("Constructing CommandLineApplication<{type}> with args [{args}]",
                 typeof(T).FullName, string.Join(",", state.Arguments));
-            _application = new CommandLineApplication<T>(state.Console, state.WorkingDirectory, true);
+            _application = new CommandLineApplication<T>(state.Console, state.WorkingDirectory);
             _application.Conventions
                 .UseDefaultConventions()
                 .UseConstructorInjection(serviceProvider);

--- a/test/CommandLineUtils.Tests/CommandAttributeTests.cs
+++ b/test/CommandLineUtils.Tests/CommandAttributeTests.cs
@@ -7,7 +7,10 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
 {
     public class CommandAttributeTests
     {
-        [Command(ResponseFileHandling = ResponseFileHandling.ParseArgsAsLineSeparated, AllowArgumentSeparator = true, ThrowOnUnexpectedArgument = false)]
+        [Command(
+            ResponseFileHandling = ResponseFileHandling.ParseArgsAsLineSeparated,
+            AllowArgumentSeparator = true,
+            UnrecognizedArgumentHandling = UnrecognizedArgumentHandling.StopParsingAndCollect)]
         private class ParsingOptions
         { }
 
@@ -18,8 +21,8 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             app.Conventions.UseCommandAttribute();
 
             Assert.Equal(ResponseFileHandling.ParseArgsAsLineSeparated, app.ResponseFileHandling);
+            Assert.Equal(UnrecognizedArgumentHandling.StopParsingAndCollect, app.UnrecognizedArgumentHandling);
             Assert.True(app.AllowArgumentSeparator);
-            Assert.False(app.ThrowOnUnexpectedArgument);
         }
     }
 }

--- a/test/CommandLineUtils.Tests/CommandLineApplicationExecutorTests.cs
+++ b/test/CommandLineUtils.Tests/CommandLineApplicationExecutorTests.cs
@@ -232,7 +232,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             Assert.Equal(200, await CommandLineApplication.ExecuteAsync<TaskReturnType>());
         }
 
-        [Command(ThrowOnUnexpectedArgument = false)]
+        [Command(UnrecognizedArgumentHandling = UnrecognizedArgumentHandling.StopParsingAndCollect)]
         private class ContextApp
         {
             public int OnExecute(CommandLineContext context)
@@ -313,7 +313,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         private class Subcommand
         {
             public DisposableParentCommand Parent { get; }
-            
+
             public void OnExecute()
             {
                 Assert.NotNull(Parent);

--- a/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
+++ b/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
@@ -186,7 +186,7 @@ Options:
         public void ShowHelpWithSubcommands(string helpOption, string expectedHintText, string expectedOptionsText,
             string expectedCommandsText)
         {
-            var app = new CommandLineApplication {Name = "test"};
+            var app = new CommandLineApplication { Name = "test" };
             if (helpOption != null) app.HelpOption(helpOption);
             app.Command("Subcommand", _ => { });
             app.Conventions.UseDefaultConventions();

--- a/test/CommandLineUtils.Tests/FilePathExistsAttributeTests.cs
+++ b/test/CommandLineUtils.Tests/FilePathExistsAttributeTests.cs
@@ -34,7 +34,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         {
             var app = new CommandLineApplication(
                 new TestConsole(_output),
-                AppContext.BaseDirectory, false);
+                AppContext.BaseDirectory);
 
             app.Argument("Files", "Files")
                 .Accepts().ExistingFileOrDirectory();
@@ -71,13 +71,11 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
 
             var appInBaseDir = new CommandLineApplication(
                 new TestConsole(_output),
-                AppContext.BaseDirectory,
-                false);
+                AppContext.BaseDirectory);
             var notFoundDir = Path.Combine(AppContext.BaseDirectory, "notfound");
             var appNotInBaseDir = new CommandLineApplication(
                new TestConsole(_output),
-               notFoundDir,
-               false);
+               notFoundDir);
 
             appInBaseDir.Argument("Files", "Files")
                 .Accepts(v => v.ExistingFileOrDirectory());

--- a/test/CommandLineUtils.Tests/FilePathNotExistsAttributeTests.cs
+++ b/test/CommandLineUtils.Tests/FilePathNotExistsAttributeTests.cs
@@ -40,7 +40,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
 
             var app = new CommandLineApplication(
                 new TestConsole(_output),
-                AppContext.BaseDirectory, false);
+                AppContext.BaseDirectory);
 
             app.Argument("Files", "Files")
                 .Accepts().NonExistingFileOrDirectory();
@@ -68,13 +68,11 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
 
             var appInBaseDir = new CommandLineApplication(
                 new TestConsole(_output),
-                AppContext.BaseDirectory,
-                false);
+                AppContext.BaseDirectory);
             var notFoundDir = Path.Combine(AppContext.BaseDirectory, "notfound");
             var appNotInBaseDir = new CommandLineApplication(
                new TestConsole(_output),
-               notFoundDir,
-               false);
+               notFoundDir);
 
             appInBaseDir.Argument("Files", "Files")
                 .Accepts(v => v.NonExistingFileOrDirectory());

--- a/test/CommandLineUtils.Tests/RemainingArgsPropertyConventionTests.cs
+++ b/test/CommandLineUtils.Tests/RemainingArgsPropertyConventionTests.cs
@@ -17,7 +17,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         protected CommandLineApplication<T> Create<T>() where T : class
         {
             var app = Create<T, RemainingArgsPropertyConvention>();
-            app.ThrowOnUnexpectedArgument = false;
+            app.UnrecognizedArgumentHandling = UnrecognizedArgumentHandling.StopParsingAndCollect;
             return app;
         }
 
@@ -57,7 +57,10 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         public void ItSetsRemainingArgsOnSubcommand()
         {
             var app = Create<Parent>();
-            app.Command<RemainingArgs_Array>("subcmd", _ => { }, throwOnUnexpectedArg: false);
+            app.Command<RemainingArgs_Array>("subcmd", s =>
+            {
+                s.UnrecognizedArgumentHandling = UnrecognizedArgumentHandling.StopParsingAndCollect;
+            });
             var result = app.Parse("subcmd", "a", "b");
             var subcmd = Assert.IsType<CommandLineApplication<RemainingArgs_Array>>(result.SelectedCommand);
             Assert.Equal(new[] { "a", "b" }, subcmd.Model.RemainingArgs);
@@ -71,7 +74,10 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         [Fact]
         public void ItSetsRemainingArguments_List()
         {
-            var app = new CommandLineApplication<RemainingArgs_List>(false);
+            var app = new CommandLineApplication<RemainingArgs_List>
+            {
+                UnrecognizedArgumentHandling = UnrecognizedArgumentHandling.StopParsingAndCollect,
+            };
             app.Conventions.UseDefaultConventions();
             app.Parse("a", "b");
             Assert.Equal(new[] { "a", "b" }, app.Model.RemainingArguments);

--- a/test/CommandLineUtils.Tests/ResponseFileTests.cs
+++ b/test/CommandLineUtils.Tests/ResponseFileTests.cs
@@ -232,7 +232,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         {
             var app = new CommandLineApplication
             {
-                ThrowOnUnexpectedArgument = false,
+                UnrecognizedArgumentHandling = UnrecognizedArgumentHandling.StopParsingAndCollect,
                 ResponseFileHandling = ResponseFileHandling.ParseArgsAsSpaceSeparated,
                 AllowArgumentSeparator = true,
             };
@@ -247,7 +247,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         {
             var app = new CommandLineApplication
             {
-                ThrowOnUnexpectedArgument = false,
+                UnrecognizedArgumentHandling = UnrecognizedArgumentHandling.StopParsingAndCollect,
                 ResponseFileHandling = ResponseFileHandling.ParseArgsAsSpaceSeparated,
                 AllowArgumentSeparator = true,
             };
@@ -279,10 +279,12 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         [Fact]
         public void HandlesResponseFilesWhenGivenAsOptionArg()
         {
-            var app = new CommandLineApplication(throwOnUnexpectedArg: false)
+            var app = new CommandLineApplication
             {
                 ResponseFileHandling = ResponseFileHandling.ParseArgsAsSpaceSeparated,
+                UnrecognizedArgumentHandling = UnrecognizedArgumentHandling.StopParsingAndCollect,
             };
+
             var opt = app.Option("--message <MESSAGE>", "Message", CommandOptionType.SingleValue);
             var rspFile = CreateResponseFile(" 'lorem ipsum' ", "dolor sit amet");
             app.Execute("--message", "@" + rspFile);

--- a/test/CommandLineUtils.Tests/Utilities/CommandLineParser.cs
+++ b/test/CommandLineUtils.Tests/Utilities/CommandLineParser.cs
@@ -21,7 +21,7 @@ namespace McMaster.Extensions.CommandLineUtils
 
         private static T ParseArgsImpl<T>(IConsole console, string[] args) where T : class
         {
-            var app = new CommandLineApplication<T>(console, Directory.GetCurrentDirectory(), true);
+            var app = new CommandLineApplication<T>(console, Directory.GetCurrentDirectory());
             app.Conventions.UseDefaultConventions();
             app.Parse(args);
             return app.Model;

--- a/test/Hosting.CommandLine.Tests/HostBuilderExtensionsTests.cs
+++ b/test/Hosting.CommandLine.Tests/HostBuilderExtensionsTests.cs
@@ -50,7 +50,9 @@ namespace McMaster.Extensions.Hosting.CommandLine.Tests
             var valueHolder = new ValueHolder<string[]>();
             var convention = new Mock<IConvention>();
             convention.Setup(c => c.Apply(It.IsAny<ConventionContext>()))
-                .Callback((ConventionContext c) => c.Application.ThrowOnUnexpectedArgument = false).Verifiable();
+                .Callback((ConventionContext c) =>
+                    c.Application.UnrecognizedArgumentHandling = UnrecognizedArgumentHandling.StopParsingAndCollect)
+                .Verifiable();
             var args = new[] { "Capture", "some", "test", "arguments" };
             await new HostBuilder()
                 .ConfigureServices(collection => collection


### PR DESCRIPTION
Fixes #339 

## What

Adds new API, UnrecognizedArgumentHandling, that I think is a better name for the behavior. It also allows room to add new ways to handle unrecognized arguments.

## Why

This is a common pitfall of using this library. It's legacy API from the original fork of this code, and it's not possible to get rid of it easily. So, this is phase 1 = obsolete it in 2.6. Phase 2 = delete it for the 3.0 release.