### PR TITLE
fix: Update sample projects to target net8.0

### DIFF
--- a/docs/samples/helloworld-async/AsyncBuilderApi.csproj
+++ b/docs/samples/helloworld-async/AsyncBuilderApi.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/samples/helloworld-attributes/HelloWorldAttributes.csproj
+++ b/docs/samples/helloworld-attributes/HelloWorldAttributes.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/docs/samples/helloworld/HelloWorld.csproj
+++ b/docs/samples/helloworld/HelloWorld.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary
- Updated three sample projects that were still targeting `net6.0` to target `net8.0`
- These projects are incompatible with the main library which now targets `net8.0`

## Changed files
- `docs/samples/helloworld/HelloWorld.csproj`
- `docs/samples/helloworld-async/AsyncBuilderApi.csproj`
- `docs/samples/helloworld-attributes/HelloWorldAttributes.csproj`

## Test plan
- [x] Verified `dotnet build docs/samples/samples.sln` builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)