### PR TITLE
Add .NET Standard 2.1 framework

### DIFF
--- a/src/CommandLineUtils/IO/Pager.cs
+++ b/src/CommandLineUtils/IO/Pager.cs
@@ -45,7 +45,7 @@ namespace McMaster.Extensions.CommandLineUtils
 #if NET45
             // if .NET Framework, assume we're on Windows unless it's running on Mono.
             _enabled = Type.GetType("Mono.Runtime") != null;
-#elif NETSTANDARD2_0
+#elif NETSTANDARD2_0 || NETSTANDARD2_1
             _enabled = !RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !console.IsOutputRedirected;
 #else
 #error Update target frameworks

--- a/src/CommandLineUtils/Internal/Util.cs
+++ b/src/CommandLineUtils/Internal/Util.cs
@@ -16,7 +16,7 @@ namespace McMaster.Extensions.CommandLineUtils
             internal static readonly T[] Value = new T[0];
         }
 
-#elif NETSTANDARD2_0
+#elif NETSTANDARD2_0 || NETSTANDARD2_1
             => Array.Empty<T>();
 #else
 #error Update target frameworks

--- a/src/CommandLineUtils/McMaster.Extensions.CommandLineUtils.csproj
+++ b/src/CommandLineUtils/McMaster.Extensions.CommandLineUtils.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;net45</TargetFrameworks>
+    <Nullable Condition="'$(TargetFramework)' != 'netstandard2.1'">annotations</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
     <Description>Command-line parsing API.</Description>
@@ -20,7 +21,7 @@ McMaster.Extensions.CommandLineUtils.ArgumentEscaper
     <PackageTags>commandline;parsing</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/CommandLineUtils/Utilities/DotNetExe.cs
+++ b/src/CommandLineUtils/Utilities/DotNetExe.cs
@@ -45,7 +45,7 @@ namespace McMaster.Extensions.CommandLineUtils
             var fileName = FileName;
 #if NET45
             fileName += ".exe";
-#elif NETSTANDARD2_0
+#elif NETSTANDARD2_0 || NETSTANDARD2_1
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 fileName += ".exe";

--- a/src/Hosting.CommandLine/McMaster.Extensions.Hosting.CommandLine.csproj
+++ b/src/Hosting.CommandLine/McMaster.Extensions.Hosting.CommandLine.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
     <Description>Provides command-line parsing API integration with the generic host API (Microsoft.Extensions.Hosting).</Description>

--- a/test/CommandLineUtils.Tests/DotNetExeTests.cs
+++ b/test/CommandLineUtils.Tests/DotNetExeTests.cs
@@ -3,7 +3,7 @@
 
 // This file has been modified from the original form. See Notice.txt in the project root for more information.
 
-#if NETCOREAPP
+#if NETCOREAPP || NET5_0
 using System.IO;
 using Xunit;
 


### PR DESCRIPTION
Required to enable C# nullable reference type checking.

