### PR TITLE
Update CommandOption/Argument.value to return DefaultValue 

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,7 +30,7 @@
   <PropertyGroup>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);1591</WarningsNotAsErrors>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <Nullable>annotations</Nullable>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)src\StrongName.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ app.OnExecute(() =>
     {
         Console.WriteLine($"Hello {subject.Value()}!");
     }
-    return 0;
 });
 
 return app.Execute(args);

--- a/README.md
+++ b/README.md
@@ -81,19 +81,18 @@ using McMaster.Extensions.CommandLineUtils;
 var app = new CommandLineApplication();
 
 app.HelpOption();
-var optionSubject = app.Option("-s|--subject <SUBJECT>", "The subject", CommandOptionType.SingleValue);
-var optionRepeat = app.Option<int>("-n|--count <N>", "Repeat", CommandOptionType.SingleValue);
+
+var subject = app.Option("-s|--subject <SUBJECT>", "The subject", CommandOptionType.SingleValue);
+subject.DefaultValue = "world";
+
+var repeat = app.Option<int>("-n|--count <N>", "Repeat", CommandOptionType.SingleValue);
+repeat.DefaultValue = 1;
 
 app.OnExecute(() =>
 {
-    var subject = optionSubject.HasValue()
-        ? optionSubject.Value()
-        : "world";
-
-    var count = optionRepeat.HasValue() ? optionRepeat.ParsedValue : 1;
-    for (var i = 0; i < count; i++)
+    for (var i = 0; i < repeat.ParsedValue; i++)
     {
-        Console.WriteLine($"Hello {subject}!");
+        Console.WriteLine($"Hello {subject.Value()}!");
     }
     return 0;
 });

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -65,14 +65,11 @@ public class Program
 
         app.HelpOption();
         var optionSubject = app.Option("-s|--subject <SUBJECT>", "The subject", CommandOptionType.SingleValue);
+        optionSubject.DefaultValue = "world";
 
         app.OnExecute(() =>
         {
-            var subject = optionSubject.HasValue()
-                ? optionSubject.Value()
-                : "world";
-
-            Console.WriteLine($"Hello {subject}!");
+            Console.WriteLine($"Hello {subject.Value()}!");
             return 0;
         });
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -64,8 +64,8 @@ public class Program
         var app = new CommandLineApplication();
 
         app.HelpOption();
