### PR TITLE
fix: prevent flaky tests by disabling parallel execution for registry tests

### DIFF
--- a/test/CommandLineUtils.Tests/RemainingArgsPropertyConventionTests.cs
+++ b/test/CommandLineUtils.Tests/RemainingArgsPropertyConventionTests.cs
@@ -10,6 +10,8 @@ using Xunit.Abstractions;
 
 namespace McMaster.Extensions.CommandLineUtils.Tests
 {
+    // Uses shared static CommandMetadataRegistry - must not run in parallel with other registry tests
+    [Collection("MetadataRegistry")]
     public class RemainingArgsPropertyConventionTests : ConventionTestBase
     {
         public RemainingArgsPropertyConventionTests(ITestOutputHelper output) : base(output)

--- a/test/CommandLineUtils.Tests/SourceGeneration/CommandMetadataRegistryTests.cs
+++ b/test/CommandLineUtils.Tests/SourceGeneration/CommandMetadataRegistryTests.cs
@@ -8,6 +8,8 @@ using Xunit;
 
 namespace McMaster.Extensions.CommandLineUtils.Tests.SourceGeneration
 {
+    // Uses shared static CommandMetadataRegistry - must not run in parallel with other registry tests
+    [Collection("MetadataRegistry")]
     public class CommandMetadataRegistryTests
     {
         [Command(Name = "test1")]

--- a/test/CommandLineUtils.Tests/SourceGeneration/ConventionAotPathTests.cs
+++ b/test/CommandLineUtils.Tests/SourceGeneration/ConventionAotPathTests.cs
@@ -14,6 +14,8 @@ namespace McMaster.Extensions.CommandLineUtils.Tests.SourceGeneration
     /// Tests for the AOT-friendly code paths in conventions.
     /// These tests exercise the generated metadata paths in conventions.
     /// </summary>
+    // Uses shared static CommandMetadataRegistry - must not run in parallel with other registry tests
+    [Collection("MetadataRegistry")]
     public class ConventionAotPathTests : IDisposable
     {
         public ConventionAotPathTests()

--- a/test/CommandLineUtils.Tests/SourceGeneration/MetadataProviderTests.cs
+++ b/test/CommandLineUtils.Tests/SourceGeneration/MetadataProviderTests.cs
@@ -8,6 +8,8 @@ using Xunit;
 
 namespace McMaster.Extensions.CommandLineUtils.Tests.SourceGeneration
 {
+    // Uses shared static CommandMetadataRegistry - must not run in parallel with other registry tests
+    [Collection("MetadataRegistry")]
     public class MetadataProviderTests
     {
         [Command(Name = "test", Description = "A test command")]


### PR DESCRIPTION
## Summary
- Added `[Collection("MetadataRegistry")]` attribute to test classes that use `CommandMetadataRegistry`
- Added explanatory comments for future maintainers

## Problem
Tests using `CommandMetadataRegistry` share static state and were failing intermittently when xUnit ran them in parallel with other test classes. One test would call `Clear()` while another was mid-execution.

## Solution
All test classes that interact with the registry now use the same xUnit collection with `DisableParallelization = true`, ensuring they run sequentially.

## Affected test classes
- `CommandMetadataRegistryTests`
- `ConventionAotPathTests`
- `MetadataProviderTests`
- `RemainingArgsPropertyConventionTests`

## Test plan
- [x] Ran full build (`./build.ps1`)
- [x] Ran affected tests 20 times in a loop with 0 failures

🤖 Generated with [Claude Code](https://claude.ai/code)