### PR TITLE
Suppress PlatformNotSupportedException on Xamarin of macOS

### DIFF
--- a/src/CommandLineUtils/IO/PhysicalConsole.cs
+++ b/src/CommandLineUtils/IO/PhysicalConsole.cs
@@ -27,7 +27,18 @@ namespace McMaster.Extensions.CommandLineUtils
         public event ConsoleCancelEventHandler? CancelKeyPress
         {
             add => Console.CancelKeyPress += value;
-            remove => Console.CancelKeyPress -= value;
+            remove
+            {
+                try
+                {
+                    Console.CancelKeyPress -= value;
+                }
+                catch (PlatformNotSupportedException)
+                {
+                    // https://github.com/natemcmaster/CommandLineUtils/issues/344
+                    // Suppress this error during unsubscription on some Xamarin platforms.
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fix #344 