### PR TITLE
fix: resolve nullable type lookup bypassing custom value parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 
 ### Fixes
 * [@claude]: Validate dotnet path exists before returning from `TryFindDotNetExePath` ([#600])
+* [@claude]: Fix nullable type lookup bypassing custom value parsers registered via `AddOrReplace` ([#559])
 
+[#559]: https://github.com/natemcmaster/CommandLineUtils/issues/559
 [#560]: https://github.com/natemcmaster/CommandLineUtils/pull/560
 [#600]: https://github.com/natemcmaster/CommandLineUtils/issues/600
 

--- a/src/CommandLineUtils/Abstractions/ValueParserProvider.cs
+++ b/src/CommandLineUtils/Abstractions/ValueParserProvider.cs
@@ -100,11 +100,6 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
                 return EnumParser.Create(type);
             }
 
-            if (_defaultValueParserFactory.TryGetParser<T>(out parser))
-            {
-                return parser;
-            }
-
             if (ReflectionHelper.IsNullableType(type, out var wrappedType))
             {
                 if (wrappedType.IsEnum)
@@ -116,6 +111,11 @@ namespace McMaster.Extensions.CommandLineUtils.Abstractions
                 {
                     return new NullableValueParser(parser);
                 }
+            }
+
+            if (_defaultValueParserFactory.TryGetParser<T>(out parser))
+            {
+                return parser;
             }
 
             if (ReflectionHelper.IsSpecialValueTupleType(type, out var wrappedType2))

--- a/src/CommandLineUtils/releasenotes.props
+++ b/src/CommandLineUtils/releasenotes.props
@@ -8,6 +8,7 @@ Features:
 
 Fixes:
 * @claude: Validate dotnet path exists before returning from TryFindDotNetExePath (#600)
+* @claude: Fix nullable type lookup bypassing custom value parsers registered via AddOrReplace (#559)
     </PackageReleaseNotes>
     <PackageReleaseNotes Condition="$(VersionPrefix.StartsWith('5.0.'))">
 Changes since 4.1:

--- a/test/CommandLineUtils.Tests/ValueParserProviderCustomTests.cs
+++ b/test/CommandLineUtils.Tests/ValueParserProviderCustomTests.cs
@@ -339,5 +339,71 @@ namespace McMaster.Extensions.CommandLineUtils.Tests
 
             Assert.Contains("parser", ex.Message);
         }
+
+        private class CustomTimeSpanParser : IValueParser<TimeSpan>
+        {
+            public Type TargetType => typeof(TimeSpan);
+
+            public TimeSpan Parse(string? argName, string? value, CultureInfo culture)
+            {
+                if (value != null && value.EndsWith("s"))
+                {
+                    var seconds = int.Parse(value.Substring(0, value.Length - 1), culture);
+                    return TimeSpan.FromSeconds(seconds);
+                }
+
+                return TimeSpan.Parse(value!, culture);
+            }
+
+            object? IValueParser.Parse(string? argName, string? value, CultureInfo culture)
+                => Parse(argName, value, culture);
+        }
+
+        private class NullableTimeSpanOptionProgram
+        {
+            [Option("--timeout", CommandOptionType.SingleValue)]
+            public TimeSpan? Timeout { get; set; }
+        }
+
+        private class NonNullableTimeSpanOptionProgram
+        {
+            [Option("--timeout", CommandOptionType.SingleValue)]
+            public TimeSpan Timeout { get; set; }
+        }
+
+        [Fact]
+        public void CustomParserWorksForNullableBuiltInType()
+        {
+            var app = new CommandLineApplication<NullableTimeSpanOptionProgram>();
+            app.ValueParsers.AddOrReplace(new CustomTimeSpanParser());
+            app.Conventions.UseDefaultConventions();
+
+            app.Parse("--timeout", "15s");
+
+            Assert.Equal(TimeSpan.FromSeconds(15), app.Model.Timeout);
+        }
+
+        [Fact]
+        public void CustomParserWorksForNonNullableBuiltInType()
+        {
+            var app = new CommandLineApplication<NonNullableTimeSpanOptionProgram>();
+            app.ValueParsers.AddOrReplace(new CustomTimeSpanParser());
+            app.Conventions.UseDefaultConventions();
+
+            app.Parse("--timeout", "15s");
+
+            Assert.Equal(TimeSpan.FromSeconds(15), app.Model.Timeout);
+        }
+
+        [Fact]
+        public void NullableBuiltInTypeUsesDefaultParserWhenNoCustomParser()
+        {
+            var app = new CommandLineApplication<NullableTimeSpanOptionProgram>();
+            app.Conventions.UseDefaultConventions();
+
+            app.Parse("--timeout", "00:00:15");
+
+            Assert.Equal(TimeSpan.FromSeconds(15), app.Model.Timeout);
+        }
     }
 }


### PR DESCRIPTION
Fix nullable type lookup in `ValueParserProvider.GetParserImpl<T>()` to check user-registered parsers under the unwrapped type before falling back to TypeDescriptor.

This fixes the bug where `AddOrReplace` with a custom parser for a built-in type like `TimeSpan` was ignored when the property type was `TimeSpan?`.

Fixes #559

Generated with [Claude Code](https://claude.ai/code)