### PR TITLE
Should set UnderlyingType when use Template

### DIFF
--- a/src/CommandLineUtils/Attributes/OptionAttribute.cs
+++ b/src/CommandLineUtils/Attributes/OptionAttribute.cs
@@ -82,9 +82,10 @@ namespace McMaster.Extensions.CommandLineUtils
                     LongName = longName,
                     ShortName = longName.Substring(0, 1),
                     ValueName = prop.Name.ToConstantCase(),
-                    UnderlyingType = prop.PropertyType,
                 };
             }
+
+            option.UnderlyingType = prop.PropertyType;
 
             Configure(option);
 

--- a/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
+++ b/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
@@ -216,6 +216,9 @@ Options:
                                     Allowed values are: None, Normal, Extreme.
   -enumOpt4|--verb4[:<VERB4>]       nullable enum option desc.
                                     Allowed values are: None, Normal, Extreme.
+  -enumOpt5|--verb5 <VERB5>         enum option desc.
+                                    Allowed values are: None, Normal, Extreme.
+                                    Default value is: None.
   -?|-h|--help                      Show help information.
 
 ",
@@ -254,6 +257,9 @@ Options:
 
             [Option(CommandOptionType.SingleOrNoValue, ShortName = "enumOpt4", Description = "nullable enum option desc.")]
             public SomeEnum? Verb4 { get; set; }
+
+            [Option("-enumOpt5 | --verb5 <VERB5>", Description = "enum option desc.")]
+            public SomeEnum Verb5 { get; set; }
 
             [Argument(0, Description = "string arg desc.")]
             public string SomeStringArgument { get; set; }


### PR DESCRIPTION
The UnderlyingType was null if use Template. For enum option, If UnderlyingType is null, the help text generator will not add the default values text. This PR fixes the issue.