### PR TITLE
A fix for "show allowed values in help text"

### DIFF
--- a/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
+++ b/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
@@ -202,8 +202,8 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
                         if (attributeValidator?.ValidationAttribute is AllowedValuesAttribute allowedValuesAttribute)
                         {
                             description += $"\nAllowed values are: {string.Join(", ", allowedValuesAttribute.AllowedValues)}.";
+                            break;
                         }
-                        break;
                     }
 
                     var wrappedDescription = IndentWriter?.Write(description);
@@ -246,8 +246,8 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
                         if (attributeValidator?.ValidationAttribute is AllowedValuesAttribute allowedValuesAttribute)
                         {
                             description += $"\nAllowed values are: {string.Join(", ", allowedValuesAttribute.AllowedValues)}.";
+                            break;
                         }
-                        break;
                     }
 
                     var wrappedDescription = IndentWriter?.Write(description);

--- a/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
+++ b/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
@@ -197,11 +197,13 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
                         ? $"{arg.Description}\nAllowed values are: {string.Join(", ", enumNames)}."
                         : arg.Description;
 
-                    var attributeValidator = arg.Validators.Cast<AttributeValidator>().FirstOrDefault();
-
-                    if (attributeValidator != null && attributeValidator.ValidationAttribute is AllowedValuesAttribute allowedValuesAttribute)
+                    foreach (var attributeValidator in arg.Validators.Cast<AttributeValidator>())
                     {
-                        description += $"\nAllowed values are: {string.Join(", ", allowedValuesAttribute.AllowedValues)}.";
+                        if (attributeValidator?.ValidationAttribute is AllowedValuesAttribute allowedValuesAttribute)
+                        {
+                            description += $"\nAllowed values are: {string.Join(", ", allowedValuesAttribute.AllowedValues)}.";
+                        }
+                        break;
                     }
 
                     var wrappedDescription = IndentWriter?.Write(description);
@@ -239,11 +241,13 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
                         ? $"{opt.Description}\nAllowed values are: {string.Join(", ", enumNames)}."
                         : opt.Description;
 
-                    var attributeValidator = opt.Validators.Cast<AttributeValidator>().FirstOrDefault();
-
-                    if (attributeValidator != null && attributeValidator.ValidationAttribute is AllowedValuesAttribute allowedValuesAttribute)
+                    foreach (var attributeValidator in opt.Validators.Cast<AttributeValidator>())
                     {
-                        description+= $"\nAllowed values are: {string.Join(", ", allowedValuesAttribute.AllowedValues)}.";
+                        if (attributeValidator?.ValidationAttribute is AllowedValuesAttribute allowedValuesAttribute)
+                        {
+                            description += $"\nAllowed values are: {string.Join(", ", allowedValuesAttribute.AllowedValues)}.";
+                        }
+                        break;
                     }
 
                     var wrappedDescription = IndentWriter?.Write(description);

--- a/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
+++ b/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.IO;
 using System.Text;
 using McMaster.Extensions.CommandLineUtils.HelpText;
@@ -108,11 +109,11 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             var app = new CommandLineApplication();
             app.HelpOption();
             app.Option("--strOpt <E>", "str option desc.", CommandOptionType.SingleValue);
-            app.Option("--rStrOpt <E>", "restricted str option desc.", CommandOptionType.SingleValue, o => o.Accepts().Values("Foo", "Bar"));
+            app.Option("--rStrOpt <E>", "restricted str option desc.", CommandOptionType.SingleValue, o => o.IsRequired().Accepts().Values("Foo", "Bar"));
             app.Option<int>("--intOpt <E>", "int option desc.", CommandOptionType.SingleValue);
             app.Option<SomeEnum>("--enumOpt <E>", "enum option desc.", CommandOptionType.SingleValue);
             app.Argument("SomeStringArgument", "string arg desc.");
-            app.Argument("RestrictedStringArgument", "restricted string arg desc.", a=>a.Accepts().Values("Foo", "Bar"));
+            app.Argument("RestrictedStringArgument", "restricted string arg desc.", a => a.IsRequired().Accepts().Values("Foo", "Bar"));
             app.Argument<SomeEnum>("SomeEnumArgument", "enum arg desc.");
             var helpText = GetHelpText(app);
 
@@ -176,6 +177,7 @@ Options:
             public string strOpt { get; set; }
 
             [Option(ShortName = "rStrOpt", Description = "restricted str option desc.")]
+            [Required]
             [AllowedValues("Foo", "Bar")]
             public string rStrOpt { get; set; }
 
@@ -189,6 +191,7 @@ Options:
             public string SomeStringArgument { get; set; }
 
             [Argument(1, Description = "restricted string arg desc.")]
+            [Required]
             [AllowedValues("Foo", "Bar")]
             public string RestrictedStringArgument { get; set; }
 


### PR DESCRIPTION
This is a follow up fix for https://github.com/natemcmaster/CommandLineUtils/pull/369
This fixes an issue where it only finds `AllowedValuesAttribute` from the first attribute validator.