### PR TITLE
:breaking-change: bump version to 5.0 and drop support for .NET Standard 2 and < .NET 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           dotnet-version: |
             6.0.x
-            7.0.x
+            8.0.x
       - name: Run build script
         id: build_script
         run: ./build.ps1 -ci

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,10 +21,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET 6
+    - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '6.0.x'
+        dotnet-version: |
+          6.0.x
+          8.0.x
     - name: Run docs generation
       run: ./docs/generate.ps1
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,7 +28,6 @@
 
   <PropertyGroup>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);1591</WarningsNotAsErrors>
-    <LangVersion>9.0</LangVersion>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <Nullable>enable</Nullable>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)src\StrongName.snk</AssemblyOriginatorKeyFile>
@@ -41,7 +40,7 @@
   </PropertyGroup>
 
    <PropertyGroup>
-    <VersionPrefix>4.1.1</VersionPrefix>
+    <VersionPrefix>5.0.0</VersionPrefix>
     <VersionSuffix>beta</VersionSuffix>
     <IncludePreReleaseLabelInPackageVersion Condition="'$(IS_STABLE_BUILD)' != 'true'">true</IncludePreReleaseLabelInPackageVersion>
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">$(GITHUB_RUN_NUMBER)</BuildNumber>
@@ -52,11 +51,6 @@
     <PackageVersion Condition="'$(IncludePreReleaseLabelInPackageVersion)' == 'true'">$(PackageVersion)-$(VersionSuffix)</PackageVersion>
     <InformationalVersion Condition="'$(RepositoryCommit)' != ''">$(PackageVersion)+$(RepositoryCommit)</InformationalVersion>
   </PropertyGroup>
-
-  <ItemGroup>
-    <!-- For x-plat development -->
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
-  </ItemGroup>
 
   <Import Project="$(MSBuildProjectDirectory)/releasenotes.props"
           Condition="Exists('$(MSBuildProjectDirectory)/releasenotes.props')" />

