### PR TITLE
Provide the ability to set UsePagerForHelpText using the CommandAttribute.

### DIFF
--- a/src/CommandLineUtils/Attributes/CommandAttribute.cs
+++ b/src/CommandLineUtils/Attributes/CommandAttribute.cs
@@ -118,6 +118,11 @@ namespace McMaster.Extensions.CommandLineUtils
         public CultureInfo ParseCulture { get; set; } = CultureInfo.CurrentCulture;
 
         /// <summary>
+        /// Whether a Pager should be used to display help text.
+        /// </summary>
+        public bool UsePagerForHelpText { get; set; } = true;
+
+        /// <summary>
         /// <para>
         /// One or more options of <see cref="CommandOptionType.NoValue"/>, followed by at most one option that takes values, should be accepted when grouped behind one '-' delimiter.
         /// </para>
@@ -170,6 +175,7 @@ namespace McMaster.Extensions.CommandLineUtils
             app.UnrecognizedArgumentHandling = UnrecognizedArgumentHandling;
             app.OptionsComparison = OptionsComparison;
             app.ValueParsers.ParseCulture = ParseCulture;
+            app.UsePagerForHelpText = UsePagerForHelpText;
 
             if (_clusterOptions.HasValue)
             {

--- a/src/CommandLineUtils/PublicAPI.Shipped.txt
+++ b/src/CommandLineUtils/PublicAPI.Shipped.txt
@@ -88,6 +88,8 @@ McMaster.Extensions.CommandLineUtils.CommandAttribute.OptionsComparison.get -> S
 McMaster.Extensions.CommandLineUtils.CommandAttribute.OptionsComparison.set -> void
 McMaster.Extensions.CommandLineUtils.CommandAttribute.ParseCulture.get -> System.Globalization.CultureInfo
 McMaster.Extensions.CommandLineUtils.CommandAttribute.ParseCulture.set -> void
+McMaster.Extensions.CommandLineUtils.CommandAttribute.UsePagerForHelpText.get -> bool
+McMaster.Extensions.CommandLineUtils.CommandAttribute.UsePagerForHelpText.set -> void
 McMaster.Extensions.CommandLineUtils.CommandAttribute.ResponseFileHandling.get -> McMaster.Extensions.CommandLineUtils.ResponseFileHandling
 McMaster.Extensions.CommandLineUtils.CommandAttribute.ResponseFileHandling.set -> void
 McMaster.Extensions.CommandLineUtils.CommandAttribute.ShowInHelpText.get -> bool


### PR DESCRIPTION
I was attempting to create my command line application using the attribute method and couldn't find an existing way of disabling the help text pager. It looks like this is how those sorts of things are exposed... Hopefully this is a minor enough enhancement that I didn't mess it up. =)