### PR TITLE
Fix trimming runtime error

### DIFF
--- a/src/CommandLineUtils/Validation/ValidationExtensions.cs
+++ b/src/CommandLineUtils/Validation/ValidationExtensions.cs
@@ -384,7 +384,7 @@ namespace McMaster.Extensions.CommandLineUtils
         public static IValidationBuilder<int> Range(this IValidationBuilder<int> builder, int minimum, int maximum, string? errorMessage = null)
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
         {
-            var attribute = AddErrorMessage(new RangeAttribute(minimum, maximum), errorMessage );
+            var attribute = AddErrorMessage(new RangeAttribute(minimum, maximum), errorMessage);
             builder.Use(new AttributeValidator(attribute));
             return builder;
         }

--- a/src/CommandLineUtils/Validation/ValidationExtensions.cs
+++ b/src/CommandLineUtils/Validation/ValidationExtensions.cs
@@ -23,8 +23,11 @@ namespace McMaster.Extensions.CommandLineUtils
         public static CommandOption IsRequired(this CommandOption option, bool allowEmptyStrings = false, string? errorMessage = null)
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
         {
-            var attribute = GetValidationAttr<RequiredAttribute>(errorMessage);
-            attribute.AllowEmptyStrings = allowEmptyStrings;
+            var attribute = new RequiredAttribute
+            {
+                ErrorMessage = errorMessage,
+                AllowEmptyStrings = allowEmptyStrings
+            };
             option.Validators.Add(new AttributeValidator(attribute));
             return option;
         }
@@ -57,8 +60,11 @@ namespace McMaster.Extensions.CommandLineUtils
         public static CommandArgument IsRequired(this CommandArgument argument, bool allowEmptyStrings = false, string? errorMessage = null)
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
         {
-            var attribute = GetValidationAttr<RequiredAttribute>(errorMessage);
-            attribute.AllowEmptyStrings = allowEmptyStrings;
+            var attribute = new RequiredAttribute
+            {
+                ErrorMessage = errorMessage,
+                AllowEmptyStrings = allowEmptyStrings
+            };
             argument.Validators.Add(new AttributeValidator(attribute));
             return argument;
         }
@@ -247,7 +253,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <returns>The builder.</returns>
         public static IValidationBuilder Values(this IValidationBuilder builder, StringComparison comparer, params string[] allowedValues)
         {
-            return builder.Satisfies<AllowedValuesAttribute>(ctorArgs: new object[] { comparer, allowedValues });
+            return builder.Satisfies(new AllowedValuesAttribute(comparer, allowedValues));
         }
 
         /// <summary>
@@ -257,7 +263,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
         public static IValidationBuilder EmailAddress(this IValidationBuilder builder, string? errorMessage = null)
-            => builder.Satisfies<EmailAddressAttribute>(errorMessage);
+            => builder.Satisfies(new EmailAddressAttribute(), errorMessage);
 
         /// <summary>
         /// Specifies that values must be a path to a file that already exists.
@@ -266,7 +272,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
         public static IValidationBuilder ExistingFile(this IValidationBuilder builder, string? errorMessage = null)
-            => builder.Satisfies<FileExistsAttribute>(errorMessage);
+            => builder.Satisfies(new FileExistsAttribute(), errorMessage);
 
         /// <summary>
         /// Specifies that values must be a path to a file that does not already exist.
@@ -275,7 +281,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
         public static IValidationBuilder NonExistingFile(this IValidationBuilder builder, string? errorMessage = null)
-            => builder.Satisfies<FileNotExistsAttribute>(errorMessage);
+            => builder.Satisfies(new FileNotExistsAttribute(), errorMessage);
 
         /// <summary>
         /// Specifies that values must be a path to a directory that already exists.
@@ -284,7 +290,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
         public static IValidationBuilder ExistingDirectory(this IValidationBuilder builder, string? errorMessage = null)
-            => builder.Satisfies<DirectoryExistsAttribute>(errorMessage);
+            => builder.Satisfies(new DirectoryExistsAttribute(), errorMessage);
 
         /// <summary>
         /// Specifies that values must be a path to a directory that does not already exist.
@@ -293,7 +299,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
         public static IValidationBuilder NonExistingDirectory(this IValidationBuilder builder, string? errorMessage = null)
-            => builder.Satisfies<DirectoryNotExistsAttribute>(errorMessage);
+            => builder.Satisfies(new DirectoryNotExistsAttribute(), errorMessage);
 
         /// <summary>
         /// Specifies that values must be a valid file path or directory, and the file path must already exist.
