### PR TITLE
Fix CommandArgumentEnumerator behavior for .NET 8

### DIFF
--- a/src/CommandLineUtils/Internal/CommandLineProcessor.cs
+++ b/src/CommandLineUtils/Internal/CommandLineProcessor.cs
@@ -525,7 +525,7 @@ namespace McMaster.Extensions.CommandLineUtils
                 _enumerator = enumerator;
             }
 
-            public CommandArgument Current => _enumerator.Current;
+            public CommandArgument Current { get; private set; } = null!;
 
             object IEnumerator.Current => Current;
 
@@ -535,7 +535,10 @@ namespace McMaster.Extensions.CommandLineUtils
             {
                 if (Current == null || !Current.MultipleValues)
                 {
-                    return _enumerator.MoveNext();
+                    var result = _enumerator.MoveNext();
+                    if (result)
+                        Current = _enumerator.Current!;
+                    return result;
                 }
 
                 // If current argument allows multiple values, we don't move forward and

--- a/test/CommandLineUtils.Tests/McMaster.Extensions.CommandLineUtils.Tests.csproj
+++ b/test/CommandLineUtils.Tests/McMaster.Extensions.CommandLineUtils.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(TestFullFramework)' != 'false'">$(TargetFrameworks);net472</TargetFrameworks>
     <!-- Once xunit supports nullable reference types, I might reconsider -->
     <Nullable>annotations</Nullable>


### PR DESCRIPTION
Fixes #541 

There's been a [breaking change](https://github.com/dotnet/runtime/issues/94256) in .NET 8. The behavior for `IEnumerator.Current`, which has always been undefined when called after `MoveNext()` returned false, has changed from "return the last value" to "throw an exception". So instead of calling `_enumerator.Current` every time `Current` is invoked, we now store the value of `_enumerator.Current` after `_enumerator.MoveNext()` returned true.

I also added the `net8.0` TFM to the unit tests to validate the behavior is now correct on .NET 8.