### PR TITLE
Show allowed values from `AllowedValues` attribute instead of Enum

### DIFF
--- a/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
+++ b/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
@@ -192,17 +192,25 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
 
                 foreach (var arg in visibleArguments)
                 {
-                    var enumNames = ExtractNamesFromEnum(arg.UnderlyingType);
-                    var description = enumNames.Any()
-                        ? $"{arg.Description}\nAllowed values are: {string.Join(", ", enumNames)}."
-                        : arg.Description;
+                    var description = arg.Description;
+                    var allowedValuesBeenSet = false;
 
                     foreach (var attributeValidator in arg.Validators.Cast<AttributeValidator>())
                     {
                         if (attributeValidator?.ValidationAttribute is AllowedValuesAttribute allowedValuesAttribute)
                         {
                             description += $"\nAllowed values are: {string.Join(", ", allowedValuesAttribute.AllowedValues)}.";
+                            allowedValuesBeenSet = true;
                             break;
+                        }
+                    }
+
+                    if (!allowedValuesBeenSet)
+                    {
+                        var enumNames = ExtractNamesFromEnum(arg.UnderlyingType);
+                        if (enumNames.Any())
+                        {
+                            description += $"\nAllowed values are: {string.Join(", ", enumNames)}.";
                         }
                     }
 
@@ -236,17 +244,25 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
 
                 foreach (var opt in visibleOptions)
                 {
-                    var enumNames = ExtractNamesFromEnum(opt.UnderlyingType);
-                    var description = enumNames.Any()
-                        ? $"{opt.Description}\nAllowed values are: {string.Join(", ", enumNames)}."
-                        : opt.Description;
+                    var description = opt.Description;
+                    var allowedValuesBeenSet = false;
 
                     foreach (var attributeValidator in opt.Validators.Cast<AttributeValidator>())
                     {
                         if (attributeValidator?.ValidationAttribute is AllowedValuesAttribute allowedValuesAttribute)
                         {
                             description += $"\nAllowed values are: {string.Join(", ", allowedValuesAttribute.AllowedValues)}.";
+                            allowedValuesBeenSet = true;
                             break;
+                        }
+                    }
+
+                    if (!allowedValuesBeenSet)
+                    {
+                        var enumNames = ExtractNamesFromEnum(opt.UnderlyingType);
+                        if (enumNames.Any())
+                        {
+                            description += $"\nAllowed values are: {string.Join(", ", enumNames)}.";
                         }
                     }
 

--- a/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
+++ b/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
@@ -112,12 +112,14 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             app.Option("--rStrOpt <E>", "restricted str option desc.", CommandOptionType.SingleValue, o => o.IsRequired().Accepts().Values("Foo", "Bar"));
             app.Option<int>("--intOpt <E>", "int option desc.", CommandOptionType.SingleValue);
             app.Option<SomeEnum>("--enumOpt <E>", "enum option desc.", CommandOptionType.SingleValue);
+            app.Option<SomeEnum>("--rEnumOpt <E>", "restricted enum option desc.", CommandOptionType.SingleValue, o => o.Accepts().Values("None", "Normal"));
             app.Argument("SomeStringArgument", "string arg desc.");
             app.Argument("RestrictedStringArgument", "restricted string arg desc.", a => a.IsRequired().Accepts().Values("Foo", "Bar"));
             app.Argument<SomeEnum>("SomeEnumArgument", "enum arg desc.");
+            app.Argument<SomeEnum>("RestrictedEnumArgument", "restricted enum arg desc.", a => a.Accepts().Values("None", "Normal"));
             var helpText = GetHelpText(app);
 
-            Assert.Equal(@"Usage:  [options] <SomeStringArgument> <RestrictedStringArgument> <SomeEnumArgument>
+            Assert.Equal(@"Usage:  [options] <SomeStringArgument> <RestrictedStringArgument> <SomeEnumArgument> <RestrictedEnumArgument>
 
 Arguments:
   SomeStringArgument        string arg desc.
@@ -125,6 +127,8 @@ Arguments:
                             Allowed values are: Foo, Bar.
   SomeEnumArgument          enum arg desc.
                             Allowed values are: None, Normal, Extreme.
+  RestrictedEnumArgument    restricted enum arg desc.
+                            Allowed values are: None, Normal.
 
 Options:
   -?|-h|--help              Show help information.
@@ -134,6 +138,8 @@ Options:
   --intOpt <E>              int option desc.
   --enumOpt <E>             enum option desc.
                             Allowed values are: None, Normal, Extreme.
+  --rEnumOpt <E>            restricted enum option desc.
+                            Allowed values are: None, Normal.
 
 ",
             helpText,
@@ -148,7 +154,7 @@ Options:
             app.Conventions.UseDefaultConventions();
             var helpText = GetHelpText(app);
 
-            Assert.Equal(@"Usage: test [options] <SomeStringArgument> <RestrictedStringArgument> <SomeEnumArgument>
+            Assert.Equal(@"Usage: test [options] <SomeStringArgument> <RestrictedStringArgument> <SomeEnumArgument> <RestrictedEnumArgument>
 
 Arguments:
   SomeStringArgument                string arg desc.
@@ -156,6 +162,8 @@ Arguments:
                                     Allowed values are: Foo, Bar.
   SomeEnumArgument                  enum arg desc.
                                     Allowed values are: None, Normal, Extreme.
+  RestrictedEnumArgument            restricted enum arg desc.
+                                    Allowed values are: None, Normal.
 
 Options:
   -strOpt|--str-opt <STR_OPT>       str option desc.
@@ -164,6 +172,8 @@ Options:
   -intOpt|--int-opt <INT_OPT>       int option desc.
   -enumOpt|--verbosity <VERBOSITY>  enum option desc.
                                     Allowed values are: None, Normal, Extreme.
+  -rEnumOpt|--verb2 <VERB2>         restricted enum option desc.
+                                    Allowed values are: None, Normal.
   -?|-h|--help                      Show help information.
 
 ",
@@ -187,6 +197,10 @@ Options:
             [Option(ShortName = "enumOpt", Description = "enum option desc.")]
             public SomeEnum Verbosity { get; set; }
 
+            [Option(ShortName = "rEnumOpt", Description = "restricted enum option desc.")]
+            [AllowedValues("None", "Normal")]
+            public SomeEnum Verb2 { get; set; }
+
             [Argument(0, Description = "string arg desc.")]
             public string SomeStringArgument { get; set; }
 
@@ -197,6 +211,10 @@ Options:
 
             [Argument(2, Description = "enum arg desc.")]
             public SomeEnum SomeEnumArgument { get; set; }
+
+            [Argument(3, Description = "restricted enum arg desc.")]
+            [AllowedValues("None", "Normal")]
+            public SomeEnum RestrictedEnumArgument { get; set; }
         }
 
         [Theory]


### PR DESCRIPTION
For example, when use [`HashAlgorithmType`](https://docs.microsoft.com/en-us/dotnet/api/system.security.authentication.hashalgorithmtype?view=netframework-4.8) as the option type, we want to limit the values to Sha256, Sha384 and Sha512.
Prior to the fix, there will be 2 lines of "Default values are: ..." in help text.