@@ -302,7 +308,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
         public static IValidationBuilder ExistingFileOrDirectory(this IValidationBuilder builder, string? errorMessage = null)
-            => builder.Satisfies<FileOrDirectoryExistsAttribute>(errorMessage);
+            => builder.Satisfies(new FileOrDirectoryExistsAttribute(), errorMessage);
 
         /// <summary>
         /// Specifies that values must be a valid file path or directory, and the file path must not already exist.
@@ -311,7 +317,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
         public static IValidationBuilder NonExistingFileOrDirectory(this IValidationBuilder builder, string? errorMessage = null)
-            => builder.Satisfies<FileOrDirectoryNotExistsAttribute>(errorMessage);
+            => builder.Satisfies(new FileOrDirectoryNotExistsAttribute(), errorMessage);
 
         /// <summary>
         /// Specifies that values must be legal file paths.
@@ -320,7 +326,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
         public static IValidationBuilder LegalFilePath(this IValidationBuilder builder, string? errorMessage = null)
-            => builder.Satisfies<LegalFilePathAttribute>(errorMessage);
+            => builder.Satisfies(new LegalFilePathAttribute(), errorMessage);
 
         /// <summary>
         /// Specifies that values must be a string at least <paramref name="length"/> characters long.
@@ -330,7 +336,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
         public static IValidationBuilder MinLength(this IValidationBuilder builder, int length, string? errorMessage = null)
-            => builder.Satisfies<MinLengthAttribute>(errorMessage, length);
+            => builder.Satisfies(new MinLengthAttribute(length), errorMessage);
 
         /// <summary>
         /// Specifies that values must be a string no more than <paramref name="length"/> characters long.
@@ -340,7 +346,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
         public static IValidationBuilder MaxLength(this IValidationBuilder builder, int length, string? errorMessage = null)
-            => builder.Satisfies<MaxLengthAttribute>(errorMessage, length);
+            => builder.Satisfies(new MaxLengthAttribute(length), errorMessage);
 
         /// <summary>
         /// Specifies that values must match a regular expression.
@@ -350,7 +356,7 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <param name="errorMessage">A custom error message to display.</param>
         /// <returns>The builder.</returns>
         public static IValidationBuilder RegularExpression(this IValidationBuilder builder, string pattern, string? errorMessage = null)
-            => builder.Satisfies<RegularExpressionAttribute>(errorMessage, pattern);
+            => builder.Satisfies(new RegularExpressionAttribute(pattern), errorMessage);
 
         /// <summary>
         /// Specifies that values must satisfy the requirements of the validation attribute of type <typeparamref name="TAttribute"/>.
@@ -380,7 +386,7 @@ namespace McMaster.Extensions.CommandLineUtils
         public static IValidationBuilder<int> Range(this IValidationBuilder<int> builder, int minimum, int maximum, string? errorMessage = null)
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
         {
-            var attribute = GetValidationAttr<RangeAttribute>(errorMessage, new object[] { minimum, maximum });
+            var attribute = new RangeAttribute(minimum, maximum) { ErrorMessage = errorMessage };
             builder.Use(new AttributeValidator(attribute));
             return builder;
         }
@@ -397,7 +403,7 @@ namespace McMaster.Extensions.CommandLineUtils
         public static IValidationBuilder<double> Range(this IValidationBuilder<double> builder, double minimum, double maximum, string? errorMessage = null)
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
         {
-            var attribute = GetValidationAttr<RangeAttribute>(errorMessage, new object[] { minimum, maximum });
+            var attribute = new RangeAttribute(minimum, maximum) { ErrorMessage = errorMessage };
             builder.Use(new AttributeValidator(attribute));
             return builder;
         }
@@ -436,6 +442,16 @@ namespace McMaster.Extensions.CommandLineUtils
         {
             option.Validators.Add(new DelegateValidator(validate));
             return option;
+        }
+
+        private static IValidationBuilder Satisfies(this IValidationBuilder builder, ValidationAttribute attribute, string? errorMessage = null)
+        {
+            if (errorMessage is not null)
+            {
+                attribute.ErrorMessage = errorMessage;
+            }
+            builder.Use(new AttributeValidator(attribute));
+            return builder;
         }
 
         private static T GetValidationAttr<T>(string? errorMessage, object[]? ctorArgs = null)

--- a/src/CommandLineUtils/Validation/ValidationExtensions.cs
+++ b/src/CommandLineUtils/Validation/ValidationExtensions.cs
@@ -23,11 +23,10 @@ namespace McMaster.Extensions.CommandLineUtils
         public static CommandOption IsRequired(this CommandOption option, bool allowEmptyStrings = false, string? errorMessage = null)
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
         {
-            var attribute = new RequiredAttribute
+            var attribute = AddErrorMessage(new RequiredAttribute
             {
-                ErrorMessage = errorMessage,
                 AllowEmptyStrings = allowEmptyStrings
-            };
+            }, errorMessage);
             option.Validators.Add(new AttributeValidator(attribute));
             return option;
         }
