### PR TITLE
Change to not throw when a validator is not of type AttributeValidator

### DIFF
--- a/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
+++ b/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
@@ -194,7 +194,7 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
                     var description = arg.Description;
                     var allowedValuesBeenSet = false;
 
-                    foreach (var attributeValidator in arg.Validators.Cast<AttributeValidator>())
+                    foreach (var attributeValidator in arg.Validators.OfType<AttributeValidator>())
                     {
                         if (attributeValidator?.ValidationAttribute is AllowedValuesAttribute allowedValuesAttribute)
                         {
@@ -251,7 +251,7 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
                     var description = opt.Description;
                     var allowedValuesBeenSet = false;
 
-                    foreach (var attributeValidator in opt.Validators.Cast<AttributeValidator>())
+                    foreach (var attributeValidator in opt.Validators.OfType<AttributeValidator>())
                     {
                         if (attributeValidator?.ValidationAttribute is AllowedValuesAttribute allowedValuesAttribute)
                         {


### PR DESCRIPTION
Found an issue adding validators via the builder that were not of the `AttributeValidator` type.

This is the error encountered:
```
System.InvalidCastException: Unable to cast object of type 'ArgumentMustBeValidEnvironmentContext' to type 'McMaster.Extensions.CommandLineUtils.Validation.AttributeValidator'.
   at System.Linq.Enumerable.<CastIterator>d__97`1.MoveNext()
```