--- a/docs/generate.ps1
+++ b/docs/generate.ps1
@@ -37,7 +37,7 @@ try {
     if (-not (Test-Path $docfx)) {
         mkdir -p $docfxRoot -ErrorAction Ignore | Out-Null
         $temp = (New-TemporaryFile).FullName + ".zip"
-        Invoke-WebRequest "https://www.nuget.org/api/v2/package/docfx.console/$docfxVersion" -O $temp
+        Invoke-WebRequest "https://www.nuget.org/api/v2/package/docfx.console/$docfxVersion" -OutFile $temp
         Expand-Archive $temp -DestinationPath $docfxRoot
         Remove-Item $temp
         if ($Install) {

--- a/docs/samples/attributes/Attributes.csproj
+++ b/docs/samples/attributes/Attributes.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/samples/custom-attribute/CustomAttribute.csproj
+++ b/docs/samples/custom-attribute/CustomAttribute.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/samples/custom-conventions/CustomConvention.csproj
+++ b/docs/samples/custom-conventions/CustomConvention.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/samples/dependency-injection/custom/CustomServices.csproj
+++ b/docs/samples/dependency-injection/custom/CustomServices.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/samples/dependency-injection/generic-host/GenericHostDI.csproj
+++ b/docs/samples/dependency-injection/generic-host/GenericHostDI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/samples/dependency-injection/standard/StandardServices.csproj
+++ b/docs/samples/dependency-injection/standard/StandardServices.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/samples/generic-host/AttributeApi/AttributeApi.csproj
+++ b/docs/samples/generic-host/AttributeApi/AttributeApi.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/samples/generic-host/BuilderApi/BuilderApi.csproj
+++ b/docs/samples/generic-host/BuilderApi/BuilderApi.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/samples/helloworld-async-attributes/AsyncAttributes.csproj
+++ b/docs/samples/helloworld-async-attributes/AsyncAttributes.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/samples/interactive-prompts/Prompt.csproj
+++ b/docs/samples/interactive-prompts/Prompt.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/samples/pager/Pager.csproj
+++ b/docs/samples/pager/Pager.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/samples/passthru-args/attributes/AttributesPassThru.csproj
+++ b/docs/samples/passthru-args/attributes/AttributesPassThru.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/samples/passthru-args/builder-api/BuilderApiPassThru.csproj
+++ b/docs/samples/passthru-args/builder-api/BuilderApiPassThru.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/samples/response-file-parsing/attributes/RspAttributes.csproj
+++ b/docs/samples/response-file-parsing/attributes/RspAttributes.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/samples/response-file-parsing/builder-api/RspBuilderApi.csproj
+++ b/docs/samples/response-file-parsing/builder-api/RspBuilderApi.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/samples/subcommands/builder-api/BuilderApiSubcommands.csproj
+++ b/docs/samples/subcommands/builder-api/BuilderApiSubcommands.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/samples/subcommands/inheritance/InheritanceSubcommands.csproj
+++ b/docs/samples/subcommands/inheritance/InheritanceSubcommands.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/samples/subcommands/nested-types/NestedTypeSubcommands.csproj
+++ b/docs/samples/subcommands/nested-types/NestedTypeSubcommands.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/samples/validation/attributes/Program.cs
+++ b/docs/samples/validation/attributes/Program.cs
@@ -5,6 +5,9 @@ using System;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using McMaster.Extensions.CommandLineUtils;
+// This is required since .NET 8 introduced a new type System.ComponentModel.DataAnnotations.AllowedValuesAttribute
+// which conflicts with the attribute in this library (added long before .NET 8.)
+using AllowedValues = McMaster.Extensions.CommandLineUtils.AllowedValuesAttribute;
 
 [MaxSizeOptionRequiresAttachmentValidation()]
 class AttributeProgram

--- a/docs/samples/validation/attributes/ValidationAttributes.csproj
+++ b/docs/samples/validation/attributes/ValidationAttributes.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/samples/validation/builder-api/ValidationBuilderApi.csproj
+++ b/docs/samples/validation/builder-api/ValidationBuilderApi.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CommandLineUtils/Abstractions/CommandLineContext.cs
+++ b/src/CommandLineUtils/Abstractions/CommandLineContext.cs
@@ -11,7 +11,7 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
     /// </summary>
     public abstract class CommandLineContext
     {
-        private string[] _args = new string[0];
+        private string[] _args = Array.Empty<string>();
         private string _workDir = Directory.GetCurrentDirectory();
         private IConsole _console = PhysicalConsole.Singleton;
 

--- a/src/CommandLineUtils/Abstractions/ValueParserProvider.cs
+++ b/src/CommandLineUtils/Abstractions/ValueParserProvider.cs
@@ -61,7 +61,11 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
         public IValueParser GetParser(Type type)
         {
             var method = s_getParserGeneric.MakeGenericMethod(type);
+#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
+#pragma warning disable CS8603 // Possible null reference return.
             return (IValueParser)method.Invoke(this, Array.Empty<object>());
+#pragma warning restore CS8603 // Possible null reference return.
+#pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
         }
 
         /// <summary>
@@ -121,8 +125,12 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
                 {
                     return null;
                 }
+#pragma warning disable CS8602 // Dereference of a possibly null reference.
                 var method = typeof(ValueTupleValueParser).GetMethod(nameof(ValueTupleValueParser.Create)).MakeGenericMethod(type.GenericTypeArguments[1]);
+#pragma warning restore CS8602 // Dereference of a possibly null reference.
+#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
                 return (IValueParser)method.Invoke(null, new object[] { innerParser });
+#pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
             }
 
             return null;

--- a/src/CommandLineUtils/Attributes/AllowedValuesAttribute.cs
+++ b/src/CommandLineUtils/Attributes/AllowedValuesAttribute.cs
@@ -40,7 +40,7 @@ namespace McMaster.Extensions.CommandLineUtils
         public AllowedValuesAttribute(StringComparison comparer, params string[] allowedValues)
             : base(GetDefaultError(allowedValues))
         {
-            _allowedValues = allowedValues ?? new string[0];
+            _allowedValues = allowedValues ?? Array.Empty<string>();
             Comparer = comparer;
         }
 

--- a/src/CommandLineUtils/Attributes/VersionOptionFromMemberAttribute.cs
+++ b/src/CommandLineUtils/Attributes/VersionOptionFromMemberAttribute.cs
@@ -60,7 +60,11 @@ namespace McMaster.Extensions.CommandLineUtils
 
                 shortFormGetter = () =>
                 {
+#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
+#pragma warning disable CS8603 // Possible null reference return.
                     return (string)methods[0].Invoke(targetInstanceFactory.Invoke(), Array.Empty<object>());
+#pragma warning restore CS8603 // Possible null reference return.
+#pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
                 };
             }
 

--- a/src/CommandLineUtils/CommandArgument{T}.cs
+++ b/src/CommandLineUtils/CommandArgument{T}.cs
@@ -38,7 +38,9 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <summary>
         /// The parsed value.
         /// </summary>
+#pragma warning disable CS8603 // Possible null reference return.
         public T ParsedValue => ParsedValues.FirstOrDefault();
+#pragma warning restore CS8603 // Possible null reference return.
 
         /// <summary>
         /// All parsed values;

--- a/src/CommandLineUtils/CommandLineApplication.cs
+++ b/src/CommandLineUtils/CommandLineApplication.cs
@@ -877,13 +877,17 @@ namespace McMaster.Extensions.CommandLineUtils
 
             try
             {
+#pragma warning disable CS8622 // Nullability of reference types in type of parameter doesn't match the target delegate (possibly because of nullability attributes).
                 _context.Console.CancelKeyPress += cancelHandler;
+#pragma warning restore CS8622 // Nullability of reference types in type of parameter doesn't match the target delegate (possibly because of nullability attributes).
 
                 return await command._handler(handlerCancellationTokenSource.Token);
             }
             finally
             {
+#pragma warning disable CS8622 // Nullability of reference types in type of parameter doesn't match the target delegate (possibly because of nullability attributes).
                 _context.Console.CancelKeyPress -= cancelHandler;
+#pragma warning restore CS8622 // Nullability of reference types in type of parameter doesn't match the target delegate (possibly because of nullability attributes).
             }
         }
 
@@ -1146,7 +1150,9 @@ namespace McMaster.Extensions.CommandLineUtils
 
         internal IServiceProvider? AdditionalServices { get; set; }
 
+#pragma warning disable CS8603 // Possible null reference return.
         object IServiceProvider.GetService(Type serviceType) => _services.Value.GetService(serviceType);
+#pragma warning restore CS8603 // Possible null reference return.
 
         private sealed class ServiceProvider : IServiceProvider
         {

--- a/src/CommandLineUtils/CommandLineApplicationExtensions.cs
+++ b/src/CommandLineUtils/CommandLineApplicationExtensions.cs
@@ -176,9 +176,11 @@ namespace McMaster.Extensions.CommandLineUtils
             var infoVersion = assembly
                 ?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
                 ?.InformationalVersion;
+#pragma warning disable CS8602 // Dereference of a possibly null reference.
             return string.IsNullOrWhiteSpace(infoVersion)
                 ? assembly?.GetName().Version.ToString()
                 : infoVersion;
+#pragma warning restore CS8602 // Dereference of a possibly null reference.
         }
     }
 }