@@ -60,11 +59,10 @@ namespace McMaster.Extensions.CommandLineUtils
         public static CommandArgument IsRequired(this CommandArgument argument, bool allowEmptyStrings = false, string? errorMessage = null)
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
         {
-            var attribute = new RequiredAttribute
+            var attribute = AddErrorMessage(new RequiredAttribute
             {
-                ErrorMessage = errorMessage,
                 AllowEmptyStrings = allowEmptyStrings
-            };
+            }, errorMessage);
             argument.Validators.Add(new AttributeValidator(attribute));
             return argument;
         }
@@ -386,7 +384,7 @@ namespace McMaster.Extensions.CommandLineUtils
         public static IValidationBuilder<int> Range(this IValidationBuilder<int> builder, int minimum, int maximum, string? errorMessage = null)
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
         {
-            var attribute = new RangeAttribute(minimum, maximum) { ErrorMessage = errorMessage };
+            var attribute = AddErrorMessage(new RangeAttribute(minimum, maximum), errorMessage );
             builder.Use(new AttributeValidator(attribute));
             return builder;
         }
@@ -403,7 +401,7 @@ namespace McMaster.Extensions.CommandLineUtils
         public static IValidationBuilder<double> Range(this IValidationBuilder<double> builder, double minimum, double maximum, string? errorMessage = null)
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
         {
-            var attribute = new RangeAttribute(minimum, maximum) { ErrorMessage = errorMessage };
+            var attribute = AddErrorMessage(new RangeAttribute(minimum, maximum), errorMessage);
             builder.Use(new AttributeValidator(attribute));
             return builder;
         }
@@ -458,6 +456,16 @@ namespace McMaster.Extensions.CommandLineUtils
             where T : ValidationAttribute
         {
             var attribute = (T)Activator.CreateInstance(typeof(T), ctorArgs ?? new object[0]);
+            if (errorMessage != null)
+            {
+                attribute.ErrorMessage = errorMessage;
+            }
+            return attribute;
+        }
+
+        private static T AddErrorMessage<T>(T attribute, string? errorMessage)
+            where T : ValidationAttribute
+        {
             if (errorMessage != null)
             {
                 attribute.ErrorMessage = errorMessage;


### PR DESCRIPTION
Hey!

I discovered that CommandLineUtils is not trimming compatible with net6.0 and will fail at runtime with an error like:

```
Unhandled exception. System.MissingMethodException: Constructor on type 'System.ComponentModel.DataAnnotations.RequiredAttribute' not found.
   at System.RuntimeType.CreateInstanceImpl(BindingFlags , Binder , Object[] , CultureInfo )
   at System.Activator.CreateInstance(Type , BindingFlags , Binder , Object[] , CultureInfo , Object[] )
   at McMaster.Extensions.CommandLineUtils.ValidationExtensions.GetValidationAttr[T](String , Object[] )
   at McMaster.Extensions.CommandLineUtils.ValidationExtensions.IsRequired(CommandArgument , Boolean , String )
   at GrpcCurl.GrpcCurlApp.Run(String[] args)
   at Program.<Main>$(String[] args)
   at Program.<Main>(String[] args)
```

I have been able to workaround it [here](https://github.com/xoofx/grpc-curl/blob/329ac4fce0c7840fbca63c0b66400fc24bce3791/src/GrpcCurl/GrpcCurlApp.cs#L19-L24) but it's not super great.

```c#
// Workaround for CommandLineUtils with trimming
// Force RequiredAttribute ctor to be kept around
if (new RequiredAttribute().GetHashCode() > 0)
{
    exeName += "";
}
``` 

Which is really unfortunate because we usually want to use trimming for small console apps. 😅 

This PR is fixing this issue with these attributes used via `Activator.CreateInstance` and use instead explicit constructors. The previous abstraction `GetValidationAttr<T>` was removed.

It should make CommandLineUtils a bit more compatible with net6.0 trimming. 

I tried to enable [trimming analysis](https://docs.microsoft.com/en-us/dotnet/core/deploying/trimming/prepare-libraries-for-trimming) by adding net6.0 target... but wow, that triggers quite a few errors. Not a lot, but as it gets viral, it might require more deeper thinking on this.

At least, this PR fixes a basic usage of this library.
