### PR TITLE
Make .Values read-only on CommandArgument/Option

### DIFF
--- a/src/CommandLineUtils/CommandArgument.cs
+++ b/src/CommandLineUtils/CommandArgument.cs
@@ -16,13 +16,7 @@ namespace McMaster.Extensions.CommandLineUtils
     /// <seealso cref="CommandOption"/>
     public class CommandArgument
     {
-        /// <summary>
-        /// Initializes a new instance of <see cref="CommandArgument"/>.
-        /// </summary>
-        public CommandArgument()
-        {
-            Values = new List<string?>();
-        }
+        private protected List<string?> _values = new List<string?>();
 
         /// <summary>
         /// The name of the argument.
@@ -42,7 +36,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <summary>
         /// All values specified, if any.
         /// </summary>
-        public List<string?> Values { get; private set; }
+        public IReadOnlyList<string?> Values => _values;
 
         /// <summary>
         /// Allow multiple values.
@@ -55,6 +49,11 @@ namespace McMaster.Extensions.CommandLineUtils
         public string? Value => Values.FirstOrDefault();
 
         /// <summary>
+        /// True if this argument has been assigned values.
+        /// </summary>
+        public bool HasValue => Values.Any();
+
+        /// <summary>
         /// A collection of validators that execute before invoking <see cref="CommandLineApplication.OnExecute(Func{int})"/>.
         /// When validation fails, <see cref="CommandLineApplication.ValidationErrorHandler"/> is invoked.
         /// </summary>
@@ -65,9 +64,28 @@ namespace McMaster.Extensions.CommandLineUtils
         /// </summary>
         internal Type UnderlyingType { get; set; }
 
-        internal void Reset()
+        /// <summary>
+        /// Try to add a value to this argument.
+        /// </summary>
+        /// <param name="value">The argument value to be added.</param>
+        /// <returns>True if the value was accepted, false if the value cannot be added.</returns>
+        public bool TryParse(string? value)
         {
-            Values.Clear();
+            if (_values.Count == 1 && !MultipleValues)
+            {
+                return false;
+            }
+
+            _values.Add(value);
+            return true;
+        }
+
+        /// <summary>
+        /// Clear any parsed values from this argument.
+        /// </summary>
+        public virtual void Reset()
+        {
+            _values.Clear();
         }
     }
 }

--- a/src/CommandLineUtils/CommandLineApplication.cs
+++ b/src/CommandLineUtils/CommandLineApplication.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.IO;
 using System.Linq;

--- a/src/CommandLineUtils/CommandOption.cs
+++ b/src/CommandLineUtils/CommandOption.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using McMaster.Extensions.CommandLineUtils.Validation;
@@ -17,6 +16,8 @@ namespace McMaster.Extensions.CommandLineUtils
     /// </summary>
     public class CommandOption
     {
+        private protected readonly List<string?> _values = new List<string?>();
+
         /// <summary>
         /// Initializes a new <see cref="CommandOption"/>.
         /// </summary>
@@ -99,7 +100,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <summary>
         /// Any values found during parsing, if any.
         /// </summary>
-        public List<string?> Values { get; } = new List<string?>();
+        public IReadOnlyList<string?> Values => _values;
 
         /// <summary>
         /// Defines the type of the option.
@@ -138,15 +139,15 @@ namespace McMaster.Extensions.CommandLineUtils
             switch (OptionType)
             {
                 case CommandOptionType.MultipleValue:
-                    Values.Add(value);
+                    _values.Add(value);
                     break;
                 case CommandOptionType.SingleOrNoValue:
                 case CommandOptionType.SingleValue:
-                    if (Values.Any())
+                    if (_values.Any())
                     {
                         return false;
                     }
-                    Values.Add(value);
+                    _values.Add(value);
                     break;
                 case CommandOptionType.NoValue:
                     if (value != null)
@@ -156,7 +157,7 @@ namespace McMaster.Extensions.CommandLineUtils
 
                     // Add a value so .HasValue() == true
                     // Also, the count can be used to determine how many times a flag was specified
-                    Values.Add(null);
+                    _values.Add(null);
                     break;
                 default:
                     throw new NotImplementedException();
@@ -235,9 +236,12 @@ namespace McMaster.Extensions.CommandLineUtils
             return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
         }
 
-        internal void Reset()
+        /// <summary>
+        /// Clear any parsed values from this argument.
+        /// </summary>
+        public virtual void Reset()
         {
-            Values.Clear();
+            _values.Clear();
         }
     }
 }

