### PR TITLE
fix: don't set DefaultValue to empty string for `string[]` options

### DIFF
--- a/src/CommandLineUtils/Conventions/OptionAttributeConventionBase.cs
+++ b/src/CommandLineUtils/Conventions/OptionAttributeConventionBase.cs
@@ -81,11 +81,16 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                             {
                                 if (getter.Invoke(modelAccessor.GetModel()) is IEnumerable<object> values)
                                 {
+                                    var count = 0;
                                     foreach (var value in values)
                                     {
+                                        count++;
                                         option.TryParse(value?.ToString());
                                     }
-                                    option.DefaultValue = string.Join(", ", values.Select(x => x?.ToString()));
+                                    if (count > 0)
+                                    {
+                                        option.DefaultValue = string.Join(", ", values.Select(x => x?.ToString()));
+                                    }
                                 }
                             }
                         }

--- a/test/CommandLineUtils.Tests/FilePathExistsAttributeTests.cs
+++ b/test/CommandLineUtils.Tests/FilePathExistsAttributeTests.cs
@@ -174,5 +174,32 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             Assert.Equal(0, CommandLineApplication.Execute<OnlyFile>(context));
             Assert.NotEqual(0, CommandLineApplication.Execute<OnlyDir>(context));
         }
+
+        private class OptionalFileChecks
+        {
+            [DirectoryExists]
+            [Option]
+            public string[] Dir { get; } = new string[0];
+
+            [FileExists]
+            [Option]
+            public string? File { get; }
+
+            private void OnExecute() { }
+        }
+
+        [Theory]
+        [InlineData(0, new string[0])]
+        [InlineData(1, new[] { "-f", "file.txt" })]
+        [InlineData(1, new[] { "-d", "dir1" })]
+        public void OnlyValidatesOptionsIfSpecified(int exitCode, string[] args)
+        {
+            var context = new DefaultCommandLineContext(
+                new TestConsole(_output),
+                AppContext.BaseDirectory,
+                args);
+
+            Assert.Equal(exitCode, CommandLineApplication.Execute<OptionalFileChecks>(context));
+        }
     }
 }


### PR DESCRIPTION
Fixes #536