### PR TITLE
cleanup: upgrade test projects and CI to .NET 5

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,19 +18,24 @@ jobs:
   strategy:
     matrix:
       Linux:
-        vmImage: ubuntu-16.04
+        vmImage: ubuntu-latest
       MacOS:
         vmImage: macOS-latest
       Windows:
-        vmImage: windows-2019
+        vmImage: windows-latest
   pool:
     vmImage: $(vmImage)
   steps:
   - task: UseDotNet@2
-    displayName: Install .NET Core 3.1 SDK
+    displayName: Install .NET 5 SDK
+    inputs:
+      version: '5.x'
+      packageType: sdk
+  - task: UseDotNet@2
+    displayName: Install .NET Core 3.1 runtime
     inputs:
       version: '3.1.x'
-      packageType: sdk
+      packageType: runtime
   - task: UseDotNet@2
     displayName: Install .NET Core 2.1 runtime
     inputs:
@@ -54,15 +59,15 @@ jobs:
   - publish: artifacts/
     artifact: Packages
     displayName: Publish artifacts
-    condition: and(succeeded(), eq('windows-2019', variables['vmImage']))
+    condition: and(succeeded(), eq('windows-latest', variables['vmImage']))
   - powershell: ./docs/generate.ps1 -NoBuild
     displayName: Generate docs
-    condition: and(succeeded(), eq('windows-2019', variables['vmImage']))
+    condition: and(succeeded(), eq('windows-latest', variables['vmImage']))
   - powershell: ./docs/push.ps1 -a $(github-api-token-repo-write)
     displayName: Publish docs to GitHub Pages
     condition: |
       and(
         succeeded(),
-        eq('windows-2019', variables['vmImage']),
+        eq('windows-latest', variables['vmImage']),
         not(eq(variables['Build.Reason'], 'PullRequest')),
         eq(variables['Build.SourceBranch'], 'refs/heads/master'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ jobs:
   strategy:
     matrix:
       Linux:
-        vmImage: ubuntu-latest
+        vmImage: ubuntu-16.04
       MacOS:
         vmImage: macOS-latest
       Windows:

--- a/test/CommandLineUtils.Tests/McMaster.Extensions.CommandLineUtils.Tests.csproj
+++ b/test/CommandLineUtils.Tests/McMaster.Extensions.CommandLineUtils.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
     <TargetFrameworks Condition="'$(TestFullFramework)' != 'false'">$(TargetFrameworks);net472</TargetFrameworks>
   </PropertyGroup>
 
@@ -15,10 +15,10 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="1.3.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.9" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Moq" Version="4.14.7" />
+    <PackageReference Include="Moq" Version="4.15.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>

--- a/test/CommandLineUtils.Tests/OptionAttributeTests.cs
+++ b/test/CommandLineUtils.Tests/OptionAttributeTests.cs
@@ -241,7 +241,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             Assert.Equal(1, PrivateSetterProgram.StaticNumber);
         }
 
-#if !NETCOREAPP3_1
+#if !NETCOREAPP3_1 && !NET5_0
         // .NET Core 3.0 made an intentional breaking change
         // see https://github.com/dotnet/coreclr/issues/21268
         [Fact]

--- a/test/Hosting.CommandLine.Tests/McMaster.Extensions.Hosting.CommandLine.Tests.csproj
+++ b/test/Hosting.CommandLine.Tests/McMaster.Extensions.Hosting.CommandLine.Tests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
     <TargetFrameworks Condition="'$(TestFullFramework)' != 'false'">$(TargetFrameworks);net472</TargetFrameworks>
   </PropertyGroup>
 
@@ -15,9 +15,9 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="1.3.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.9" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="Moq" Version="4.14.7" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Moq" Version="4.15.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>


### PR DESCRIPTION
No changes to supported frameworks in the libraries. Just adding .NET 5 test coverage.

Other cleanups:
* upgrade test dependencies
* update azure-pipelines.yml to always use latest windows versions