--- a/src/CommandLineUtils/CommandOption{T}.cs
+++ b/src/CommandLineUtils/CommandOption{T}.cs
@@ -39,7 +39,9 @@ namespace McMaster.Extensions.CommandLineUtils
         /// <summary>
         /// The parsed value.
         /// </summary>
+#pragma warning disable CS8603 // Possible null reference return.
         public T ParsedValue => ParsedValues.FirstOrDefault();
+#pragma warning restore CS8603 // Possible null reference return.
 
         /// <summary>
         /// All parsed values;

--- a/src/CommandLineUtils/Conventions/ArgumentAttributeConvention.cs
+++ b/src/CommandLineUtils/Conventions/ArgumentAttributeConvention.cs
@@ -151,6 +151,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                     if (r.SelectedCommand is IModelAccessor cmd)
                     {
                         var model = cmd.GetModel();
+#pragma warning disable CS8602 // Dereference of a possibly null reference.
                         if (prop.DeclaringType.IsAssignableFrom(model.GetType()))
                         {
                             if (argument.Values.Count == 0)
@@ -175,6 +176,7 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                                         convention.Application.ValueParsers.ParseCulture));
                             }
                         }
+#pragma warning restore CS8602 // Dereference of a possibly null reference.
                     }
                 });
             }

--- a/src/CommandLineUtils/Conventions/ConstructorInjectionConvention.cs
+++ b/src/CommandLineUtils/Conventions/ConstructorInjectionConvention.cs
@@ -94,9 +94,11 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                             goto nextCtor;
                         }
 