--- a/src/CommandLineUtils/Internal/CommandLineProcessor.cs
+++ b/src/CommandLineUtils/Internal/CommandLineProcessor.cs
@@ -125,7 +125,7 @@ namespace McMaster.Extensions.CommandLineUtils
 
             if (_currentCommandArguments.MoveNext())
             {
-                _currentCommandArguments.Current.Values.Add(arg.Raw);
+                _currentCommandArguments.Current.TryParse(arg.Raw);
                 return true;
             }
 

--- a/src/CommandLineUtils/PublicAPI.Shipped.txt
+++ b/src/CommandLineUtils/PublicAPI.Shipped.txt
@@ -63,7 +63,7 @@ McMaster.Extensions.CommandLineUtils.CommandArgument.ShowInHelpText.get -> bool
 McMaster.Extensions.CommandLineUtils.CommandArgument.ShowInHelpText.set -> void
 McMaster.Extensions.CommandLineUtils.CommandArgument.Validators.get -> System.Collections.Generic.ICollection<McMaster.Extensions.CommandLineUtils.Validation.IArgumentValidator!>!
 McMaster.Extensions.CommandLineUtils.CommandArgument.Value.get -> string?
-McMaster.Extensions.CommandLineUtils.CommandArgument.Values.get -> System.Collections.Generic.List<string?>!
+McMaster.Extensions.CommandLineUtils.CommandArgument.Values.get -> System.Collections.Generic.IReadOnlyList<string?>!
 McMaster.Extensions.CommandLineUtils.CommandArgument<T>
 McMaster.Extensions.CommandLineUtils.CommandArgument<T>.CommandArgument(McMaster.Extensions.CommandLineUtils.Abstractions.IValueParser<T>! valueParser) -> void
 McMaster.Extensions.CommandLineUtils.CommandArgument<T>.ParsedValue.get -> T
@@ -213,7 +213,7 @@ McMaster.Extensions.CommandLineUtils.CommandOption.Validators.get -> System.Coll
 McMaster.Extensions.CommandLineUtils.CommandOption.Value() -> string?
 McMaster.Extensions.CommandLineUtils.CommandOption.ValueName.get -> string?
 McMaster.Extensions.CommandLineUtils.CommandOption.ValueName.set -> void
-McMaster.Extensions.CommandLineUtils.CommandOption.Values.get -> System.Collections.Generic.List<string?>!
+McMaster.Extensions.CommandLineUtils.CommandOption.Values.get -> System.Collections.Generic.IReadOnlyList<string?>!
 McMaster.Extensions.CommandLineUtils.CommandOption<T>
 McMaster.Extensions.CommandLineUtils.CommandOption<T>.CommandOption(McMaster.Extensions.CommandLineUtils.Abstractions.IValueParser<T>! valueParser, string! template, McMaster.Extensions.CommandLineUtils.CommandOptionType optionType) -> void
 McMaster.Extensions.CommandLineUtils.CommandOption<T>.ParsedValue.get -> T

--- a/src/CommandLineUtils/PublicAPI.Unshipped.txt
+++ b/src/CommandLineUtils/PublicAPI.Unshipped.txt
@@ -1,1 +1,5 @@
 #nullable enable
+McMaster.Extensions.CommandLineUtils.CommandArgument.HasValue.get -> bool
+McMaster.Extensions.CommandLineUtils.CommandArgument.TryParse(string? value) -> bool
+virtual McMaster.Extensions.CommandLineUtils.CommandArgument.Reset() -> void
+virtual McMaster.Extensions.CommandLineUtils.CommandOption.Reset() -> void

--- a/src/CommandLineUtils/Validation/AttributeValidator.cs
+++ b/src/CommandLineUtils/Validation/AttributeValidator.cs
@@ -52,7 +52,7 @@ namespace McMaster.Extensions.CommandLineUtils.Validation
         public ValidationResult GetValidationResult(CommandArgument argument, ValidationContext context)
             => GetValidationResult(argument.Values, context);
 
