### PR TITLE
Add dotnet-format to build.ps1

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -7,6 +7,12 @@
       "commands": [
         "reportgenerator"
       ]
+    },
+    "dotnet-format": {
+      "version": "4.1.131201",
+      "commands": [
+        "dotnet-format"
+      ]
     }
   }
 }

--- a/build.ps1
+++ b/build.ps1
@@ -42,6 +42,14 @@ $artifacts = "$PSScriptRoot/artifacts/"
 Remove-Item -Recurse $artifacts -ErrorAction Ignore
 
 exec dotnet tool restore
+
+[string[]] $formatArgs=@()
+if ($ci) {
+    $formatArgs += '--check'
+}
+
+exec dotnet tool run dotnet-format -- -v detailed @formatArgs "$PSScriptRoot/CommandLineUtils.sln"
+exec dotnet tool run dotnet-format -- -v detailed @formatArgs "$PSScriptRoot/docs/samples/samples.sln"
 exec dotnet build --configuration $Configuration '-warnaserror:CS1591' @MSBuildArgs
 exec dotnet pack --no-restore --no-build --configuration $Configuration -o $artifacts @MSBuildArgs
 exec dotnet build --configuration $Configuration "$PSScriptRoot/docs/samples/samples.sln"


### PR DESCRIPTION
Auto-format code when run locally

Fails CI checks if code doesn't match expected style.