+#pragma warning disable CS8604 // Possible null reference argument.
                         return () =>
                             throw new InvalidOperationException(
                                 Strings.NoParameterTypeRegistered(ctorCandidate.DeclaringType, paramType));
+#pragma warning restore CS8604 // Possible null reference argument.
                     }
 
                     args[i] = service;

--- a/src/CommandLineUtils/Conventions/ExecuteMethodConvention.cs
+++ b/src/CommandLineUtils/Conventions/ExecuteMethodConvention.cs
@@ -79,17 +79,23 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
         {
             try
             {
+#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
                 var result = (Task)method.Invoke(instance, arguments);
+#pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
                 if (result is Task<int> intResult)
                 {
                     return await intResult;
                 }
 
+#pragma warning disable CS8602 // Dereference of a possibly null reference.
                 await result;
+#pragma warning restore CS8602 // Dereference of a possibly null reference.
             }
             catch (TargetInvocationException e)
             {
+#pragma warning disable CS8604 // Possible null reference argument.
                 ExceptionDispatchInfo.Capture(e.InnerException).Throw();
+#pragma warning restore CS8604 // Possible null reference argument.
             }
 
             return 0;
@@ -102,12 +108,16 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                 var result = method.Invoke(instance, arguments);
                 if (method.ReturnType == typeof(int))
                 {
+#pragma warning disable CS8605 // Unboxing a possibly null value.
                     return (int)result;
+#pragma warning restore CS8605 // Unboxing a possibly null value.
                 }
             }
             catch (TargetInvocationException e)
             {
+#pragma warning disable CS8604 // Possible null reference argument.
                 ExceptionDispatchInfo.Capture(e.InnerException).Throw();
+#pragma warning restore CS8604 // Possible null reference argument.
             }
 
             return 0;

--- a/src/CommandLineUtils/Conventions/ValidateMethodConvention.cs
+++ b/src/CommandLineUtils/Conventions/ValidateMethodConvention.cs
@@ -59,7 +59,11 @@ namespace McMaster.Extensions.CommandLineUtils
                     }
                 }
 
+#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
+#pragma warning disable CS8603 // Possible null reference return.
                 return (ValidationResult)method.Invoke(modelAccessor.GetModel(), arguments);
+#pragma warning restore CS8603 // Possible null reference return.
+#pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
             });
         }
     }

--- a/src/CommandLineUtils/Conventions/ValidationErrorMethodConvention.cs
+++ b/src/CommandLineUtils/Conventions/ValidationErrorMethodConvention.cs
@@ -34,7 +34,9 @@ namespace McMaster.Extensions.CommandLineUtils.Conventions
                 var result = method.Invoke(modelAccessor.GetModel(), arguments);
                 if (method.ReturnType == typeof(int))
                 {
+#pragma warning disable CS8605 // Unboxing a possibly null value.
                     return (int)result;
+#pragma warning restore CS8605 // Unboxing a possibly null value.
                 }
 
                 return CommandLineApplication.ValidationErrorExitCode;

--- a/src/CommandLineUtils/IO/Pager.cs
+++ b/src/CommandLineUtils/IO/Pager.cs
@@ -42,15 +42,7 @@ namespace McMaster.Extensions.CommandLineUtils
                 throw new ArgumentNullException(nameof(console));
             }
 
-#if NET46_OR_GREATER
-            // if .NET Framework, assume we're on Windows unless it's running on Mono.
-            _enabled = Type.GetType("Mono.Runtime") != null;
-#elif NETSTANDARD2_0_OR_GREATER
             _enabled = !RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !console.IsOutputRedirected;
-#else
-#error Update target frameworks
-#endif
-
             _less = new Lazy<Process?>(CreateWriter);
             _fallbackWriter = console.Out;
         }

--- a/src/CommandLineUtils/Internal/CollectionParserProvider.cs
+++ b/src/CommandLineUtils/Internal/CollectionParserProvider.cs
@@ -20,7 +20,9 @@ namespace McMaster.Extensions.CommandLineUtils
             if (type.IsArray)
             {
                 var elementType = type.GetElementType();
+#pragma warning disable CS8604 // Possible null reference argument.
                 var elementParser = valueParsers.GetParser(elementType);
+#pragma warning restore CS8604 // Possible null reference argument.
 
                 return new ArrayParser(elementType, elementParser, valueParsers.ParseCulture);
             }

