### PR TITLE
Show allowed values in help text

### DIFF
--- a/src/CommandLineUtils/Attributes/AllowedValuesAttribute.cs
+++ b/src/CommandLineUtils/Attributes/AllowedValuesAttribute.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.ObjectModel;
 using System.ComponentModel.DataAnnotations;
 
 namespace McMaster.Extensions.CommandLineUtils
@@ -27,6 +28,8 @@ namespace McMaster.Extensions.CommandLineUtils
             : this(StringComparison.CurrentCulture, allowedValues)
         {
         }
+
+        internal ReadOnlyCollection<string> AllowedValues => Array.AsReadOnly(this._allowedValues);
 
         /// <summary>
         /// Initializes an instance of <see cref="AllowedValuesAttribute"/>.

--- a/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
+++ b/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using McMaster.Extensions.CommandLineUtils.Validation;
 
 namespace McMaster.Extensions.CommandLineUtils.HelpText
 {
@@ -196,6 +197,13 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
                         ? $"{arg.Description}\nAllowed values are: {string.Join(", ", enumNames)}."
                         : arg.Description;
 
+                    var attributeValidator = arg.Validators.Cast<AttributeValidator>().FirstOrDefault();
+
+                    if (attributeValidator != null && attributeValidator.ValidationAttribute is AllowedValuesAttribute allowedValuesAttribute)
+                    {
+                        description += $"\nAllowed values are: {string.Join(", ", allowedValuesAttribute.AllowedValues)}.";
+                    }
+
                     var wrappedDescription = IndentWriter?.Write(description);
                     var message = string.Format(outputFormat, arg.Name, wrappedDescription);
 
@@ -230,6 +238,13 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
                     var description = enumNames.Any()
                         ? $"{opt.Description}\nAllowed values are: {string.Join(", ", enumNames)}."
                         : opt.Description;
+
+                    var attributeValidator = opt.Validators.Cast<AttributeValidator>().FirstOrDefault();
+
+                    if (attributeValidator != null && attributeValidator.ValidationAttribute is AllowedValuesAttribute allowedValuesAttribute)
+                    {
+                        description+= $"\nAllowed values are: {string.Join(", ", allowedValuesAttribute.AllowedValues)}.";
+                    }
 
                     var wrappedDescription = IndentWriter?.Write(description);
                     var message = string.Format(outputFormat, Format(opt), wrappedDescription);

--- a/src/CommandLineUtils/Validation/AttributeValidator.cs
+++ b/src/CommandLineUtils/Validation/AttributeValidator.cs
@@ -24,6 +24,8 @@ namespace McMaster.Extensions.CommandLineUtils.Validation
             _attribute = attribute ?? throw new ArgumentNullException(nameof(attribute));
         }
 
+        internal ValidationAttribute ValidationAttribute => this._attribute;
+
         /// <summary>
         /// Gets the validation result for a command line option.
         /// </summary>

--- a/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
+++ b/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
@@ -108,25 +108,31 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             var app = new CommandLineApplication();
             app.HelpOption();
             app.Option("--strOpt <E>", "str option desc.", CommandOptionType.SingleValue);
+            app.Option("--rStrOpt <E>", "restricted str option desc.", CommandOptionType.SingleValue, o => o.Accepts().Values("Foo", "Bar"));
             app.Option<int>("--intOpt <E>", "int option desc.", CommandOptionType.SingleValue);
             app.Option<SomeEnum>("--enumOpt <E>", "enum option desc.", CommandOptionType.SingleValue);
             app.Argument("SomeStringArgument", "string arg desc.");
+            app.Argument("RestrictedStringArgument", "restricted string arg desc.", a=>a.Accepts().Values("Foo", "Bar"));
             app.Argument<SomeEnum>("SomeEnumArgument", "enum arg desc.");
             var helpText = GetHelpText(app);
 
-            Assert.Equal(@"Usage:  [options] <SomeStringArgument> <SomeEnumArgument>
+            Assert.Equal(@"Usage:  [options] <SomeStringArgument> <RestrictedStringArgument> <SomeEnumArgument>
 
 Arguments:
-  SomeStringArgument  string arg desc.
-  SomeEnumArgument    enum arg desc.
-                      Allowed values are: None, Normal, Extreme.
+  SomeStringArgument        string arg desc.
+  RestrictedStringArgument  restricted string arg desc.
+                            Allowed values are: Foo, Bar.
+  SomeEnumArgument          enum arg desc.
+                            Allowed values are: None, Normal, Extreme.
 
 Options:
-  -?|-h|--help        Show help information.
-  --strOpt <E>        str option desc.
-  --intOpt <E>        int option desc.
-  --enumOpt <E>       enum option desc.
-                      Allowed values are: None, Normal, Extreme.
+  -?|-h|--help              Show help information.
+  --strOpt <E>              str option desc.
+  --rStrOpt <E>             restricted str option desc.
+                            Allowed values are: Foo, Bar.
+  --intOpt <E>              int option desc.
+  --enumOpt <E>             enum option desc.
+                            Allowed values are: None, Normal, Extreme.
 
 ",
             helpText,
@@ -141,15 +147,19 @@ Options:
             app.Conventions.UseDefaultConventions();
             var helpText = GetHelpText(app);
 
-            Assert.Equal(@"Usage: test [options] <SomeStringArgument> <SomeEnumArgument>
+            Assert.Equal(@"Usage: test [options] <SomeStringArgument> <RestrictedStringArgument> <SomeEnumArgument>
 
 Arguments:
   SomeStringArgument                string arg desc.
+  RestrictedStringArgument          restricted string arg desc.
+                                    Allowed values are: Foo, Bar.
   SomeEnumArgument                  enum arg desc.
                                     Allowed values are: None, Normal, Extreme.
 
 Options:
   -strOpt|--str-opt <STR_OPT>       str option desc.
+  -rStrOpt|--r-str-opt <R_STR_OPT>  restricted str option desc.
+                                    Allowed values are: Foo, Bar.
   -intOpt|--int-opt <INT_OPT>       int option desc.
   -enumOpt|--verbosity <VERBOSITY>  enum option desc.
                                     Allowed values are: None, Normal, Extreme.
@@ -165,6 +175,10 @@ Options:
             [Option(ShortName = "strOpt", Description = "str option desc.")]
             public string strOpt { get; set; }
 
+            [Option(ShortName = "rStrOpt", Description = "restricted str option desc.")]
+            [AllowedValues("Foo", "Bar")]
+            public string rStrOpt { get; set; }
+
             [Option(ShortName = "intOpt", Description = "int option desc.")]
             public int intOpt { get; set; }
 
@@ -174,7 +188,11 @@ Options:
             [Argument(0, Description = "string arg desc.")]
             public string SomeStringArgument { get; set; }
 
-            [Argument(1, Description = "enum arg desc.")]
+            [Argument(1, Description = "restricted string arg desc.")]
+            [AllowedValues("Foo", "Bar")]
+            public string RestrictedStringArgument { get; set; }
+
+            [Argument(2, Description = "enum arg desc.")]
             public SomeEnum SomeEnumArgument { get; set; }
         }
 


### PR DESCRIPTION
Similar with enum type, if a string argument/option accepts limited value(s), let's show the allowed values in help text.