-        var optionSubject = app.Option("-s|--subject <SUBJECT>", "The subject", CommandOptionType.SingleValue);
-        optionSubject.DefaultValue = "world";
+        var subject = app.Option("-s|--subject <SUBJECT>", "The subject", CommandOptionType.SingleValue);
+        subject.DefaultValue = "world";
 
         app.OnExecute(() =>
         {

--- a/docs/samples/custom-attribute/Program.cs
+++ b/docs/samples/custom-attribute/Program.cs
@@ -44,12 +44,10 @@ internal class MyFieldConventionAttribute : Attribute, IMemberConvention
         if (member is FieldInfo field)
         {
             var opt = context.Application.Option("--working-dir", "The working directory", CommandOptionType.SingleOrNoValue);
+            opt.DefaultValue = context.Application.WorkingDirectory;
             context.Application.OnParsingComplete(_ =>
             {
-                var cwd = opt.HasValue()
-                    ? opt.Value()
-                    : context.Application.WorkingDirectory;
-                field.SetValue(context.ModelAccessor.GetModel(), cwd);
+                field.SetValue(context.ModelAccessor.GetModel(), opt.Value());
             });
         }
     }

--- a/docs/samples/helloworld-async/Program.cs
+++ b/docs/samples/helloworld-async/Program.cs
@@ -5,24 +5,22 @@ using McMaster.Extensions.CommandLineUtils;
 var app = new CommandLineApplication();
 
 app.HelpOption();
-var optionSubject = app.Option("-s|--subject <SUBJECT>", "The subject", CommandOptionType.SingleValue);
-var optionRepeat = app.Option<int>("-n|--count <N>", "Repeat", CommandOptionType.SingleValue);
+var subject = app.Option("-s|--subject <SUBJECT>", "The subject", CommandOptionType.SingleValue);
+subject.DefaultValue = "world";
+
+var repeat = app.Option<int>("-n|--count <N>", "Repeat", CommandOptionType.SingleValue);
+repeat.DefaultValue = 1;
 
 app.OnExecuteAsync(async cancellationToken =>
 {
-    var subject = optionSubject.HasValue()
-        ? optionSubject.Value()
-        : "world";
-
-    var count = optionRepeat.HasValue() ? optionRepeat.ParsedValue : 1;
-    for (var i = 0; i < count; i++)
+    for (var i = 0; i < repeat.ParsedValue; i++)
     {
         Console.Write($"Hello");
 
         // Pause for dramatic effect
         await Task.Delay(2000, cancellationToken);
 
-        Console.WriteLine($" {subject}!");
+        Console.WriteLine($" {subject.Value()}!");
     }
 });
 

--- a/docs/samples/helloworld/HelloWorld.csproj
+++ b/docs/samples/helloworld/HelloWorld.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/samples/helloworld/Program.cs
+++ b/docs/samples/helloworld/Program.cs
@@ -4,18 +4,17 @@ using McMaster.Extensions.CommandLineUtils;
 var app = new CommandLineApplication();
 
 app.HelpOption();
-var optionSubject = app.Option("-s|--subject <SUBJECT>", "The subject", CommandOptionType.SingleValue);
-optionSubject.DefaultValue = "world";
-var optionRepeat = app.Option<int?>("-n|--count <N>", "Repeat", CommandOptionType.SingleValue);
-optionRepeat.DefaultValue = 1;
+var subject = app.Option("-s|--subject <SUBJECT>", "The subject", CommandOptionType.SingleValue);
+subject.DefaultValue = "world";
+var repeat = app.Option<int?>("-n|--count <N>", "Repeat", CommandOptionType.SingleValue);
+repeat.DefaultValue = 1;
 
 app.OnExecute(() =>
 {
-    for (var i = 0; i < optionRepeat.ParsedValue; i++)
+    for (var i = 0; i < repeat.ParsedValue; i++)
     {
-        Console.WriteLine($"Hello {optionSubject.Value()}!");
+        Console.WriteLine($"Hello {subject.Value()}!");
     }
-    return 0;
 });
 
 return app.Execute(args);

--- a/docs/samples/helloworld/Program.cs
+++ b/docs/samples/helloworld/Program.cs
@@ -5,18 +5,15 @@ var app = new CommandLineApplication();
 
 app.HelpOption();
 var optionSubject = app.Option("-s|--subject <SUBJECT>", "The subject", CommandOptionType.SingleValue);
-var optionRepeat = app.Option<int>("-n|--count <N>", "Repeat", CommandOptionType.SingleValue);
+optionSubject.DefaultValue = "world";
+var optionRepeat = app.Option<int?>("-n|--count <N>", "Repeat", CommandOptionType.SingleValue);
+optionRepeat.DefaultValue = 1;
 
 app.OnExecute(() =>
 {
-    var subject = optionSubject.HasValue()
-        ? optionSubject.Value()
-        : "world";
-
-    var count = optionRepeat.HasValue() ? optionRepeat.ParsedValue : 1;
-    for (var i = 0; i < count; i++)
+    for (var i = 0; i < optionRepeat.ParsedValue; i++)
     {
-        Console.WriteLine($"Hello {subject}!");
+        Console.WriteLine($"Hello {optionSubject.Value()}!");
     }
     return 0;
 });

--- a/src/CommandLineUtils/CommandArgument.cs
+++ b/src/CommandLineUtils/CommandArgument.cs
@@ -54,7 +54,7 @@ namespace McMaster.Extensions.CommandLineUtils
         public bool MultipleValues { get; set; }
 
         /// <summary>
-        /// The first value from <see cref="Values"/>, if any.
+        /// The first value from <see cref="Values"/>, if any, or <see cref="DefaultValue" />.
         /// </summary>
         public string? Value => Values.FirstOrDefault();
 
@@ -66,7 +66,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <summary>
         /// True when <see cref="Values"/> is not empty or when a <see cref="DefaultValue" /> is given.
         /// </summary>
-        public bool HasValue => _values.Count != 0 || DefaultValue != null;
+        public bool HasValue => Values.Any();
 
         /// <summary>
         /// A collection of validators that execute before invoking <see cref="CommandLineApplication.OnExecute(Func{int})"/>.

--- a/src/CommandLineUtils/CommandArgument.cs
+++ b/src/CommandLineUtils/CommandArgument.cs
@@ -36,7 +36,17 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <summary>
         /// All values specified, if any.
         /// </summary>
-        public IReadOnlyList<string?> Values => _values;
+        public IReadOnlyList<string?> Values
+        {
+            get
+            {
+                if (_values.Count == 0 && DefaultValue != null)
+                {
+                    return new List<string?> { DefaultValue };
+                }
+                return _values;
+            }
+        }
 
         /// <summary>
         /// Allow multiple values.
@@ -54,9 +64,9 @@ namespace McMaster.Extensions.CommandLineUtils
         public string? DefaultValue { get; set; }
 
         /// <summary>
-        /// True if this argument has been assigned values.
+        /// True when <see cref="Values"/> is not empty or when a <see cref="DefaultValue" /> is given.
         /// </summary>
-        public bool HasValue => Values.Any();
+        public bool HasValue => _values.Count != 0 || DefaultValue != null;
 
         /// <summary>
         /// A collection of validators that execute before invoking <see cref="CommandLineApplication.OnExecute(Func{int})"/>.

--- a/src/CommandLineUtils/CommandArgument{T}.cs
+++ b/src/CommandLineUtils/CommandArgument{T}.cs
@@ -17,12 +17,13 @@ namespace McMaster.Extensions.CommandLineUtils
     /// </summary>
     /// <seealso cref="CommandOption"/>
     public class CommandArgument<T> : CommandArgument, IInternalCommandParamOfT
+        where T : notnull
     {
         private readonly List<T> _parsedValues = new List<T>();
         private readonly IValueParser<T> _valueParser;
         private bool _hasBeenParsed;
         private bool _hasDefaultValue;
-        private T _defaultValue;
+        private T? _defaultValue;
 
         /// <summary>
         /// Initializes a new instance of <see cref="CommandArgument{T}" />
@@ -31,7 +32,6 @@ namespace McMaster.Extensions.CommandLineUtils
         public CommandArgument(IValueParser<T> valueParser)
         {
             _valueParser = valueParser ?? throw new ArgumentNullException(nameof(valueParser));
-            DefaultValue = default;
             UnderlyingType = typeof(T);
         }
 
@@ -64,7 +64,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <summary>
         /// The default value of the argument.
         /// </summary>
-        public new T DefaultValue
+        public new T? DefaultValue
         {
             get => _defaultValue;
             set

--- a/src/CommandLineUtils/CommandArgument{T}.cs
+++ b/src/CommandLineUtils/CommandArgument{T}.cs
@@ -17,7 +17,6 @@ namespace McMaster.Extensions.CommandLineUtils
     /// </summary>
     /// <seealso cref="CommandOption"/>
     public class CommandArgument<T> : CommandArgument, IInternalCommandParamOfT
-        where T : notnull
     {
         private readonly List<T> _parsedValues = new List<T>();
         private readonly IValueParser<T> _valueParser;

--- a/src/CommandLineUtils/CommandOption.cs
+++ b/src/CommandLineUtils/CommandOption.cs
@@ -100,7 +100,17 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <summary>
         /// Any values found during parsing, if any.
         /// </summary>
-        public IReadOnlyList<string?> Values => _values;
+        public IReadOnlyList<string?> Values
+        {
+            get
+            {
+                if (_values.Count == 0 && DefaultValue != null)
+                {
+                    return new List<string?> { DefaultValue };
+                }
+                return _values;
+            }
+        }
 
         /// <summary>
         /// The default value of the option.
@@ -171,12 +181,12 @@ namespace McMaster.Extensions.CommandLineUtils
         }
 
         /// <summary>
-        /// True when <see cref="Values"/> is not empty.
+        /// True when <see cref="Values"/> is not empty or when a <see cref="DefaultValue" /> is given.
         /// </summary>
         /// <returns></returns>
         public bool HasValue()
         {
-            return Values.Any();
+            return _values.Any() || DefaultValue != null;
         }
 
         /// <summary>

--- a/src/CommandLineUtils/CommandOption.cs
+++ b/src/CommandLineUtils/CommandOption.cs
@@ -186,17 +186,14 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <returns></returns>
         public bool HasValue()
         {
-            return _values.Any() || DefaultValue != null;
+            return Values.Any();
         }
 
         /// <summary>
-        /// Returns the first element of <see cref="Values"/>, if any.
+        /// Returns the first element of <see cref="Values"/>, if any, or <see cref="DefaultValue" />.
         /// </summary>
         /// <returns></returns>
-        public string? Value()
-        {
-            return HasValue() ? Values[0] : null;
-        }
+        public string? Value() => Values.FirstOrDefault();
 
         /// <summary>
         /// Generates the template string in the format "-{Symbol}|-{Short}|--{Long} &lt;{Value}&gt;" for display in help text.

--- a/src/CommandLineUtils/CommandOption{T}.cs
+++ b/src/CommandLineUtils/CommandOption{T}.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Reflection;
 using McMaster.Extensions.CommandLineUtils.Abstractions;
 
 namespace McMaster.Extensions.CommandLineUtils
@@ -17,10 +16,11 @@ namespace McMaster.Extensions.CommandLineUtils
     /// </summary>
     /// <typeparam name="T">The type of the option value(s)</typeparam>
     public class CommandOption<T> : CommandOption, IInternalCommandParamOfT
+        where T : notnull
     {
         private readonly List<T> _parsedValues = new List<T>();
         private readonly IValueParser<T> _valueParser;
-        private T _defaultValue;
+        private T? _defaultValue;
         private bool _hasDefaultValue;
         private bool _hasBeenParsed;
 
@@ -34,9 +34,7 @@ namespace McMaster.Extensions.CommandLineUtils
             : base(template, optionType)
         {
             _valueParser = valueParser ?? throw new ArgumentNullException(nameof(valueParser));
-            DefaultValue = default;
             UnderlyingType = typeof(T);
-            SetBaseDefaultValue(default);
         }
 
         /// <summary>
@@ -56,7 +54,7 @@ namespace McMaster.Extensions.CommandLineUtils
                     ((IInternalCommandParamOfT)this).Parse(CultureInfo.CurrentCulture);
                 }
 
-                if (_values.Count == 0 && _hasDefaultValue)
+                if (_parsedValues.Count == 0 && _hasDefaultValue)
                 {
                     return new[] { DefaultValue };
                 }
@@ -68,7 +66,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <summary>
         /// The default value of the option.
         /// </summary>
-        public new T DefaultValue
+        public new T? DefaultValue
         {
             get => _defaultValue;
             set

--- a/src/CommandLineUtils/CommandOption{T}.cs
+++ b/src/CommandLineUtils/CommandOption{T}.cs
@@ -16,7 +16,6 @@ namespace McMaster.Extensions.CommandLineUtils
     /// </summary>
     /// <typeparam name="T">The type of the option value(s)</typeparam>
     public class CommandOption<T> : CommandOption, IInternalCommandParamOfT
-        where T : notnull
     {
         private readonly List<T> _parsedValues = new List<T>();
         private readonly IValueParser<T> _valueParser;

--- a/src/CommandLineUtils/PublicAPI.Shipped.txt
+++ b/src/CommandLineUtils/PublicAPI.Shipped.txt
@@ -53,8 +53,6 @@ McMaster.Extensions.CommandLineUtils.ArgumentAttribute.ShowInHelpText.set -> voi
 McMaster.Extensions.CommandLineUtils.ArgumentEscaper
 McMaster.Extensions.CommandLineUtils.CommandArgument
 McMaster.Extensions.CommandLineUtils.CommandArgument.CommandArgument() -> void
-McMaster.Extensions.CommandLineUtils.CommandArgument.DefaultValue.get -> string?
-McMaster.Extensions.CommandLineUtils.CommandArgument.DefaultValue.set -> void
 McMaster.Extensions.CommandLineUtils.CommandArgument.Description.get -> string?
 McMaster.Extensions.CommandLineUtils.CommandArgument.Description.set -> void
 McMaster.Extensions.CommandLineUtils.CommandArgument.MultipleValues.get -> bool
@@ -68,8 +66,6 @@ McMaster.Extensions.CommandLineUtils.CommandArgument.Value.get -> string?
 McMaster.Extensions.CommandLineUtils.CommandArgument.Values.get -> System.Collections.Generic.IReadOnlyList<string?>!
 McMaster.Extensions.CommandLineUtils.CommandArgument<T>
 McMaster.Extensions.CommandLineUtils.CommandArgument<T>.CommandArgument(McMaster.Extensions.CommandLineUtils.Abstractions.IValueParser<T>! valueParser) -> void
-McMaster.Extensions.CommandLineUtils.CommandArgument<T>.DefaultValue.get -> T
-McMaster.Extensions.CommandLineUtils.CommandArgument<T>.DefaultValue.set -> void
 McMaster.Extensions.CommandLineUtils.CommandArgument<T>.ParsedValue.get -> T
 McMaster.Extensions.CommandLineUtils.CommandArgument<T>.ParsedValues.get -> System.Collections.Generic.IReadOnlyList<T>!
 McMaster.Extensions.CommandLineUtils.CommandAttribute
@@ -198,8 +194,6 @@ McMaster.Extensions.CommandLineUtils.CommandLineApplication<TModel>.ModelFactory
 McMaster.Extensions.CommandLineUtils.CommandLineApplicationExtensions
 McMaster.Extensions.CommandLineUtils.CommandOption
 McMaster.Extensions.CommandLineUtils.CommandOption.CommandOption(string! template, McMaster.Extensions.CommandLineUtils.CommandOptionType optionType) -> void
-McMaster.Extensions.CommandLineUtils.CommandOption.DefaultValue.get -> string?
-McMaster.Extensions.CommandLineUtils.CommandOption.DefaultValue.set -> void
 McMaster.Extensions.CommandLineUtils.CommandOption.Description.get -> string?
 McMaster.Extensions.CommandLineUtils.CommandOption.Description.set -> void
 McMaster.Extensions.CommandLineUtils.CommandOption.HasValue() -> bool
@@ -222,8 +216,6 @@ McMaster.Extensions.CommandLineUtils.CommandOption.ValueName.set -> void
 McMaster.Extensions.CommandLineUtils.CommandOption.Values.get -> System.Collections.Generic.IReadOnlyList<string?>!
 McMaster.Extensions.CommandLineUtils.CommandOption<T>
 McMaster.Extensions.CommandLineUtils.CommandOption<T>.CommandOption(McMaster.Extensions.CommandLineUtils.Abstractions.IValueParser<T>! valueParser, string! template, McMaster.Extensions.CommandLineUtils.CommandOptionType optionType) -> void
-McMaster.Extensions.CommandLineUtils.CommandOption<T>.DefaultValue.get -> T
-McMaster.Extensions.CommandLineUtils.CommandOption<T>.DefaultValue.set -> void
 McMaster.Extensions.CommandLineUtils.CommandOption<T>.ParsedValue.get -> T
 McMaster.Extensions.CommandLineUtils.CommandOption<T>.ParsedValues.get -> System.Collections.Generic.IReadOnlyList<T>!
 McMaster.Extensions.CommandLineUtils.CommandOptionType

--- a/src/CommandLineUtils/PublicAPI.Unshipped.txt
+++ b/src/CommandLineUtils/PublicAPI.Unshipped.txt
@@ -3,5 +3,7 @@ McMaster.Extensions.CommandLineUtils.CommandArgument.HasValue.get -> bool
 McMaster.Extensions.CommandLineUtils.CommandArgument.TryParse(string? value) -> bool
 virtual McMaster.Extensions.CommandLineUtils.CommandArgument.Reset() -> void
 virtual McMaster.Extensions.CommandLineUtils.CommandOption.Reset() -> void
+override McMaster.Extensions.CommandLineUtils.CommandArgument<T>.Reset() -> void
+override McMaster.Extensions.CommandLineUtils.CommandOption<T>.Reset() -> void
 McMaster.Extensions.CommandLineUtils.CommandLineApplication.AddArgument(McMaster.Extensions.CommandLineUtils.CommandArgument! argument) -> void
 McMaster.Extensions.CommandLineUtils.CommandLineApplication.AddOption(McMaster.Extensions.CommandLineUtils.CommandOption! option) -> void

--- a/src/CommandLineUtils/PublicAPI.Unshipped.txt
+++ b/src/CommandLineUtils/PublicAPI.Unshipped.txt
@@ -1,6 +1,14 @@
 #nullable enable
+McMaster.Extensions.CommandLineUtils.CommandOption.DefaultValue.get -> string?
+McMaster.Extensions.CommandLineUtils.CommandOption.DefaultValue.set -> void
+McMaster.Extensions.CommandLineUtils.CommandArgument.DefaultValue.get -> string?
+McMaster.Extensions.CommandLineUtils.CommandArgument.DefaultValue.set -> void
+McMaster.Extensions.CommandLineUtils.CommandArgument<T>.DefaultValue.get -> T?
+McMaster.Extensions.CommandLineUtils.CommandArgument<T>.DefaultValue.set -> void
 McMaster.Extensions.CommandLineUtils.CommandArgument.HasValue.get -> bool
 McMaster.Extensions.CommandLineUtils.CommandArgument.TryParse(string? value) -> bool
+McMaster.Extensions.CommandLineUtils.CommandOption<T>.DefaultValue.get -> T?
+McMaster.Extensions.CommandLineUtils.CommandOption<T>.DefaultValue.set -> void
 virtual McMaster.Extensions.CommandLineUtils.CommandArgument.Reset() -> void
 virtual McMaster.Extensions.CommandLineUtils.CommandOption.Reset() -> void
 override McMaster.Extensions.CommandLineUtils.CommandArgument<T>.Reset() -> void

--- a/test/CommandLineUtils.Tests/CommandArgumentTests.cs
+++ b/test/CommandLineUtils.Tests/CommandArgumentTests.cs
@@ -16,6 +16,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             var app = new CommandLineApplication();
             var arg = app.Argument<int>("abc", "xyz");
             Assert.False(arg.HasValue);
+            Assert.Null(arg.Value);
         }
 
         [Fact]

--- a/test/CommandLineUtils.Tests/CommandArgumentTests.cs
+++ b/test/CommandLineUtils.Tests/CommandArgumentTests.cs
@@ -11,76 +11,78 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
     {
 
         [Fact]
-        public void AlwaysHasDefaultValueForValueTypes()
+        public void DoesNotHaveDefaultForValueTypes()
         {
             var app = new CommandLineApplication();
-            var argument = app.Argument<int>("abc", "xyz");
-            Assert.Equal(default, argument.DefaultValue);
-            Assert.True(argument.HasValue);
+            var arg = app.Argument<int>("abc", "xyz");
+            Assert.False(arg.HasValue);
         }
 
         [Fact]
         public void DoesNotHaveDefaultForReferenceTypes()
         {
             var app = new CommandLineApplication();
-            var argument = app.Argument<int?>("abc", "xyz");
-            Assert.Null(argument.DefaultValue);
-            Assert.False(argument.HasValue);
+            var arg = app.Argument<int?>("abc", "xyz");
+            Assert.Null(arg.DefaultValue);
+            Assert.False(arg.HasValue);
         }
 
         [Fact]
         public void DefaultValueReturnedIfUnset()
         {
-            var option = new CommandArgument
+            var arg = new CommandArgument
             {
                 DefaultValue = "ABC"
             };
 
-            Assert.Equal("ABC", option.Value);
-            Assert.Equal(new List<string> { "ABC" }, option.Values);
+            Assert.Equal("ABC", arg.Value);
+            Assert.True(arg.HasValue);
+            Assert.Equal(new List<string> { "ABC" }, arg.Values);
         }
 
         [Fact]
         public void DefaultValueOfTReturnedIfUnset()
         {
-            var option = new CommandArgument<int>(StockValueParsers.Int32)
+            var arg = new CommandArgument<int>(StockValueParsers.Int32)
             {
                 DefaultValue = 42
             };
 
-            Assert.Equal("42", option.Value);
-            Assert.Equal(new List<string> { "42" }, option.Values);
-            Assert.Equal(42, option.ParsedValue);
-            Assert.Equal(new List<int> { 42 }, option.ParsedValues);
+            Assert.Equal("42", arg.Value);
+            Assert.True(arg.HasValue);
+            Assert.Equal(new List<string> { "42" }, arg.Values);
+            Assert.Equal(42, arg.ParsedValue);
+            Assert.Equal(new List<int> { 42 }, arg.ParsedValues);
         }
 
         [Fact]
         public void DefaultOverriddenBySettingValue()
         {
-            var option = new CommandArgument
+            var arg = new CommandArgument
             {
                 DefaultValue = "ABC"
             };
 
-            option.TryParse("xyz");
+            arg.TryParse("xyz");
 
-            Assert.Equal("xyz", option.Value);
+            Assert.Equal("xyz", arg.Value);
         }
 
         [Fact]
         public void DefaultOfTOverriddenBySettingValue()
         {
-            var option = new CommandArgument<int>(StockValueParsers.Int32)
+            var arg = new CommandArgument<int>(StockValueParsers.Int32)
             {
                 DefaultValue = 42
             };
 
-            option.TryParse("999");
+            arg.TryParse("999");
 
-            Assert.Equal("999", option.Value);
-            Assert.Equal(new List<string> { "999" }, option.Values);
-            Assert.Equal(999, option.ParsedValue);
-            Assert.Equal(new List<int> { 999 }, option.ParsedValues);
+            Assert.Equal("999", arg.Value);
+            Assert.True(arg.HasValue);
+            Assert.Equal(new List<string> { "999" }, arg.Values);
+            Assert.Equal(999, arg.ParsedValue);
+            Assert.Equal(new List<int> { 999 }, arg.ParsedValues);
         }
 
         [Fact]

--- a/test/CommandLineUtils.Tests/CommandArgumentTests.cs
+++ b/test/CommandLineUtils.Tests/CommandArgumentTests.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) Nate McMaster.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using McMaster.Extensions.CommandLineUtils.Abstractions;
+using Xunit;
+
+namespace McMaster.Extensions.CommandLineUtils.Tests
+{
+    public class CommandArgumentTests
+    {
+
+        [Fact]
+        public void AlwaysHasDefaultValueForValueTypes()
+        {
+            var app = new CommandLineApplication();
+            var argument = app.Argument<int>("abc", "xyz");
+            Assert.Equal(default, argument.DefaultValue);
+            Assert.True(argument.HasValue());
+        }
+
+        [Fact]
+        public void DoesNotHaveDefaultForReferenceTypes()
+        {
+            var app = new CommandLineApplication();
+            var argument = app.Argument<int?>("abc", "xyz");
+            Assert.Null(argument.DefaultValue);
+            Assert.False(argument.HasValue());
+        }
+
+        [Fact]
+        public void DefaultValueReturnedIfUnset()
+        {
+            var option = new CommandArgument
+            {
+                DefaultValue = "ABC"
+            };
+
+            Assert.Equal("ABC", option.Value);
+            Assert.Equal(new List<string> { "ABC" }, option.Values);
+        }
+
+        [Fact]
+        public void DefaultValueOfTReturnedIfUnset()
+        {
+            var option = new CommandArgument<int>(StockValueParsers.Int32)
+            {
+                DefaultValue = 42
+            };
+
+            Assert.Equal("42", option.Value);
+            Assert.Equal(new List<string> { "42" }, option.Values);
+            Assert.Equal(42, option.ParsedValue);
+            Assert.Equal(new List<int> { 42 }, option.ParsedValues);
+        }
+
+        [Fact]
+        public void DefaultOverriddenBySettingValue()
+        {
+            var option = new CommandArgument
+            {
+                DefaultValue = "ABC"
+            };
+
+            option.TryParse("xyz");
+
+            Assert.Equal("xyz", option.Value);
+        }
+
+        [Fact]
+        public void DefaultOfTOverriddenBySettingValue()
+        {
+            var option = new CommandArgument<int>(StockValueParsers.Int32)
+            {
+                DefaultValue = 42
+            };
+
+            option.TryParse("999");
+
+            Assert.Equal("999", option.Value);
+            Assert.Equal(new List<string> { "999" }, option.Values);
+            Assert.Equal(999, option.ParsedValue);
+            Assert.Equal(new List<int> { 999 }, option.ParsedValues);
+        }
+
+        [Fact]
+        public void DefaultOverriddenAndResetReturnsDefault()
+        {
+            var option = new CommandArgument
+            {
+                DefaultValue = "ABC"
+            };
+
+            option.TryParse("xyz");
+
+            option.Reset();
+
+            Assert.Equal("ABC", option.Value);
+        }
+    }
+}

--- a/test/CommandLineUtils.Tests/CommandArgumentTests.cs
+++ b/test/CommandLineUtils.Tests/CommandArgumentTests.cs
@@ -16,7 +16,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             var app = new CommandLineApplication();
             var argument = app.Argument<int>("abc", "xyz");
             Assert.Equal(default, argument.DefaultValue);
-            Assert.True(argument.HasValue());
+            Assert.True(argument.HasValue);
         }
 
         [Fact]
@@ -25,7 +25,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             var app = new CommandLineApplication();
             var argument = app.Argument<int?>("abc", "xyz");
             Assert.Null(argument.DefaultValue);
-            Assert.False(argument.HasValue());
+            Assert.False(argument.HasValue);
         }
 
         [Fact]

--- a/test/CommandLineUtils.Tests/CommandOptionTests.cs
+++ b/test/CommandLineUtils.Tests/CommandOptionTests.cs
@@ -50,6 +50,23 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         }
 
         [Fact]
+        public void DoesNotHaveDefaultForValueTypes()
+        {
+            var app = new CommandLineApplication();
+            var option = app.Option<int>("--value <ABC>", "abc", CommandOptionType.SingleValue);
+            Assert.False(option.HasValue());
+        }
+
+        [Fact]
+        public void DoesNotHaveDefaultForReferenceTypes()
+        {
+            var app = new CommandLineApplication();
+            var option = app.Option<int?>("--value <ABC>", "abc", CommandOptionType.SingleValue);
+            Assert.Null(option.DefaultValue);
+            Assert.False(option.HasValue());
+        }
+
+        [Fact]
         public void DefaultValueReturnedIfUnset()
         {
             var option = new CommandOption("--value <ABC>", CommandOptionType.SingleValue)
@@ -78,24 +95,6 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         }
 
         [Fact]
-        public void AlwaysHasDefaultValueForValueTypes()
-        {
-            var app = new CommandLineApplication();
-            var option = app.Option<int>("--value <ABC>", "abc", CommandOptionType.SingleValue);
-            Assert.Equal(default, option.DefaultValue);
-            Assert.True(option.HasValue());
-        }
-
-        [Fact]
-        public void DoesNotHaveDefaultForReferenceTypes()
-        {
-            var app = new CommandLineApplication();
-            var option = app.Option<int?>("--value <ABC>", "abc", CommandOptionType.SingleValue);
-            Assert.Null(option.DefaultValue);
-            Assert.False(option.HasValue());
-        }
-
-        [Fact]
         public void DefaultOverriddenBySettingValue()
         {
             var option = new CommandOption("--value <ABC>", CommandOptionType.SingleValue)
@@ -118,6 +117,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
 
             option.TryParse("999");
 
+            Assert.True(option.HasValue());
             Assert.Equal("999", option.Value());
             Assert.Equal(new List<string> { "999" }, option.Values);
             Assert.Equal(999, option.ParsedValue);

--- a/test/CommandLineUtils.Tests/CommandOptionTests.cs
+++ b/test/CommandLineUtils.Tests/CommandOptionTests.cs
@@ -55,6 +55,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             var app = new CommandLineApplication();
             var option = app.Option<int>("--value <ABC>", "abc", CommandOptionType.SingleValue);
             Assert.False(option.HasValue());
+            Assert.Null(option.Value());
         }
 
         [Fact]

--- a/test/CommandLineUtils.Tests/CommandOptionTests.cs
+++ b/test/CommandLineUtils.Tests/CommandOptionTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Nate McMaster.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+using McMaster.Extensions.CommandLineUtils.Abstractions;
 using Xunit;
 
 namespace McMaster.Extensions.CommandLineUtils.Tests
@@ -45,6 +47,96 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             Assert.Equal(symbolName, opt.SymbolName);
             Assert.Equal(longName, opt.LongName);
             Assert.Equal(valueName, opt.ValueName);
+        }
+
+        [Fact]
+        public void DefaultValueReturnedIfUnset()
+        {
+            var option = new CommandOption("--value <ABC>", CommandOptionType.SingleValue)
+            {
+                DefaultValue = "ABC"
+            };
+
+            Assert.True(option.HasValue());
+            Assert.Equal("ABC", option.Value());
+            Assert.Equal(new List<string> { "ABC" }, option.Values);
+        }
+
+        [Fact]
+        public void DefaultValueOfTReturnedIfUnset()
+        {
+            var option = new CommandOption<int>(StockValueParsers.Int32, "--value <ABC>", CommandOptionType.SingleValue)
+            {
+                DefaultValue = 42
+            };
+
+            Assert.True(option.HasValue());
+            Assert.Equal("42", option.Value());
+            Assert.Equal(new List<string> { "42" }, option.Values);
+            Assert.Equal(42, option.ParsedValue);
+            Assert.Equal(new List<int> { 42 }, option.ParsedValues);
+        }
+
+        [Fact]
+        public void AlwaysHasDefaultValueForValueTypes()
+        {
+            var app = new CommandLineApplication();
+            var option = app.Option<int>("--value <ABC>", "abc", CommandOptionType.SingleValue);
+            Assert.Equal(default, option.DefaultValue);
+            Assert.True(option.HasValue());
+        }
+
+        [Fact]
+        public void DoesNotHaveDefaultForReferenceTypes()
+        {
+            var app = new CommandLineApplication();
+            var option = app.Option<int?>("--value <ABC>", "abc", CommandOptionType.SingleValue);
+            Assert.Null(option.DefaultValue);
+            Assert.False(option.HasValue());
+        }
+
+        [Fact]
+        public void DefaultOverriddenBySettingValue()
+        {
+            var option = new CommandOption("--value <ABC>", CommandOptionType.SingleValue)
+            {
+                DefaultValue = "ABC"
+            };
+
+            option.TryParse("xyz");
+
+            Assert.Equal("xyz", option.Value());
+        }
+
+        [Fact]
+        public void DefaultOfTOverriddenBySettingValue()
+        {
+            var option = new CommandOption<int>(StockValueParsers.Int32, "--value <ABC>", CommandOptionType.SingleValue)
+            {
+                DefaultValue = 42
+            };
+
+            option.TryParse("999");
+
+            Assert.Equal("999", option.Value());
+            Assert.Equal(new List<string> { "999" }, option.Values);
+            Assert.Equal(999, option.ParsedValue);
+            Assert.Equal(new List<int> { 999 }, option.ParsedValues);
+        }
+
+        [Fact]
+        public void DefaultOverriddenAndResetReturnsDefault()
+        {
+            var option = new CommandOption("--value <ABC>", CommandOptionType.SingleValue)
+            {
+                DefaultValue = "ABC"
+            };
+
+            option.TryParse("xyz");
+
+            option.Reset();
+
+            Assert.Equal("ABC", option.Value());
         }
     }
 }

