### PR TITLE
Support collecting all unrecognized arguments after parsing known args

### DIFF
--- a/src/CommandLineUtils/PublicAPI.Unshipped.txt
+++ b/src/CommandLineUtils/PublicAPI.Unshipped.txt
@@ -13,6 +13,7 @@ McMaster.Extensions.CommandLineUtils.CommandLineApplication.UnrecognizedArgument
 McMaster.Extensions.CommandLineUtils.CommandLineApplication.Command(string name, System.Action<McMaster.Extensions.CommandLineUtils.CommandLineApplication> configuration) -> McMaster.Extensions.CommandLineUtils.CommandLineApplication
 McMaster.Extensions.CommandLineUtils.CommandLineApplication.Command<TModel>(string name, System.Action<McMaster.Extensions.CommandLineUtils.CommandLineApplication<TModel>> configuration) -> McMaster.Extensions.CommandLineUtils.CommandLineApplication<TModel>
 McMaster.Extensions.CommandLineUtils.UnrecognizedArgumentHandling
+McMaster.Extensions.CommandLineUtils.UnrecognizedArgumentHandling.CollectAndContinue = 2 -> McMaster.Extensions.CommandLineUtils.UnrecognizedArgumentHandling
 McMaster.Extensions.CommandLineUtils.UnrecognizedArgumentHandling.StopParsingAndCollect = 1 -> McMaster.Extensions.CommandLineUtils.UnrecognizedArgumentHandling
 McMaster.Extensions.CommandLineUtils.UnrecognizedArgumentHandling.Throw = 0 -> McMaster.Extensions.CommandLineUtils.UnrecognizedArgumentHandling
 static McMaster.Extensions.CommandLineUtils.CommandLineApplicationExtensions.VersionOptionFromAssemblyAttributes(this McMaster.Extensions.CommandLineUtils.CommandLineApplication app, string template, System.Reflection.Assembly assembly) -> McMaster.Extensions.CommandLineUtils.CommandOption

--- a/src/CommandLineUtils/UnrecognizedArgumentHandling.cs
+++ b/src/CommandLineUtils/UnrecognizedArgumentHandling.cs
@@ -18,5 +18,11 @@ namespace McMaster.Extensions.CommandLineUtils
         /// including the first unrecognized argument, in <see cref="CommandLineApplication.RemainingArguments"/>.
         /// </summary>
         StopParsingAndCollect,
+
+        /// <summary>
+        /// When an unrecognized argument is encountered, save it in a list that will be assigned
+        /// to <see cref="CommandLineApplication.RemainingArguments"/>.
+        /// </summary>
+        CollectAndContinue,
     }
 }

--- a/test/CommandLineUtils.Tests/CommandLineApplicationTests.cs
+++ b/test/CommandLineUtils.Tests/CommandLineApplicationTests.cs
@@ -522,6 +522,28 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             Assert.Equal(new[] { "apple", "banana" }, app.RemainingArguments.ToArray());
         }
 
+        [Theory]
+        [InlineData("-Xabc")]
+        [InlineData("-abcX")]
+        [InlineData("-abXc")]
+        public void CollectUnrecognizedClusteredOptions(string clusteredOptions)
+        {
+            var app = new CommandLineApplication
+            {
+                UnrecognizedArgumentHandling = UnrecognizedArgumentHandling.CollectAndContinue,
+            };
+            var optA = app.Option("-a", "Option a", CommandOptionType.NoValue);
+            var optB = app.Option("-b", "Option b", CommandOptionType.NoValue);
+            var optC = app.Option("-c", "Option c", CommandOptionType.NoValue);
+
+            app.Execute("apple", clusteredOptions, "banana");
+
+            Assert.Equal(new[] { "apple", clusteredOptions, "banana" }, app.RemainingArguments.ToArray());
+            Assert.False(optA.HasValue());
+            Assert.False(optB.HasValue());
+            Assert.False(optC.HasValue());
+        }
+
         [Fact]
         public void CollectUnrecognizedOption()
         {

--- a/test/CommandLineUtils.Tests/CommandLineApplicationTests.cs
+++ b/test/CommandLineUtils.Tests/CommandLineApplicationTests.cs
@@ -495,6 +495,72 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         }
 
         [Fact]
+        public void CollectUnrecognizedArguments()
+        {
+            var app = new CommandLineApplication
+            {
+                UnrecognizedArgumentHandling = UnrecognizedArgumentHandling.CollectAndContinue,
+            };
+            app.Argument("foo", "foo");
+
+            app.Execute("apple", "--foo", "bar", "banana");
+
+            Assert.Equal(new[] { "--foo", "bar", "banana" }, app.RemainingArguments.ToArray());
+        }
+
+        [Fact]
+        public void CollectUnrecognizedOptions()
+        {
+            var app = new CommandLineApplication
+            {
+                UnrecognizedArgumentHandling = UnrecognizedArgumentHandling.CollectAndContinue,
+            };
+            app.Option("--foo", "Foo", CommandOptionType.SingleValue);
+
+            app.Execute("apple", "--foo", "bar", "banana");
+
+            Assert.Equal(new[] { "apple", "banana" }, app.RemainingArguments.ToArray());
+        }
+
+        [Fact]
+        public void CollectUnrecognizedOption()
+        {
+            var app = new CommandLineApplication
+            {
+                UnrecognizedArgumentHandling = UnrecognizedArgumentHandling.CollectAndContinue,
+            };
+            app.Execute("apple", "--foo", "bar", "banana");
+
+            Assert.Equal(new[] { "apple", "--foo", "bar", "banana" }, app.RemainingArguments.ToArray());
+        }
+
+        [Fact]
+        public void CollectUnrecognizedArgSeparator()
+        {
+            var app = new CommandLineApplication
+            {
+                UnrecognizedArgumentHandling = UnrecognizedArgumentHandling.CollectAndContinue,
+            };
+            app.Execute("apple", "--", "banana");
+
+            Assert.Equal(new[] { "apple", "--", "banana" }, app.RemainingArguments.ToArray());
+        }
+
+        [Fact]
+        public void CollectBeforeAndAfterArgSeparator()
+        {
+            var app = new CommandLineApplication
+            {
+                UnrecognizedArgumentHandling = UnrecognizedArgumentHandling.CollectAndContinue,
+                AllowArgumentSeparator = true,
+            };
+            app.Option("--option", "abc", CommandOptionType.NoValue);
+            app.Execute("apple", "--option", "--", "banana", "--option");
+
+            Assert.Equal(new[] { "apple", "banana", "--option" }, app.RemainingArguments.ToArray());
+        }
+
+        [Fact]
         public void OptionsCanBeInherited()
         {
             var app = new CommandLineApplication();


### PR DESCRIPTION
Addresses #171 

Prior to this, the only options were to treat all unrecognized arguments as fatal errors, or to treat them as the beginning of a list of unrecognized args. 

This allows a new, third way to handle unrecognized arguments. Regardless of order, all recognized arguments are parsed and the unrecognized ones will be made available in CommandLineApplication. RemainingArguments.