### PR TITLE
Support Builder API in RunCommandLineApplicationAsync<T>()

### DIFF
--- a/src/Hosting.CommandLine/HostBuilderExtensions.cs
+++ b/src/Hosting.CommandLine/HostBuilderExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Nate McMaster.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -63,6 +64,27 @@ namespace Microsoft.Extensions.Hosting
             }
 
             return state.ExitCode;
+        }
+
+        /// <summary>
+        ///     Configures an instance of <see cref="CommandLineApplication" />&lt;<typeparamref name="TApp" />&gt; when it is created.
+        /// </summary>
+        /// <typeparam name="TApp">The type of the command line application implementation</typeparam>
+        /// <param name="hostBuilder">This instance</param>
+        /// <param name="configure">An action which configures an instance of <see cref="CommandLineApplication" />&lt;<typeparamref name="TApp" />&gt;.</param>
+        /// <returns>This instance</returns>
+        /// <seealso href="https://github.com/natemcmaster/CommandLineUtils/issues/271">Builder API support</seealso>
+        public static IHostBuilder UseCommandLineApplication<TApp>(this IHostBuilder hostBuilder, Action<CommandLineApplication<TApp>, IServiceProvider> configure)
+            where TApp : class
+        {
+            if (hostBuilder == null) throw new ArgumentNullException(nameof(hostBuilder));
+
+            hostBuilder.ConfigureServices((context, services) =>
+            {
+                services.AddSingleton(configure);
+            });
+
+            return hostBuilder;
         }
     }
 }

--- a/src/Hosting.CommandLine/Internal/CommandLineService.cs
+++ b/src/Hosting.CommandLine/Internal/CommandLineService.cs
@@ -24,8 +24,9 @@ namespace McMaster.Extensions.Hosting.CommandLine.Internal
         /// <param name="logger">A logger</param>
         /// <param name="state">The command line state</param>
         /// <param name="serviceProvider">The DI service provider</param>
+        /// <param name="configure">An action which configures an instance of <see cref="CommandLineApplication" />&lt;<typeparamref name="T" />&gt;.</param>
         public CommandLineService(ILogger<CommandLineService<T>> logger, CommandLineState state,
-            IServiceProvider serviceProvider)
+            IServiceProvider serviceProvider, Action<CommandLineApplication<T>, IServiceProvider> configure = null)
         {
             _logger = logger;
             _state = state;
@@ -41,6 +42,9 @@ namespace McMaster.Extensions.Hosting.CommandLine.Internal
             {
                 _application.Conventions.AddConvention(convention);
             }
+
+            // If an action was specified with .UseCommandLineApplication<T>(), then invoke it to configure the application
+            configure?.Invoke((CommandLineApplication<T>)_application, serviceProvider);
         }
 
         /// <inheritdoc />

--- a/src/Hosting.CommandLine/PublicAPI.Shipped.txt
+++ b/src/Hosting.CommandLine/PublicAPI.Shipped.txt
@@ -2,3 +2,4 @@ McMaster.Extensions.Hosting.CommandLine.IUnhandledExceptionHandler
 McMaster.Extensions.Hosting.CommandLine.IUnhandledExceptionHandler.HandleException(System.Exception e) -> void
 Microsoft.Extensions.Hosting.HostBuilderExtensions
 static Microsoft.Extensions.Hosting.HostBuilderExtensions.RunCommandLineApplicationAsync<TApp>(this Microsoft.Extensions.Hosting.IHostBuilder hostBuilder, string[] args, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>
+static Microsoft.Extensions.Hosting.HostBuilderExtensions.UseCommandLineApplication<TApp>(this Microsoft.Extensions.Hosting.IHostBuilder hostBuilder, System.Action<McMaster.Extensions.CommandLineUtils.CommandLineApplication<TApp>, System.IServiceProvider> configure) -> Microsoft.Extensions.Hosting.IHostBuilder

--- a/test/Hosting.CommandLine.Tests/HostBuilderExtensionsTests.cs
+++ b/test/Hosting.CommandLine.Tests/HostBuilderExtensionsTests.cs
@@ -65,6 +65,23 @@ namespace McMaster.Extensions.Hosting.CommandLine.Tests
         }
 
         [Fact]
+        public void TestUseCommandLineApplication()
+        {
+            var configure = new Mock<Action<CommandLineApplication<Return42Command>, IServiceProvider>>();
+            configure.Setup(c => c.Invoke(It.IsAny<CommandLineApplication<Return42Command>>(), It.IsAny<IServiceProvider>()));
+
+            Assert.Equal(42,
+                new HostBuilder()
+                    .ConfigureServices(collection => collection.AddSingleton<IConsole>(new TestConsole(_output)))
+                    .UseCommandLineApplication<Return42Command>(configure.Object)
+                    .RunCommandLineApplicationAsync<Return42Command>(new string[0])
+                    .GetAwaiter()
+                    .GetResult());
+
+            Mock.Verify(configure);
+        }
+
+        [Fact]
         public void ItThrowsOnUnknownSubCommand()
         {
             var ex = Assert.Throws<UnrecognizedCommandParsingException>(


### PR DESCRIPTION
Resolves #271

Allows code like this:

```
    class Program
    {
        public static async Task<int> Main(string[] args)
        {
            var result = await
                Host
                .CreateDefaultBuilder()
                .UseCommandLineApplication<Worker>((application, serviceProvider) =>
                {
                    Configure(application, serviceProvider);
                })
                .RunCommandLineApplicationAsync<Worker>(args)
                ;

            return result;
        }

        public static void Configure(CommandLineApplication<Worker> application, IServiceProvider serviceProvider)
        {
            application.Name = "SomeName";
            application.Command("SomeCommand", (command) =>
                command.Option<int>("-p|--port <value>", "Port number", CommandOptionType.SingleValue)
            );
        }
    }

    public class Worker
    {
        public int OnExecute()
        {
            return 42;
        }
    }
```

The IServiceProvider parameter can be used to create new objects with dependency injection during construction...
```
    public static void Configure(CommandLineApplication<Worker> application, IServiceProvider serviceProvider)
    {
        var myClass = ActivatorUtilities.CreateInstance<ClassWithConstructorInjection>(serviceProvider);
    }

    public class ClassWithConstructorInjection
    {
        ILogger _logger;

        public ClassWithConstructorInjection(ILogger<ClassWithConstructorInjection> logger)
        {
            _logger = logger;
        }
    }
```