--- a/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
+++ b/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
@@ -121,9 +121,11 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             app.Argument("RestrictedStringArgument", "restricted string arg desc.", a => a.IsRequired().Accepts().Values("Foo", "Bar"));
             app.Argument("DefaultValStringArgument", "string arg with default value desc.", a => a.DefaultValue = "Foo");
             app.Argument<SomeEnum>("SomeEnumArgument", "enum arg desc.");
-            app.Argument<SomeEnum>("RestrictedEnumArgument", "restricted enum arg desc.", a => a.Accepts().Values("None", "Normal"));
+            var a = app.Argument<SomeEnum>("RestrictedEnumArgument", "restricted enum arg desc.", a => a.Accepts().Values("None", "Normal"));
+            a.DefaultValue = SomeEnum.Normal;
             app.Argument<(bool, SomeEnum)>("SomeNullableEnumArgument", "nullable enum arg desc.");
             var helpText = GetHelpText(app);
+            _output.WriteLine(helpText);
 
             Assert.Equal(@"Usage:  [options] <SomeStringArgument> <RestrictedStringArgument> <DefaultValStringArgument> <SomeEnumArgument> <RestrictedEnumArgument> <SomeNullableEnumArgument>
 
@@ -138,7 +140,7 @@ Arguments:
                             Default value is: None.
   RestrictedEnumArgument    restricted enum arg desc.
                             Allowed values are: None, Normal.
-                            Default value is: None.
+                            Default value is: Normal.
   SomeNullableEnumArgument  nullable enum arg desc.
                             Allowed values are: None, Normal, Extreme.
 

--- a/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
+++ b/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
@@ -113,14 +113,18 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             app.Option("--rStrOpt <E>", "restricted str option desc.", CommandOptionType.SingleValue, o => o.IsRequired().Accepts().Values("Foo", "Bar"));
             app.Option("--dStrOpt <E>", "str option with default value desc.", CommandOptionType.SingleValue, o => o.DefaultValue = "Foo");
             app.Option<int>("--intOpt <E>", "int option desc.", CommandOptionType.SingleValue);
-            app.Option<SomeEnum>("--enumOpt <E>", "enum option desc.", CommandOptionType.SingleValue);
-            app.Option<SomeEnum>("--enumOpt2 <E>", "restricted enum option desc.", CommandOptionType.SingleValue, o => o.Accepts().Values("None", "Normal"));
+            app.Option<SomeEnum>("--enumOpt <E>", "enum option desc.", CommandOptionType.SingleValue, o => o.DefaultValue = default);
+            app.Option<SomeEnum>("--enumOpt2 <E>", "restricted enum option desc.", CommandOptionType.SingleValue, o =>
+            {
+                o.DefaultValue = default;
+                o.Accepts().Values("None", "Normal");
+            });
             app.Option<(bool, SomeEnum)>("--enumOpt3 <E>", "nullable enum option desc.", CommandOptionType.SingleOrNoValue);
             app.Option<SomeEnum?>("--enumOpt4 <E>", "nullable enum option desc.", CommandOptionType.SingleOrNoValue);
             app.Argument("SomeStringArgument", "string arg desc.");
             app.Argument("RestrictedStringArgument", "restricted string arg desc.", a => a.IsRequired().Accepts().Values("Foo", "Bar"));
             app.Argument("DefaultValStringArgument", "string arg with default value desc.", a => a.DefaultValue = "Foo");
-            app.Argument<SomeEnum>("SomeEnumArgument", "enum arg desc.");
+            app.Argument<SomeEnum>("SomeEnumArgument", "enum arg desc.", a => a.DefaultValue = default);
             var a = app.Argument<SomeEnum>("RestrictedEnumArgument", "restricted enum arg desc.", a => a.Accepts().Values("None", "Normal"));
             a.DefaultValue = SomeEnum.Normal;
             app.Argument<(bool, SomeEnum)>("SomeNullableEnumArgument", "nullable enum arg desc.");
@@ -152,7 +156,6 @@ Options:
   --dStrOpt <E>             str option with default value desc.
                             Default value is: Foo.
   --intOpt <E>              int option desc.
-                            Default value is: 0.
   --enumOpt <E>             enum option desc.
                             Allowed values are: None, Normal, Extreme.
                             Default value is: None.

--- a/test/CommandLineUtils.Tests/ValidationTests.cs
+++ b/test/CommandLineUtils.Tests/ValidationTests.cs
@@ -37,7 +37,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             var sub = app.Command("sub", c => { });
             var called = false;
             sub.OnValidationError(_ => called = true);
-            CommandArgument<int> arg = sub.Argument<int>("t", "test").IsRequired();
+            var arg = sub.Argument<int?>("t", "test").IsRequired();
             Assert.NotEqual(0, app.Execute("sub"));
             Assert.True(called, "Validation on subcommand should be called");
         }

--- a/test/CommandLineUtils.Tests/ValidationTests.cs
+++ b/test/CommandLineUtils.Tests/ValidationTests.cs
@@ -37,7 +37,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             var sub = app.Command("sub", c => { });
             var called = false;
             sub.OnValidationError(_ => called = true);
-            var arg = sub.Argument<int?>("t", "test").IsRequired();
+            var arg = sub.Argument<int>("t", "test").IsRequired();
             Assert.NotEqual(0, app.Execute("sub"));
             Assert.True(called, "Validation on subcommand should be called");
         }


### PR DESCRIPTION
Follow-up to #389. This updates `CommandOption.Value` and `CommandArgument.Value` to return `DefaultValue` when nothing has been passed on command line.