### PR TITLE
fix: Correct bugs in multiple value enum option help text

### DIFF
--- a/src/CommandLineUtils/Abstractions/ValueParserProvider.cs
+++ b/src/CommandLineUtils/Abstractions/ValueParserProvider.cs
@@ -133,6 +133,16 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
 #pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
             }
 
+            // For array and collection types, return a parser for the element type
+            if (type.IsArray)
+            {
+                var elementType = type.GetElementType();
+                if (elementType != null)
+                {
+                    return GetParser(elementType);
+                }
+            }
+
             return null;
         }
 

--- a/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
+++ b/src/CommandLineUtils/HelpText/DefaultHelpTextGenerator.cs
@@ -428,7 +428,7 @@ namespace McMaster.Extensions.CommandLineUtils.HelpText
 
             if (ReflectionHelper.IsEnumerableType(type, out var wrappedEnumerableType))
             {
-                return ExtractNamesFromEnum(wrappedType2);
+                return ExtractNamesFromEnum(wrappedEnumerableType);
             }
 
             if (type.IsEnum)

--- a/src/CommandLineUtils/Internal/ReflectionHelper.cs
+++ b/src/CommandLineUtils/Internal/ReflectionHelper.cs
@@ -160,11 +160,20 @@ namespace McMaster.Extensions.CommandLineUtils
 
         public static bool IsEnumerableType(Type type, [NotNullWhen(true)] out Type? wrappedType)
         {
-            var result = type.IsGenericType &&
-                         type.IsAssignableTo(typeof(IEnumerable<>));
-            wrappedType = result ? type.GenericTypeArguments[1] : null;
+            if (type.IsArray)
+            {
+                wrappedType = type.GetElementType()!;
+                return true;
+            }
 
-            return result;
+            if (type.IsGenericType)
+            {
+                wrappedType = type.GenericTypeArguments[0];
+                return true;
+            }
+
+            wrappedType = null;
+            return false;
         }
 
         private static IEnumerable<MemberInfo> GetAllMembers(Type type)

--- a/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
+++ b/test/CommandLineUtils.Tests/DefaultHelpTextGeneratorTests.cs
@@ -165,7 +165,7 @@ Options:
                             Allowed values are: None, Normal, Extreme.
   --enumOpt4[:<E>]          nullable enum option desc.
                             Allowed values are: None, Normal, Extreme.
-  --enumOpt5[:<E>]          multiple enum option desc.
+  --enumOpt5 <E>            multiple enum option desc.
                             Allowed values are: None, Normal, Extreme.
 
 ",


### PR DESCRIPTION
## Summary

- Fixes several bugs introduced in f1a8455 that broke `app.Option<SomeEnum[]>()` with `MultipleValue` options
- Corrects `ReflectionHelper.IsEnumerableType` to properly detect array element types
- Fixes wrong variable name in `ExtractNamesFromEnum` (`wrappedType2` → `wrappedEnumerableType`)
- Adds array type support to `ValueParserProvider.GetParserImpl`

## Test plan

- [x] All 797 existing unit tests pass
- [x] `DefaultHelpTextGeneratorTests.ShowHelp` now correctly tests `Option<SomeEnum[]>` with `MultipleValue`

🤖 Generated with [Claude Code](https://claude.com/claude-code)