### PR TITLE
chore: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  # NuGet packages - patch updates only for LTS stability
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    ignore:
+      # Only allow patch updates (ignore minor and major)
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+
+  # Sample and test projects - allow all updates (latest versions)
+  - package-ecosystem: "nuget"
+    directories:
+      - "/docs/samples"
+      - "/test"
+    schedule:
+      interval: "monthly"
+
+  # GitHub Actions - monthly updates
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "quarterly"


### PR DESCRIPTION
## Summary
- Enable Dependabot for automated dependency updates
- NuGet packages in root: monthly, patch updates only (LTS stability)
- Samples and test projects: monthly, all updates allowed (latest versions)
- GitHub Actions: quarterly updates

## Test plan
- [ ] Verify Dependabot detects the configuration after merge
- [ ] Monitor initial dependency PRs to ensure rules are applied correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)