### PR TITLE
Make options, arguments, and commands *read-only* collections on CommandLineApplication

### DIFF
--- a/src/CommandLineUtils/Attributes/OptionAttribute.cs
+++ b/src/CommandLineUtils/Attributes/OptionAttribute.cs
@@ -90,7 +90,7 @@ namespace McMaster.Extensions.CommandLineUtils
 
             option.Description ??= prop.Name;
 
-            app.Options.Add(option);
+            app.AddOption(option);
             return option;
         }
 

--- a/src/CommandLineUtils/Conventions/ArgumentAttributeConvention.cs
+++ b/src/CommandLineUtils/Conventions/ArgumentAttributeConvention.cs
@@ -64,7 +64,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                     }
                 }
 
-                context.Application.Arguments.Add(arg.Value);
+                context.Application.AddArgument(arg.Value);
             }
         }
 

--- a/src/CommandLineUtils/Conventions/DefaultHelpOptionConvention.cs
+++ b/src/CommandLineUtils/Conventions/DefaultHelpOptionConvention.cs
@@ -70,7 +70,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
             if (help.LongName != null || help.ShortName != null || help.SymbolName != null)
             {
                 context.Application.OptionHelp = help;
-                context.Application.Options.Add(help);
+                context.Application.AddOption(help);
             }
         }
     }

--- a/src/CommandLineUtils/Conventions/RemainingArgsPropertyConvention.cs
+++ b/src/CommandLineUtils/Conventions/RemainingArgsPropertyConvention.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 
 namespace McMaster.Extensions.CommandLineUtils.Conventions

--- a/src/CommandLineUtils/Internal/CommandLineProcessor.cs
+++ b/src/CommandLineUtils/Internal/CommandLineProcessor.cs
@@ -335,7 +335,7 @@ namespace McMaster.Extensions.CommandLineUtils
 
                 case UnrecognizedArgumentHandling.CollectAndContinue:
                     var arg = _enumerator.Current;
-                    _currentCommand.RemainingArguments.Add(arg.Raw);
+                    _currentCommand._remainingArguments.Add(arg.Raw);
                     return true;
 
                 case UnrecognizedArgumentHandling.StopParsingAndCollect:
@@ -354,7 +354,7 @@ namespace McMaster.Extensions.CommandLineUtils
                 var arg = _enumerator.Current;
                 if (arg != null)
                 {
-                    _currentCommand.RemainingArguments.Add(arg.Raw);
+                    _currentCommand._remainingArguments.Add(arg.Raw);
                 }
             } while (_enumerator.MoveNext());
         }

--- a/src/CommandLineUtils/PublicAPI.Shipped.txt
+++ b/src/CommandLineUtils/PublicAPI.Shipped.txt
@@ -105,7 +105,7 @@ McMaster.Extensions.CommandLineUtils.CommandLineApplication.AllowArgumentSeparat
 McMaster.Extensions.CommandLineUtils.CommandLineApplication.Argument(string! name, string! description, bool multipleValues = false) -> McMaster.Extensions.CommandLineUtils.CommandArgument!
 McMaster.Extensions.CommandLineUtils.CommandLineApplication.Argument(string! name, string! description, System.Action<McMaster.Extensions.CommandLineUtils.CommandArgument!>! configuration, bool multipleValues = false) -> McMaster.Extensions.CommandLineUtils.CommandArgument!
 McMaster.Extensions.CommandLineUtils.CommandLineApplication.Argument<T>(string! name, string! description, System.Action<McMaster.Extensions.CommandLineUtils.CommandArgument<T>!>! configuration, bool multipleValues = false) -> McMaster.Extensions.CommandLineUtils.CommandArgument<T>!
-McMaster.Extensions.CommandLineUtils.CommandLineApplication.Arguments.get -> System.Collections.Generic.List<McMaster.Extensions.CommandLineUtils.CommandArgument!>!
+McMaster.Extensions.CommandLineUtils.CommandLineApplication.Arguments.get -> System.Collections.Generic.IReadOnlyList<McMaster.Extensions.CommandLineUtils.CommandArgument!>!
 McMaster.Extensions.CommandLineUtils.CommandLineApplication.ClusterOptions.get -> bool
 McMaster.Extensions.CommandLineUtils.CommandLineApplication.ClusterOptions.set -> void
 McMaster.Extensions.CommandLineUtils.CommandLineApplication.Command(string! name, System.Action<McMaster.Extensions.CommandLineUtils.CommandLineApplication!>! configuration) -> McMaster.Extensions.CommandLineUtils.CommandLineApplication!