--- a/src/CommandLineUtils/Internal/ReflectionHelper.cs
+++ b/src/CommandLineUtils/Internal/ReflectionHelper.cs
@@ -25,7 +25,9 @@ namespace McMaster.Extensions.CommandLineUtils
             }
             else
             {
+#pragma warning disable CS8602 // Dereference of a possibly null reference.
                 var backingField = prop.DeclaringType.GetField($"<{prop.Name}>k__BackingField", DeclaredOnlyLookup);
+#pragma warning restore CS8602 // Dereference of a possibly null reference.
                 if (backingField == null)
                 {
                     throw new InvalidOperationException(
@@ -41,30 +43,40 @@ namespace McMaster.Extensions.CommandLineUtils
             var getter = prop.GetGetMethod(nonPublic: true);
             if (getter != null)
             {
-                return obj => getter.Invoke(obj, new object[] { });
+#pragma warning disable CS8603 // Possible null reference return.
+                return obj => getter.Invoke(obj, Array.Empty<object>());
+#pragma warning restore CS8603 // Possible null reference return.
             }
             else
             {
+#pragma warning disable CS8602 // Dereference of a possibly null reference.
                 var backingField = prop.DeclaringType.GetField($"<{prop.Name}>k__BackingField", DeclaredOnlyLookup);
+#pragma warning restore CS8602 // Dereference of a possibly null reference.
                 if (backingField == null)
                 {
                     throw new InvalidOperationException(
                         $"Could not find a way to get {prop.DeclaringType.FullName}.{prop.Name}. Try adding a getter.");
                 }
 
+#pragma warning disable CS8603 // Possible null reference return.
                 return obj => backingField.GetValue(obj);
+#pragma warning restore CS8603 // Possible null reference return.
             }
         }
 
         public static MethodInfo[] GetPropertyOrMethod(Type type, string name)
         {
             var members = GetAllMembers(type).ToList();
+#pragma warning disable CS8602 // Dereference of a possibly null reference.
+#pragma warning disable CS8619 // Nullability of reference types in value doesn't match target type.
             return members
                 .OfType<MethodInfo>()
                 .Where(m => m.Name == name)
                 .Concat(members.OfType<PropertyInfo>().Where(m => m.Name == name).Select(p => p.GetMethod))
                 .Where(m => m.ReturnType == typeof(string) && m.GetParameters().Length == 0)
                 .ToArray();
+#pragma warning restore CS8619 // Nullability of reference types in value doesn't match target type.
+#pragma warning restore CS8602 // Dereference of a possibly null reference.
         }
 
         public static PropertyInfo[] GetProperties(Type type)
@@ -156,7 +168,9 @@ namespace McMaster.Extensions.CommandLineUtils
                     yield return member;
                 }
 
+#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
                 type = type.BaseType;
+#pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
             }
         }
     }

--- a/src/CommandLineUtils/Internal/ValueParsers/HashSetParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/HashSetParser.cs
@@ -15,11 +15,15 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
         private readonly MethodInfo _addMethod;
         private readonly CultureInfo _parserCulture;
 
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         public HashSetParser(Type elementType, IValueParser elementParser, CultureInfo parserCulture)
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         {
             _elementParser = elementParser;
             _listType = typeof(HashSet<>).MakeGenericType(elementType);
+#pragma warning disable CS8601 // Possible null reference assignment.
             _addMethod = _listType.GetRuntimeMethod("Add", new[] { elementType });
+#pragma warning restore CS8601 // Possible null reference assignment.
             _parserCulture = parserCulture;
         }
 
@@ -30,7 +34,9 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
             {
                 _addMethod.Invoke(set, new[] { _elementParser.Parse(argName, t, _parserCulture) });
             }
+#pragma warning disable CS8603 // Possible null reference return.
             return set;
+#pragma warning restore CS8603 // Possible null reference return.
         }
     }
 }

--- a/src/CommandLineUtils/Internal/ValueParsers/ListParser.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/ListParser.cs
@@ -24,12 +24,18 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
 
         public object Parse(string? argName, IReadOnlyList<string?> values)
         {
+#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
             var list = (IList)Activator.CreateInstance(_listType, new object[] { values.Count });
+#pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
             foreach (var t in values)
             {
+#pragma warning disable CS8602 // Dereference of a possibly null reference.
                 list.Add(_elementParser.Parse(argName, t, _parserCulture));
+#pragma warning restore CS8602 // Dereference of a possibly null reference.
             }
+#pragma warning disable CS8603 // Possible null reference return.
             return list;
+#pragma warning restore CS8603 // Possible null reference return.
         }
     }
 }