-        private ValidationResult GetValidationResult(List<string?>? values, ValidationContext context)
+        private ValidationResult GetValidationResult(IReadOnlyList<string?>? values, ValidationContext context)
         {
             if (values == null)
             {

--- a/test/CommandLineUtils.Tests/AttributeValidatorTests.cs
+++ b/test/CommandLineUtils.Tests/AttributeValidatorTests.cs
@@ -29,7 +29,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
 
             Assert.Equal(ValidationResult.Success, validator.GetValidationResult(arg, context));
 
-            arg.Values.Add(null);
+            arg.TryParse(null);
 
             Assert.Throws<InvalidOperationException>(() => validator.GetValidationResult(arg, context));
         }
@@ -46,12 +46,12 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             var factory = new CommandLineValidationContextFactory(app);
             var context = factory.Create(arg);
 
-            arg.Values.Add(validValue);
+            arg.TryParse(validValue);
 
             Assert.Equal(ValidationResult.Success, validator.GetValidationResult(arg, context));
 
-            arg.Values.Clear();
-            arg.Values.Add(invalidValue);
+            arg.Reset();
+            arg.TryParse(invalidValue);
             var result = validator.GetValidationResult(arg, context);
             Assert.NotNull(result);
             Assert.NotEmpty(result.ErrorMessage);

--- a/test/CommandLineUtils.Tests/CommandLineApplicationTests.cs
+++ b/test/CommandLineUtils.Tests/CommandLineApplicationTests.cs
@@ -655,7 +655,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             Assert.Equal("top", top.Value());
             Assert.Null(nested?.Value());
 
-            top.Values.Clear();
+            top.Reset();
 
             app.Execute("subcmd", "-a", "nested");
             Assert.Null(top.Value());
@@ -765,7 +765,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
                 app.Parse("--debug:hive", "abc"));
             Assert.Equal("Missing value for option 'debug:hive'", ex.Message);
 
-            option.Values.Clear();
+            option.Reset();
             app.Parse("--debug:hive=abc");
             Assert.Equal("abc", option.Value());
         }

--- a/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
+++ b/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
@@ -242,10 +242,10 @@ Options:
         }
 
         [Theory]
-        [InlineData("-h", "-h", "  -h          Show help information.", "  Subcommand ")]
-        [InlineData("--help", "--help", "  --help      Show help information.", "  Subcommand ")]
-        [InlineData("-?", "-?", "  -?          Show help information.", "  Subcommand ")]
-        [InlineData(null, "-?|-h|--help", "  -?|-h|--help  Show help information.", "  Subcommand   ")]
+        [InlineData("-h", "-h", "  -h          Show help information.", "  Subcommand  ")]
+        [InlineData("--help", "--help", "  --help      Show help information.", "  Subcommand  ")]
+        [InlineData("-?", "-?", "  -?          Show help information.", "  Subcommand  ")]
+        [InlineData(null, "-?|-h|--help", "  -?|-h|--help  Show help information.", "  Subcommand    ")]
         public void ShowHelpWithSubcommands(string helpOption, string expectedHintText, string expectedOptionsText,
             string expectedCommandsText)
         {
@@ -261,7 +261,7 @@ Options:
 {expectedOptionsText}
 
 Commands:
-{expectedCommandsText} 
+{expectedCommandsText}
 
 Run 'test [command] {expectedHintText}' for more information about a command.
 

--- a/test/CommandLineUtils.Tests/ResponseFileTests.cs
+++ b/test/CommandLineUtils.Tests/ResponseFileTests.cs
@@ -30,7 +30,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             return rsp;
         }
 
-        private List<string?> ParseResponseFile(ResponseFileHandling options, params string[] responseFileLines)
+        private IReadOnlyList<string?> ParseResponseFile(ResponseFileHandling options, params string[] responseFileLines)
         {
             var rsp = CreateResponseFile(responseFileLines);
             var app = new CommandLineApplication


### PR DESCRIPTION
Exposing a raw List<string> of values on CommandArgument and
CommandOption has made it difficult to cleanly implement features like
default values or parsing. This changes the return type of .Values to a
read-only list, and adds TryParse for adding new values, and Reset for
clearing them.

## Upgrading

### Before

```csharp
var myOption = new CommandOption("--abc <ABC>", CommandOptionType.MultipleValue);
myOption.Values.Add("xyz");
myOption.Values.AddRange(new [] { "xyz", "123" });
myOption.Values.Clear();

var myArg = new CommandArgument("ABC");
myArg.Values.Add("xyz");
myArg.Values.AddRange(new [] { "xyz", "123" });
myArg.Values.Clear();
```

### After

```csharp
var myOption = new CommandOption("--abc <ABC>", CommandOptionType.MultipleValue);
myOption.TryParse("xyz");  // note! You should check to see the return type on `TryParse` as it might be values if this value was not accepted.
foreach (var v in new [] { "xyz", "123" })
   myOption.TryParse(v);
myOption.Reset();

var myArg = new CommandArgument("ABC");
myArg.TryParse("xyz");  // note! You should check to see the return type on `TryParse` as it might be values if this value was not accepted.
foreach (var v in new [] { "xyz", "123" })
   myArg.TryParse(v);
myArg.Reset();
```