@@ -114,7 +114,7 @@ McMaster.Extensions.CommandLineUtils.CommandLineApplication.CommandLineApplicati
 McMaster.Extensions.CommandLineUtils.CommandLineApplication.CommandLineApplication(McMaster.Extensions.CommandLineUtils.HelpText.IHelpTextGenerator! helpTextGenerator, McMaster.Extensions.CommandLineUtils.IConsole! console, string! workingDirectory) -> void
 McMaster.Extensions.CommandLineUtils.CommandLineApplication.CommandLineApplication(McMaster.Extensions.CommandLineUtils.IConsole! console, string! workingDirectory) -> void
 McMaster.Extensions.CommandLineUtils.CommandLineApplication.CommandLineApplication(McMaster.Extensions.CommandLineUtils.IConsole! console) -> void
-McMaster.Extensions.CommandLineUtils.CommandLineApplication.Commands.get -> System.Collections.Generic.List<McMaster.Extensions.CommandLineUtils.CommandLineApplication!>!
+McMaster.Extensions.CommandLineUtils.CommandLineApplication.Commands.get -> System.Collections.Generic.IReadOnlyCollection<McMaster.Extensions.CommandLineUtils.CommandLineApplication!>!
 McMaster.Extensions.CommandLineUtils.CommandLineApplication.Conventions.get -> McMaster.Extensions.CommandLineUtils.Conventions.IConventionBuilder!
 McMaster.Extensions.CommandLineUtils.CommandLineApplication.Description.get -> string?
 McMaster.Extensions.CommandLineUtils.CommandLineApplication.Description.set -> void
@@ -152,7 +152,7 @@ McMaster.Extensions.CommandLineUtils.CommandLineApplication.Option<T>(string! te
 McMaster.Extensions.CommandLineUtils.CommandLineApplication.OptionHelp.get -> McMaster.Extensions.CommandLineUtils.CommandOption?
 McMaster.Extensions.CommandLineUtils.CommandLineApplication.OptionNameValueSeparators.get -> char[]!
 McMaster.Extensions.CommandLineUtils.CommandLineApplication.OptionNameValueSeparators.set -> void
-McMaster.Extensions.CommandLineUtils.CommandLineApplication.Options.get -> System.Collections.Generic.List<McMaster.Extensions.CommandLineUtils.CommandOption!>!
+McMaster.Extensions.CommandLineUtils.CommandLineApplication.Options.get -> System.Collections.Generic.IReadOnlyCollection<McMaster.Extensions.CommandLineUtils.CommandOption!>!
 McMaster.Extensions.CommandLineUtils.CommandLineApplication.OptionsComparison.get -> System.StringComparison
 McMaster.Extensions.CommandLineUtils.CommandLineApplication.OptionsComparison.set -> void
 McMaster.Extensions.CommandLineUtils.CommandLineApplication.OptionVersion.get -> McMaster.Extensions.CommandLineUtils.CommandOption?
@@ -161,7 +161,7 @@ McMaster.Extensions.CommandLineUtils.CommandLineApplication.Out.set -> void
 McMaster.Extensions.CommandLineUtils.CommandLineApplication.Parent.get -> McMaster.Extensions.CommandLineUtils.CommandLineApplication?
 McMaster.Extensions.CommandLineUtils.CommandLineApplication.Parent.set -> void
 McMaster.Extensions.CommandLineUtils.CommandLineApplication.Parse(params string![]! args) -> McMaster.Extensions.CommandLineUtils.Abstractions.ParseResult!
-McMaster.Extensions.CommandLineUtils.CommandLineApplication.RemainingArguments.get -> System.Collections.Generic.List<string!>!
+McMaster.Extensions.CommandLineUtils.CommandLineApplication.RemainingArguments.get -> System.Collections.Generic.IReadOnlyList<string!>!
 McMaster.Extensions.CommandLineUtils.CommandLineApplication.ResponseFileHandling.get -> McMaster.Extensions.CommandLineUtils.ResponseFileHandling
 McMaster.Extensions.CommandLineUtils.CommandLineApplication.ResponseFileHandling.set -> void
 McMaster.Extensions.CommandLineUtils.CommandLineApplication.ShortVersionGetter.get -> System.Func<string?>?

--- a/src/CommandLineUtils/PublicAPI.Unshipped.txt
+++ b/src/CommandLineUtils/PublicAPI.Unshipped.txt
@@ -3,3 +3,5 @@ McMaster.Extensions.CommandLineUtils.CommandArgument.HasValue.get -> bool
 McMaster.Extensions.CommandLineUtils.CommandArgument.TryParse(string? value) -> bool
 virtual McMaster.Extensions.CommandLineUtils.CommandArgument.Reset() -> void
 virtual McMaster.Extensions.CommandLineUtils.CommandOption.Reset() -> void
+McMaster.Extensions.CommandLineUtils.CommandLineApplication.AddArgument(McMaster.Extensions.CommandLineUtils.CommandArgument! argument) -> void
+McMaster.Extensions.CommandLineUtils.CommandLineApplication.AddOption(McMaster.Extensions.CommandLineUtils.CommandOption! option) -> void

--- a/test/CommandLineUtils.Tests/CommandLineApplicationTests.cs
+++ b/test/CommandLineUtils.Tests/CommandLineApplicationTests.cs
@@ -745,7 +745,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             {
                 LongName = "debug:hive"
             };
-            app.Options.Add(option);
+            app.AddOption(option);
             app.Parse("--debug:hive", "abc");
             Assert.Equal("abc", option.Value());
         }
