### PR TITLE
Fix to the bug #518 

### DIFF
--- a/src/CommandLineUtils/Conventions/ArgumentAttributeConvention.cs
+++ b/src/CommandLineUtils/Conventions/ArgumentAttributeConvention.cs
@@ -150,26 +150,30 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
 
                     if (r.SelectedCommand is IModelAccessor cmd)
                     {
-                        if (argument.Values.Count == 0)
+                        var model = cmd.GetModel();
+                        if (prop.DeclaringType.IsAssignableFrom(model.GetType()))
                         {
-                            if (!ReflectionHelper.IsSpecialValueTupleType(prop.PropertyType, out _))
+                            if (argument.Values.Count == 0)
                             {
-                                var value = getter.Invoke(cmd.GetModel());
-                                if (value != null)
+                                if (!ReflectionHelper.IsSpecialValueTupleType(prop.PropertyType, out _))
                                 {
-                                    argument.TryParse(value.ToString());
-                                    argument.DefaultValue = value.ToString();
+                                    var value = getter.Invoke(model);
+                                    if (value != null)
+                                    {
+                                        argument.TryParse(value.ToString());
+                                        argument.DefaultValue = value.ToString();
+                                    }
                                 }
                             }
-                        }
-                        else
-                        {
-                            setter.Invoke(
-                                cmd.GetModel(),
-                                parser.Parse(
-                                    argument.Name,
-                                    argument.Value,
-                                    convention.Application.ValueParsers.ParseCulture));
+                            else
+                            {
+                                setter.Invoke(
+                                    model,
+                                    parser.Parse(
+                                        argument.Name,
+                                        argument.Value,
+                                        convention.Application.ValueParsers.ParseCulture));
+                            }
                         }
                     }
                 });

--- a/test/CommandLineUtils.Tests/ArgumentAttributeTests.cs
+++ b/test/CommandLineUtils.Tests/ArgumentAttributeTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -93,6 +94,48 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             app3.Parse();
             Assert.Equal("a", app3.Model.Arg1);
             Assert.Equal(new[] { "b", "c" }, app3.Model.Arg2);
+        }
+
+        [Subcommand(typeof(ACommand))]
+        public class Program
+        {
+        }
+
+        [Command("a")]
+        [Subcommand(typeof(BCommand))]
+        public class ACommand
+        {
+            [Argument(0)]
+            public string? Arg1 { get; set; }
+        }
+
+        [Command("b")]
+        public class BCommand
+        {
+            [Argument(0)]
+            public string? Arg1 { get; set; }
+        }
+
+        [Fact]
+        public void SameArgumentInSubcommandsCallingACommand()
+        {
+            var app1 = new CommandLineApplication<Program>();
+            app1.Conventions.UseDefaultConventions();
+            var result = app1.Parse("a", "any-value");
+            var command = result.SelectedCommand as CommandLineApplication<ACommand>;
+            Assert.NotNull(command);
+            Assert.Equal("any-value", command.Model.Arg1);
+        }
+
+        [Fact]
+        public void SameArgumentInSubcommandsCallingBCommand()
+        {
+            var app1 = new CommandLineApplication<Program>();
+            app1.Conventions.UseDefaultConventions();
+            var result = app1.Parse("a", "b", "any-value");
+            var command = result.SelectedCommand as CommandLineApplication<BCommand>;
+            Assert.NotNull(command);
+            Assert.Equal("any-value", command.Model.Arg1);
         }
     }
 }


### PR DESCRIPTION
Added check on the model type before it proceeds accessing the property with its getter or setter.
The exception is thrown because it tries to get the value of a property defined on a different type.

Given two commands A and B, where B is sub command of A, bot commands define an argument property. In this case it tries to get the value of the argument property defined in A from the model of type B. This thows the exception described in the bug #518.