--- a/src/CommandLineUtils/Internal/ValueParsers/StockValueParsers.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/StockValueParsers.cs
@@ -40,7 +40,9 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
         public static readonly IValueParser<string?> String = ValueParser.Create((_, value, __) => value);
 
         public static readonly IValueParser<Uri> Uri = ValueParser.Create(
+#pragma warning disable CS8604 // Possible null reference argument.
             (_, value, culture) => new Uri(value, UriKind.RelativeOrAbsolute));
+#pragma warning restore CS8604 // Possible null reference argument.
 
         private static FormatException InvalidValueException(string? argName, string specifics) =>
             new($"Invalid value specified for {argName}. {specifics}");

--- a/src/CommandLineUtils/Internal/ValueParsers/TypeDescriptorValueParserFactory.cs
+++ b/src/CommandLineUtils/Internal/ValueParsers/TypeDescriptorValueParserFactory.cs
@@ -45,7 +45,13 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
                 try
                 {
                     culture ??= CultureInfo.InvariantCulture;
+#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
+#pragma warning disable CS8603 // Possible null reference return.
+#pragma warning disable CS8604 // Possible null reference argument.
                     return (T)TypeConverter.ConvertFromString(null, culture, value);
+#pragma warning restore CS8604 // Possible null reference argument.
+#pragma warning restore CS8603 // Possible null reference return.
+#pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
                 }
                 catch (ArgumentException e)
                 {

--- a/src/CommandLineUtils/McMaster.Extensions.CommandLineUtils.csproj
+++ b/src/CommandLineUtils/McMaster.Extensions.CommandLineUtils.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netstandard2.0;net46</TargetFrameworks>
-    <Nullable Condition="'$(TargetFramework)' != 'netstandard2.1'">annotations</Nullable>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
     <Description>Command-line parsing API.</Description>
@@ -21,16 +20,6 @@ McMaster.Extensions.CommandLineUtils.ArgumentEscaper
     <PackageTags>commandline;parsing</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1'">
-    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
-    <Reference Include="System.ComponentModel.DataAnnotations" />
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-  </ItemGroup>
 
   <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />

--- a/src/CommandLineUtils/Properties/Strings.cs
+++ b/src/CommandLineUtils/Properties/Strings.cs
@@ -40,31 +40,31 @@ namespace McMaster.Extensions.CommandLineUtils
 
         public static string CannotDetermineOptionType(PropertyInfo member)
             => $"Could not automatically determine the {nameof(CommandOptionType)} for type {member.PropertyType.FullName}. " +
-                    $"Set the {nameof(OptionAttribute.OptionType)} on the {nameof(OptionAttribute)} declaration for {member.DeclaringType.FullName}.{member.Name}.";
+                    $"Set the {nameof(OptionAttribute.OptionType)} on the {nameof(OptionAttribute)} declaration for {member.DeclaringType?.FullName}.{member.Name}.";
 
         public static string OptionNameIsAmbiguous(string optionName, PropertyInfo first, PropertyInfo second)
-            => $"Ambiguous option name. Both {first.DeclaringType.FullName}.{first.Name} and {second.DeclaringType.FullName}.{second.Name} produce a CommandOption with the name '{optionName}'.";
+            => $"Ambiguous option name. Both {first.DeclaringType?.FullName}.{first.Name} and {second.DeclaringType?.FullName}.{second.Name} produce a CommandOption with the name '{optionName}'.";
 
         public static string DuplicateSubcommandName(string commandName)
             => $"The subcommand name '{commandName}' has already been been specified. Subcommand names must be unique.";
 
         public static string BothOptionAndArgumentAttributesCannotBeSpecified(PropertyInfo prop)
-            => $"Cannot specify both {nameof(OptionAttribute)} and {nameof(ArgumentAttribute)} on property {prop.DeclaringType.Name}.{prop.Name}.";
+            => $"Cannot specify both {nameof(OptionAttribute)} and {nameof(ArgumentAttribute)} on property {prop.DeclaringType?.Name}.{prop.Name}.";
 
         public static string BothOptionAndHelpOptionAttributesCannotBeSpecified(PropertyInfo prop)
-            => $"Cannot specify both {nameof(OptionAttribute)} and {nameof(HelpOptionAttribute)} on property {prop.DeclaringType.Name}.{prop.Name}.";
+            => $"Cannot specify both {nameof(OptionAttribute)} and {nameof(HelpOptionAttribute)} on property {prop.DeclaringType?.Name}.{prop.Name}.";
 
         public static string BothOptionAndVersionOptionAttributesCannotBeSpecified(PropertyInfo prop)
-            => $"Cannot specify both {nameof(OptionAttribute)} and {nameof(VersionOptionAttribute)} on property {prop.DeclaringType.Name}.{prop.Name}.";
+            => $"Cannot specify both {nameof(OptionAttribute)} and {nameof(VersionOptionAttribute)} on property {prop.DeclaringType?.Name}.{prop.Name}.";
 
         internal static string UnsupportedParameterTypeOnMethod(string methodName, ParameterInfo methodParam)
             => $"Unsupported type on {methodName} '{methodParam.ParameterType.FullName}' on parameter {methodParam.Name}.";
 
         public static string BothHelpOptionAndVersionOptionAttributesCannotBeSpecified(PropertyInfo prop)
-            => $"Cannot specify both {nameof(HelpOptionAttribute)} and {nameof(VersionOptionAttribute)} on property {prop.DeclaringType.Name}.{prop.Name}.";
+            => $"Cannot specify both {nameof(HelpOptionAttribute)} and {nameof(VersionOptionAttribute)} on property {prop.DeclaringType?.Name}.{prop.Name}.";
 
         public static string DuplicateArgumentPosition(int order, PropertyInfo first, PropertyInfo second)
-            => $"Duplicate value for argument order. Both {first.DeclaringType.FullName}.{first.Name} and {second.DeclaringType.FullName}.{second.Name} have set Order = {order}.";
+            => $"Duplicate value for argument order. Both {first.DeclaringType?.FullName}.{first.Name} and {second.DeclaringType?.FullName}.{second.Name} have set Order = {order}.";
 
         public static string OnlyLastArgumentCanAllowMultipleValues(string? lastArgName)
             => $"The last argument '{lastArgName}' accepts multiple values. No more argument can be added.";
@@ -73,7 +73,7 @@ namespace McMaster.Extensions.CommandLineUtils
             => $"Could not automatically determine how to convert string values into {type.FullName}.";
 
         public static string CannotDetermineParserType(PropertyInfo prop)
-            => $"Could not automatically determine how to convert string values into {prop.PropertyType.FullName} on property {prop.DeclaringType.Name}.{prop.Name}.";
+            => $"Could not automatically determine how to convert string values into {prop.PropertyType.FullName} on property {prop.DeclaringType?.Name}.{prop.Name}.";
 
         public const string HelpOptionOnTypeAndProperty
             = "Multiple HelpOptionAttributes found. HelpOptionAttribute should only be used one per type, either on one property or on the type.";

--- a/src/CommandLineUtils/Utilities/DotNetExe.cs
+++ b/src/CommandLineUtils/Utilities/DotNetExe.cs
@@ -43,9 +43,6 @@ namespace McMaster.Extensions.CommandLineUtils
         private static string? TryFindDotNetExePath()
         {
             var fileName = FileName;
-#if NET46_OR_GREATER
-            fileName += ".exe";
-#elif NETSTANDARD2_0_OR_GREATER
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 fileName += ".exe";
@@ -57,9 +54,7 @@ namespace McMaster.Extensions.CommandLineUtils
             {
                 return mainModule.FileName;
             }
-#else
-#error Update target frameworks
-#endif
+
             // DOTNET_ROOT specifies the location of the .NET runtimes, if they are not installed in the default location.
             var dotnetRoot = Environment.GetEnvironmentVariable("DOTNET_ROOT");
 

--- a/src/CommandLineUtils/Utilities/Prompt.cs
+++ b/src/CommandLineUtils/Utilities/Prompt.cs
@@ -79,7 +79,7 @@ namespace McMaster.Extensions.CommandLineUtils
             Write(prompt, promptColor, promptBgColor);
             Console.Write(' ');
 
-            string resp;
+            string? resp;
             using (ShowCursor())
             {
                 resp = Console.ReadLine();
@@ -284,7 +284,9 @@ namespace McMaster.Extensions.CommandLineUtils
             {
                 try
                 {
+#pragma warning disable CA1416 // Validate platform compatibility
                     _original = Console.CursorVisible;
+#pragma warning restore CA1416 // Validate platform compatibility
                 }
                 catch
                 {

--- a/src/CommandLineUtils/Validation/ValidationExtensions.cs
+++ b/src/CommandLineUtils/Validation/ValidationExtensions.cs
@@ -455,12 +455,18 @@ namespace McMaster.Extensions.CommandLineUtils
         private static T GetValidationAttr<T>(string? errorMessage, object[]? ctorArgs = null)
             where T : ValidationAttribute
         {
-            var attribute = (T)Activator.CreateInstance(typeof(T), ctorArgs ?? new object[0]);
+#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
+            var attribute = (T)Activator.CreateInstance(typeof(T), ctorArgs ?? Array.Empty<object>());
+#pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
             if (errorMessage != null)
             {
+#pragma warning disable CS8602 // Dereference of a possibly null reference.
                 attribute.ErrorMessage = errorMessage;
+#pragma warning restore CS8602 // Dereference of a possibly null reference.
             }
+#pragma warning disable CS8603 // Possible null reference return.
             return attribute;
+#pragma warning restore CS8603 // Possible null reference return.
         }
 
         private static T AddErrorMessage<T>(T attribute, string? errorMessage)

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,7 +1,7 @@
 <Project InitialTargets="UpdateCiSettings">
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(DisablePublicApiAnalyzer)' != 'true'">

--- a/src/Hosting.CommandLine/McMaster.Extensions.Hosting.CommandLine.csproj
+++ b/src/Hosting.CommandLine/McMaster.Extensions.Hosting.CommandLine.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
     <Description>Provides command-line parsing API integration with the generic host API (Microsoft.Extensions.Hosting).</Description>

--- a/test/CommandLineUtils.Tests/FilePathExistsAttributeTests.cs
+++ b/test/CommandLineUtils.Tests/FilePathExistsAttributeTests.cs
@@ -179,7 +179,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
         {
             [DirectoryExists]
             [Option]
-            public string[] Dir { get; } = new string[0];
+            public string[] Dir { get; } = Array.Empty<string>();
 
             [FileExists]
             [Option]

--- a/test/CommandLineUtils.Tests/McMaster.Extensions.CommandLineUtils.Tests.csproj
+++ b/test/CommandLineUtils.Tests/McMaster.Extensions.CommandLineUtils.Tests.csproj
@@ -1,18 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(TestFullFramework)' != 'false'">$(TargetFrameworks);net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <!-- Once xunit supports nullable reference types, I might reconsider -->
     <Nullable>annotations</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\CommandLineUtils\McMaster.Extensions.CommandLineUtils.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
-    <Reference Include="System.ComponentModel.DataAnnotations" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/CommandLineUtils.Tests/OptionAttributeTests.cs
+++ b/test/CommandLineUtils.Tests/OptionAttributeTests.cs
@@ -153,7 +153,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             public (bool hasValue, string value) Arg4 { get; } = (false, "Yellow");
 
             [Option("-a5")]
-            public string[] Arg5 { get; } = new string[0];
+            public string[] Arg5 { get; } = Array.Empty<string>();
         }
 
         [Fact]
@@ -206,7 +206,7 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
             string[] Opt1 { get; }
 
             [Option("-o2")]
-            string[] Opt2 { get; } = new string[0];
+            string[] Opt2 { get; } = Array.Empty<string>();
         }
 
         [Fact]

--- a/test/Hosting.CommandLine.Tests/McMaster.Extensions.Hosting.CommandLine.Tests.csproj
+++ b/test/Hosting.CommandLine.Tests/McMaster.Extensions.Hosting.CommandLine.Tests.csproj
@@ -1,16 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(TestFullFramework)' != 'false'">$(TargetFrameworks);net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Hosting.CommandLine\McMaster.Extensions.Hosting.CommandLine.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
-    <Reference Include="System.ComponentModel.DataAnnotations" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This change makes the following breaking changes:

* Drops support for .NET Standard 2
* Drops support for any version of .NET < 6.0
* Removes some internal code that was necessary to preserve backwards compat with Mono and .NET Framework 4

The major version of this package is bumped to 5.0 to indicate this may break for some users.