@@ -759,7 +759,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             {
                 LongName = "debug:hive"
             };
-            app.Options.Add(option);
+            app.AddOption(option);
 
             var ex = Assert.ThrowsAny<CommandParsingException>(() =>
                 app.Parse("--debug:hive", "abc"));

--- a/test/CommandLineUtils.Tests/HelpOptionAttributeTests.cs
+++ b/test/CommandLineUtils.Tests/HelpOptionAttributeTests.cs
@@ -169,7 +169,10 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             var outWriter = new StringWriter(sb);
             var app = new CommandLineApplication<Parent> { Out = outWriter };
             app.Conventions.UseDefaultConventions();
-            app.Commands.ForEach(f => f.Out = outWriter);
+            foreach (var subcmd in app.Commands)
+            {
+                subcmd.Out = outWriter;
+            }
             app.Execute("lvl2", "--help");
             var outData = sb.ToString();
 
@@ -210,7 +213,10 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
                 return 1;
             });
 
-            app.Commands.ForEach(f => f.Out = outWriter);
+            foreach (var subcmd in app.Commands)
+            {
+                subcmd.Out = outWriter;
+            }
 
             app.Execute(args);
             var outData = sb.ToString();

--- a/test/CommandLineUtils.Tests/OptionAttributeTests.cs
+++ b/test/CommandLineUtils.Tests/OptionAttributeTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using McMaster.Extensions.CommandLineUtils.Conventions;
@@ -314,7 +315,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             var appBuilder = typeof(CommandLineApplication<>).MakeGenericType(program);
             var app = (CommandLineApplication)Activator.CreateInstance(appBuilder, Util.EmptyArray<object>());
             app.Conventions.UseOptionAttributes();
-            return app.Options[0];
+            return app.Options.First();
         }
     }
 }

--- a/test/CommandLineUtils.Tests/ValueParserProviderCustomTests.cs
+++ b/test/CommandLineUtils.Tests/ValueParserProviderCustomTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using System.Linq;
 using System.Threading.Tasks;
 using McMaster.Extensions.CommandLineUtils.Abstractions;
 using Xunit;
@@ -227,7 +228,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
 
             Assert.Equal(1, result);
             Assert.Equal(expectedDate, app.Model.MainDate);
-            Assert.Equal(expectedDate.AddSeconds(123456), ((CommandLineApplication<CustomParserProgramAttributesSubCommand>)app.Commands[0]).Model.SubDate);
+            Assert.Equal(expectedDate.AddSeconds(123456), app.Commands.OfType<CommandLineApplication<CustomParserProgramAttributesSubCommand>>().Single().Model.SubDate);
         }
 
         [Fact]

--- a/test/Hosting.CommandLine.Tests/HostBuilderExtensionsBuilderAPITests.cs
+++ b/test/Hosting.CommandLine.Tests/HostBuilderExtensionsBuilderAPITests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using McMaster.Extensions.CommandLineUtils;
 using McMaster.Extensions.CommandLineUtils.Abstractions;


### PR DESCRIPTION
This gives CommandLineApplication more control over how the definition of the
application is constructed. Validation can be enforced, and refactoring of the internal
storage mechanism can happen without breaking the contract with callers.

## Impact

### Before

```csharp
var app = new CommandLineApplication();
app.Options.Add(new CommandOption("-v", CommandOptionType.NoValue));
app.Arguments.Add(new CommandArgument());
app.Commands.Add(new CommandLineApplication());
```

### After

New API has been added to replace these actions

```csharp
var app = new CommandLineApplication();
app.AddOption(new CommandOption("-v", CommandOptionType.NoValue));
app.AddArgument(new CommandArgument());
app.AddSubcommand(new CommandLineApplication());
```